### PR TITLE
Phase 0.6 — GitHub Actions CI + rename PUBLISHABLE_KEY → ANON_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Copy to .env.local and fill in. Never commit .env.local.
 NEXT_PUBLIC_SUPABASE_URL=
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
 
 # Testing
 PLAYWRIGHT_BASE_URL=http://localhost:3001

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, "task/**"]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [main, "task/**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start Supabase
+        run: supabase start
+
+      - name: Run pgTAP tests
+        run: supabase test db
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium webkit
+
+      - name: Set Supabase env vars
+        run: |
+          eval $(supabase status --output env)
+          echo "NEXT_PUBLIC_SUPABASE_URL=$API_URL" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY" >> $GITHUB_ENV
+
+      - name: Build
+        run: npm run build
+        env:
+          NOTIFICATIONS_ENABLED: "false"
+
+      - name: Start app
+        run: npm start &
+        env:
+          NOTIFICATIONS_ENABLED: "false"
+
+      - name: Wait for app
+        run: timeout 30 bash -c 'until curl -sf http://localhost:3001 > /dev/null; do sleep 1; done'
+
+      - name: Run Playwright tests
+        run: npx playwright test
+        env:
+          PLAYWRIGHT_BASE_URL: http://localhost:3001
+          NOTIFICATIONS_ENABLED: "false"
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 2.98.2
 
       - name: Start Supabase
         run: supabase start
@@ -38,6 +38,8 @@ jobs:
       - name: Set Supabase env vars
         run: |
           eval $(supabase status --output env)
+          [[ -z "$API_URL" ]] && echo "ERROR: API_URL empty — supabase status failed" && exit 1
+          [[ -z "$ANON_KEY" ]] && echo "ERROR: ANON_KEY empty — supabase status failed" && exit 1
           echo "NEXT_PUBLIC_SUPABASE_URL=$API_URL" >> $GITHUB_ENV
           echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY" >> $GITHUB_ENV
 
@@ -47,7 +49,7 @@ jobs:
           NOTIFICATIONS_ENABLED: "false"
 
       - name: Start app
-        run: npm start &
+        run: nohup npm start -- -p 3001 & disown
         env:
           NOTIFICATIONS_ENABLED: "false"
 

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -4,6 +4,6 @@ import type { Database } from "./types";
 export function createClient() {
   return createBrowserClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
   );
 }

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -7,7 +7,7 @@ export async function updateSession(request: NextRequest) {
 
   const supabase = createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
         getAll() {

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -7,7 +7,7 @@ export async function createClient() {
 
   return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
         getAll() {


### PR DESCRIPTION
closes #6

## Summary

Adds GitHub Actions CI workflow (Supabase Docker → pgTAP → build → Playwright 3-device). Also renames `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` to the standard `NEXT_PUBLIC_SUPABASE_ANON_KEY` across all Supabase client code.

## Files changed

- `.github/workflows/ci.yml` — new CI workflow
- `.env.example` — key rename
- `src/lib/supabase/client.ts` — key rename
- `src/lib/supabase/middleware.ts` — key rename
- `src/lib/supabase/server.ts` — key rename

## Code review

Issues fixed before open:
- **bug** `npm start` defaults to port 3000 — fixed with `-p 3001`
- **bug** `npm start &` doesn't survive to next GHA step — fixed with `nohup ... & disown`
- **bug** `eval $(supabase status --output env)` could silently yield empty vars — added explicit non-empty guards before writing to `$GITHUB_ENV`
- **bug** `NOTIFICATIONS_ENABLED` missing from `Start app` step env — added
- **consistency** `supabase/setup-cli@v1 version: latest` floating pin — pinned to `2.98.2` (current installed version)

## Test plan

- [ ] PR CI run goes green (triggered by this PR push) — watch Actions tab
- [ ] `supabase test db` passes locally: confirms pgTAP step will pass in CI
- [ ] Confirm `.env.local` has been updated to use `NEXT_PUBLIC_SUPABASE_ANON_KEY` (not committed — update manually if not done already)
- [ ] Run `npx playwright test tests/smoke.spec.ts --project=desktop` locally → 1 test passes
- [ ] Run `npx playwright test tests/smoke.spec.ts --project=mobile` locally → 1 test passes (WebKit)