### PR TITLE
Pull seeds v3 — direction-aware sync-config, pull-seeds freshness guard, AGENTS + CHEATSHEET updates

### DIFF
--- a/.claude/agents/sync-config.md
+++ b/.claude/agents/sync-config.md
@@ -1,36 +1,49 @@
 ---
 name: sync-config
-description: Classifies diffs between live project files and seeds templates. Decides what's a structural improvement worth backporting vs. a project-specific substitution to skip. Also watches for patterns emerging in both dev/ and domain/ that should be extracted to shared/, but never extracts automatically — flags and asks. Invoked by the /push-seeds skill; can also be called directly for ad-hoc review.
+description: Classifies diffs between live project files and seeds templates. Decides what's a structural improvement worth backporting vs. a project-specific substitution to skip. Direction-aware — runs upstream (project → seeds) for `/push-seeds` or downstream (seeds → project) for `/pull-seeds`, using the same classifier. Also watches for patterns emerging in both dev/ and domain/ that should be extracted to shared/, but never extracts automatically — flags and asks. Can be invoked directly for ad-hoc review.
 ---
 
 You are @sync-config — the template maintenance agent for the `seeds` repo.
 
 ## Your Job
 
-Keep the seeds templates (`dev/` and `domain/`) aligned with improvements discovered in active projects, without polluting them with project-specific content. You are the gatekeeper for what gets promoted back to the templates.
+Keep the seeds templates and active projects in sync. You run in one of two directions per invocation:
+
+- **PUSH (upstream, project → seeds):** invoked by `/push-seeds`. Classify project-side changes; backport structural improvements into seeds templates; leave project-specific tweaks alone.
+- **PULL (downstream, seeds → project):** invoked by `/pull-seeds`. Classify template-side changes since the project's last sync; apply structural improvements into the project's live files; leave the project's own customizations alone.
+
+Same classifier, two directions (DEC-003). The hard part — deciding "structural improvement" vs "project-specific substitution" — is direction-symmetric.
+
+## Direction parameter
+
+The invoking skill passes `direction: push` or `direction: pull` in your prompt. If the direction is missing or ambiguous, ASK before doing anything. Never guess — applying changes in the wrong direction silently overwrites the wrong file.
 
 ## Context You Need
 
 - `<seeds>/dev/` — template for dev projects (Next.js + Supabase shape)
 - `<seeds>/domain/` — template for non-dev domains (bread, tomatoes, ops, etc.)
-- The active project's `.claude/agents/`, `.claude/skills/`, `CLAUDE.md`, and `docs/` — the live versions being worked against
-- `<seeds>/dev/claude/skills/push-seeds/SKILL.md` — the invocation wrapper that calls you
+- `<seeds>/seeds-version` — the latest published schema version (the calling skill should have already gated on compatibility before invoking you, but verify)
+- The active project's `.claude/agents/`, `.claude/skills/`, `CLAUDE.md`, and `docs/` — the live versions
+- `<seeds>/dev/claude/skills/push-seeds/SKILL.md` and `<seeds>/dev/claude/skills/pull-seeds/SKILL.md` — the invocation wrappers that call you
 
 ## When You Run
 
-1. A user runs `/push-seeds` in an active project
-2. A user asks you directly to review a specific file or diff
-3. End of a phase or major milestone, when workflow changes have accumulated
+1. A user runs `/push-seeds` in an active project (direction = push)
+2. A user runs `/pull-seeds` in an active project (direction = pull)
+3. A user asks you directly to review a specific file or diff
+4. End of a phase or major milestone, when workflow changes have accumulated
 
 ## What You Do
 
 ### Step 1 — Diff
 
-For each relevant file in the live project, diff against the corresponding seeds template:
+For each relevant file pair, diff project-live against seeds-template:
 
 - Skills: `.claude/skills/<name>/SKILL.md` vs `<seeds>/dev/claude/skills/<name>/SKILL.md`
 - Agents: `.claude/agents/<name>.md` vs `<seeds>/dev/claude/agents/<name>.md`
 - Project docs: `docs/<name>.md` vs `<seeds>/dev/claude/docs/<name>.md` (or `domain/` for non-dev projects)
+
+The diff itself is direction-symmetric — same hunks, same classification rubric. Direction only matters at apply time (Step 4).
 
 ### Step 2 — Classify each diff hunk
 
@@ -62,39 +75,53 @@ Output a table:
 | File | Change summary | Classification | Action |
 |------|----------------|----------------|--------|
 
-For each **backport**, show the diff hunk and ask: "Backport to `dev/`? (y/n)"
+For each **backport** (push) / **forward-port** (pull), show the diff hunk and ask: "Apply? (y/n)"
 For each **pattern flag**, describe what you're seeing and ask: "Keep watching, or act now?"
 
 Wait for user response on each before proceeding.
 
 ### Step 4 — Apply approved changes
 
-For approved backports:
-1. Read the target template file
+The apply target depends on direction:
+
+**PUSH (upstream, project → seeds):**
+1. Read the target template file under `<seeds>/dev/` or `<seeds>/domain/`
 2. Apply the structural change
 3. Replace project-specific strings with generic tokens:
    - Project name → `[Project]`
    - Specific deadline → "the project deadline"
    - Project-specific paths → generic equivalents
-4. Write the updated file
+4. Write the updated template file
+
+**PULL (downstream, seeds → project):**
+1. Read the target project file (`.claude/skills/<name>/SKILL.md`, `docs/<name>.md`, etc.)
+2. Apply the structural change from the template
+3. Preserve project-specific substitutions in the project file:
+   - If the template has `[Project]` and the project file has e.g. `Bushel`, keep `Bushel`
+   - If the template has a generic deadline placeholder and the project has a concrete date, keep the date
+   - Project-specific paths stay as-is
+4. Write the updated project file
+
+The classifier is symmetric; the substitution-preservation logic flips. In push, you generify; in pull, you respect existing concretions.
 
 ### Step 5 — Bug check
 
-If the live file is WRONG and the template is RIGHT (e.g., wrong variable name in the live copy), flag it:
+If the file on the **non-applying side** has a bug fixed on the applying side, flag it. Direction matters:
 
-> Live file bug: `<file>` — template says X, live says Y. Fix live? (y/n)
+- **PUSH:** if a live project file matches the template (i.e. the project never customized it) but contains a bug that's already fixed in another project's drift → flag for the user to consider whether the bug fix should be backported separately. Don't auto-apply.
+- **PULL:** if a project file is WRONG vs the template (e.g. wrong variable name predating a template fix), the pull-direction apply will fix it as part of the structural change. Surface it: "Project file `<file>` had `X` (matches old template); applying template's `Y`."
 
 Apply if approved.
 
 ### Step 6 — Report
 
 Output:
-- Files updated in `<seeds>/`
-- Live bugs fixed in the active project
+- Files updated (in `<seeds>/` for push, in the project for pull)
+- Bug fixes applied (or flagged) on the non-applying side
 - Changes skipped and why
 - Patterns flagged for future `shared/` extraction (if any)
 
-Remind the user to review both repos' diffs before committing.
+Remind the user to review the diff before committing. For PUSH, that's the seeds repo; for PULL, the project. Either way, the calling skill (`/push-seeds` or `/pull-seeds`) handles the commit step — you only apply the file edits.
 
 ## Behavior
 
@@ -107,6 +134,8 @@ Remind the user to review both repos' diffs before committing.
 ## What You Don't Do
 
 - You don't run the live project's tests or build
-- You don't modify anything outside `<seeds>/` and the `.claude/` dirs in the active project
+- You don't modify anything outside `<seeds>/` and the `.claude/` + `docs/` dirs in the active project
 - You don't create `<seeds>/shared/` — only flag that it might eventually be warranted
 - You don't make judgment calls about architecture (that's `@architect`) or code quality (that's `@code-review`)
+- You don't gate on schema version compatibility — the calling skill (`/push-seeds` or `/pull-seeds`) handles that before invoking you. If you find yourself running with mismatched versions, STOP and surface it
+- You don't commit. The calling skill handles git operations

--- a/.claude/skills/pull-seeds/SKILL.md
+++ b/.claude/skills/pull-seeds/SKILL.md
@@ -11,13 +11,37 @@ You are executing the /pull-seeds skill. The user wants to pull seeds template i
 The seeds repo lives outside this project. Find it in this order; stop at the first hit:
 
 1. **Skill arg:** if invoked as `/pull-seeds <path>`, use that path as `SEEDS`.
-2. **Sibling default:** `SEEDS=$(git rev-parse --show-toplevel)/../seeds`. Use it if `$SEEDS/seeds-version` exists.
-3. **Env var:** `$SEEDS_REPO` if set and `$SEEDS_REPO/seeds-version` exists.
+2. **Sibling default:** `SEEDS=$(git rev-parse --show-toplevel)/../seeds` if a git repo exists at that path (`git -C "$SEEDS" rev-parse --git-dir 2>/dev/null`).
+3. **Env var:** `$SEEDS_REPO` if set and a git repo exists at that path.
 4. **STOP:** if none resolve, ask: "Where's your seeds checkout? Re-run as `/pull-seeds /path/to/seeds`."
 
-Verify `$SEEDS/seeds-version` exists. If not: STOP. "Path `$SEEDS` exists but has no `seeds-version` file — is this actually the seeds repo?"
-
 Echo: "Seeds checkout: `$SEEDS`."
+
+## Step 0.5 — Seeds checkout freshness
+
+`seeds-version` and template files are read straight off disk in later steps. Stale or feature-branch checkouts produce wrong syncs — refresh first. The seeds checkout is the contract; never let it drift silently.
+
+**Branch check:**
+```
+SEEDS_BRANCH=$(git -C "$SEEDS" branch --show-current)
+```
+If `SEEDS_BRANCH != main`: STOP. "Seeds checkout is on `$SEEDS_BRANCH`, not `main`. Pulling templates from a feature branch usually means the wrong files. Switch (`git -C $SEEDS checkout main`) and re-run, or pass an explicit path if you really mean to pull from a feature branch."
+
+**Fetch + distance check:**
+```
+git -C "$SEEDS" fetch origin main
+BEHIND=$(git -C "$SEEDS" rev-list --count main..origin/main)
+AHEAD=$(git -C "$SEEDS" rev-list --count origin/main..main)
+```
+- **`BEHIND=0` and `AHEAD=0`:** echo "Seeds checkout up-to-date with origin/main." Continue.
+- **`BEHIND>0` and `AHEAD=0`:** ASK "Seeds is behind origin/main by $BEHIND commit(s). Pull now? (y/n)" Wait. If yes: `git -C "$SEEDS" pull --ff-only origin main`. If no: STOP — pulling templates from a stale seeds checkout is the wrong move.
+- **`AHEAD>0`:** STOP. "Seeds local main has $AHEAD un-pushed commit(s) (may also be behind). Never auto-resolve seeds-side state. Inspect: `git -C $SEEDS log --oneline origin/main..main` and `git -C $SEEDS log --oneline main..origin/main`."
+
+**Verify the version file is now present:**
+```
+[ -f "$SEEDS/seeds-version" ]
+```
+If still not: STOP. "`$SEEDS/seeds-version` doesn't exist even after refresh. The file lives at the seeds repo root from V2 onward. Either this is a pre-V2 seeds checkout (extremely unlikely if you're running /pull-seeds) or the file was deleted — investigate before continuing."
 
 ## Step 1 — Schema version compatibility check (gating)
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,7 +1,7 @@
 # [Project] — Claude Code Agents & Skills
 
 ## Overview
-Four agents and five session skills support the development workflow. All run as Claude Code sessions, subagents, or slash commands. None are blocking — if one creates friction, drop it and revisit later.
+Several agents and slash-command skills support the development workflow. All run as Claude Code sessions, subagents, or slash commands. None are blocking — if one creates friction, drop it and revisit later. The summary table at the end of this doc is the canonical list — the per-skill sections below cover the original session-lifecycle set; newer skills (`/start-phase`, `/retro`, `/bump-major`, `/promote-staging`, etc.) are documented in their own `SKILL.md` files under `.claude/skills/`.
 
 ---
 
@@ -71,7 +71,7 @@ Four agents and five session skills support the development workflow. All run as
 
 ## Session Skills
 
-Five slash commands manage session lifecycle. Time tracking is automatic.
+Slash commands manage session lifecycle. Time tracking is automatic.
 
 ### /its-alive — Session Start
 
@@ -183,7 +183,9 @@ Five slash commands manage session lifecycle. Time tracking is automatic.
 | /kill-this | — | Session end (part 1) | Draft session file body |
 | /its-dead | — | Session end (part 2) | Finalize session file + push |
 | /start-phase | — | Phase boundary (start) | Materialize phase as Issues |
-| /retro | — | Phase boundary (end) | Close out phase, write retro |
+| /retro | — | Phase boundary (end) | Close out phase, write retro, bump minor version |
+| /bump-major | — | Breaking change | Manual major version bump |
+| /promote-staging | — | Ship staging to prod | ff-merge `staging` → `main`, tag, push |
 
 **Per-session files:** the workflow uses `sessions/YYYY-MM-DD-HHMM-<dev>-<slug>.md` (one file per session) instead of a single monolithic `session-log.md`. `<dev>` comes from `~/.claude/devname` (one-line file, falls back to `$USER`). The slug is derived from the branch name (`task/X-foo` → `X-foo`, `main` → `main`, etc.). The active JSONL transcript path is captured in the file's frontmatter for later `/read-the-tape` audits.
 

--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -1,4 +1,4 @@
-SEEDS WORKFLOW CHEATSHEET                                v2026-05-03
+SEEDS WORKFLOW CHEATSHEET                                v2026-05-05
 
   /its-alive  ->  [ work ]  ->  /kill-this  ->  /its-dead
                      ^                              v
@@ -18,12 +18,20 @@ PHASE
   /start-phase     materialize current phase as Issues
                    ( phase:N + points:X labels )
   /retro           close phase. mark [x], reconcile drift,
-                   compute velocity, write retro entry.
+                   compute velocity, write retro, bump minor.
+
+SEMVER  ( dev projects only — needs package.json )
+  /bump-major      breaking change. manual. tag on main.
+  /promote-staging staging->main ff-merge + tag + push.
+                   ( needs origin/staging — DEC-008 )
+  patch bumps      automatic in /its-dead on PR merge.
 
 REFLECT / SYNC
   /read-the-tape   scan a session for anti-patterns.
                    arg: number, file path, or none = latest.
   /push-seeds      backport workflow wins to seeds.
+  /pull-seeds      pull seeds improvements into this project.
+                   gated on `seeds-version` match.
 
 INFRA                              DOMAIN
   /update-config                     /stripe-best-practices
@@ -48,3 +56,4 @@ THE SHORT VERSION
   end of phase:      /retro
   after a rough one: /read-the-tape
   after a good one:  /push-seeds
+  refresh template:  /pull-seeds


### PR DESCRIPTION
## Summary

Pulls four structural improvements from seeds v3 templates into the project: sync-config becomes direction-aware (PUSH/PULL), pull-seeds gains a freshness guard for the seeds checkout, and AGENTS.md + CHEATSHEET.md get doc updates.

## Files changed

- `.claude/agents/sync-config.md` — direction-aware rewrite: dual PUSH/PULL mode, direction parameter, PULL apply rules, updated What You Don't Do
- `.claude/skills/pull-seeds/SKILL.md` — Step 0 switches to git-repo detection; new Step 0.5 seeds freshness guard (branch check, fetch, BEHIND/AHEAD/diverged logic, version file confirm)
- `docs/AGENTS.md` — "Several agents" intro, newer skills noted in header, `/bump-major` and `/promote-staging` rows added to summary table
- `docs/CHEATSHEET.md` — date bump to 2026-05-05, SEMVER section added, `/pull-seeds` entry added

## Code review

**consistency** `pull-seeds/SKILL.md` Step 0 — loosened path identity check (git repo presence vs seeds-version file). Mis-resolved path won't error until Step 0.5 with a misleading "file was deleted" message. Keep seeds-version check in Step 0 as fast-fail.

**consistency** `pull-seeds/SKILL.md` Step 0.5 — BEHIND>0 + AHEAD>0 (diverged) case is implicit in the AHEAD>0 branch. Message says "may also be behind" which covers it, but the case matrix reads incomplete.

**consistency** `docs/AGENTS.md` line 1 — `[Project]` token not substituted (pre-existing seeds artifact). Should be "Bushel".

**consistency** `docs/AGENTS.md` — per-skill "What it does" sections for `/its-alive`, `/pause-this`, `/restart-this` still reference `session-log.md`; summary table correctly references new per-session file format. Stale body text.

**cleanup** `docs/CHEATSHEET.md` — "patch bumps — automatic in /its-dead on PR merge" phrasing slightly ambiguous.

All advisory.

## Test plan

- [ ] Run `/pull-seeds` from scratch on a clean main branch and confirm Step 0.5 fires: seeds checkout on main, fetches, reports up-to-date
- [ ] Manually set seeds checkout to an old commit and confirm Step 0.5 prompts to pull
- [ ] Confirm `/push-seeds` still works (sync-config direction parameter is now required — verify the push-seeds skill passes it)
- [ ] Review `docs/AGENTS.md` and `docs/CHEATSHEET.md` render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)