### PR TITLE
pull-seeds: tree-sitter fix, P2 false-positive guard, prod write protection

### DIFF
--- a/.claude/agents/tape-reader.md
+++ b/.claude/agents/tape-reader.md
@@ -49,8 +49,9 @@ For each pattern, note: **occurred / not found / inconclusive**.
 ---
 
 ### P2 — Repeated permission prompt for same command
-**Signal:** Same Bash command pattern appears in multiple tool calls — suggests the allowlist didn't catch it
+**Signal:** Same Bash command pattern appears in multiple tool calls AND the command is not on Claude Code's built-in auto-allow list — suggests the allowlist didn't catch it
 **Why it hurts:** User clicks Allow repeatedly for identical operations
+**Cross-reference before flagging:** Claude Code never prompts for these commands — skip them entirely: `cat`, `head`, `tail`, `ls`, `find`, `grep`, `wc`, `echo`, `printf`, `date`, `which`, `file`, `pwd`, `true`, `false`, `test`, `[`, `[[`, `basename`, `dirname`, `sort`, `uniq`, `tr`, `cut`, `diff`, `stat`. A repeated `ls` or `grep` is not a P2 hit.
 **Fix:** Add the pattern to `.claude/settings.json` `permissions.allow`
 **Files:** `.claude/settings.json`
 

--- a/.claude/skills/its-alive/SKILL.md
+++ b/.claude/skills/its-alive/SKILL.md
@@ -78,8 +78,11 @@ If `sessions/` does not exist: this is the first session under the new format. C
 ```
 PROJECT_SLUG=$(pwd | tr '/' '-')
 JSONL_DIR="$HOME/.claude/projects/$PROJECT_SLUG"
-TRANSCRIPT=$(ls -t "$JSONL_DIR"/*.jsonl 2>/dev/null | head -1)
+TRANSCRIPT=$(cd "$JSONL_DIR" 2>/dev/null && ls -t *.jsonl 2>/dev/null | head -1)
+[ -n "$TRANSCRIPT" ] && TRANSCRIPT="$JSONL_DIR/$TRANSCRIPT"
 ```
+
+The `cd`-and-relative-glob form is deliberate. Tree-sitter-bash (used by Claude Code's static command validator) parses `"$VAR"/*.glob` as a string-concatenated-with-glob node it can't classify, so the harness drops to "needs confirmation" on every session start. Doing the lookup from inside the dir sidesteps the pattern entirely. Don't revert to `ls -t "$JSONL_DIR"/*.jsonl`.
 
 If no JSONL is found, leave `transcript:` empty in the frontmatter. /read-the-tape will fall back to "latest JSONL" matching at audit time.
 

--- a/.claude/skills/read-the-tape/SKILL.md
+++ b/.claude/skills/read-the-tape/SKILL.md
@@ -18,8 +18,12 @@ Use it directly.
 ```
 PROJECT_SLUG=$(pwd | tr '/' '-')
 JSONL_DIR="$HOME/.claude/projects/$PROJECT_SLUG"
-ls -lt "$JSONL_DIR"/*.jsonl
+(cd "$JSONL_DIR" 2>/dev/null && ls -lt *.jsonl)
 ```
+
+The `cd`-and-relative-glob form is deliberate — tree-sitter-bash chokes on `"$VAR"/*.glob`, dropping every invocation into a permission prompt. See its-alive Step 5 for the longer note.
+
+The listing shows **basenames only** (because the `ls` ran from inside `$JSONL_DIR`). Re-prefix `$JSONL_DIR/` onto the chosen filename before passing to Step 2 — the @tape-reader agent expects a full absolute path.
 
 Default to the **second most recently modified JSONL** — the current session's JSONL is always the newest (being written live); the one to audit is the previous one. If only one JSONL exists, use it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,35 @@ If direnv is wired (`.envrc` exports the token, gitignored), the var is set auto
 
 Why two accounts: bushel is billed separately from sailbook so LTSC can take sailbook later without untangling shared accounts.
 
+### Production write protection (DEC-009)
+
+Two-layer defense against accidentally running destructive Supabase CLI ops on production:
+
+1. **Discipline:** never `supabase link` to a prod project ref from a dev box. Production deploys read `SUPABASE_URL` and the service-role key from Vercel env vars — there is no reason for a local link to prod. Link only to staging or local.
+2. **Wrapper script (`scripts/safe-supabase.sh`):** reads the linked ref from `supabase/.temp/project-ref` and refuses to pass through `db reset`, `db push`, `db remote *`, `migration up`, or `migration repair` if the linked ref appears in `.claude/prod-supabase-refs`. Pass-through for everything else. The matcher walks adjacent argument pairs, so leading global flags (`--debug`, `--workdir`, etc.) don't bypass the guard.
+
+Setup (one-time):
+
+```
+chmod +x scripts/safe-supabase.sh
+mkdir -p .claude
+echo "<your-prod-project-ref>" > .claude/prod-supabase-refs
+echo ".claude/prod-supabase-refs" >> .gitignore
+```
+
+Optional shell alias for transparent protection:
+
+```
+alias supabase='./scripts/safe-supabase.sh'
+```
+
+The `.claude/prod-supabase-refs` file accepts one ref per line; blank lines and `#` comments are ignored. Per-project rather than global so multi-project dev boxes don't cross-contaminate.
+
+The wrapper only catches CLI ops. The following are **not** guarded — they rely on the discipline:
+- `--db-url postgres://...prod...` flags on `db push` / `db remote commit` skip the linked-project entirely.
+- Direct `psql` against the prod URL.
+- Any tool that doesn't go through the `supabase` binary.
+
 ## Commands
 ```bash
 # Development

--- a/scripts/safe-supabase.sh
+++ b/scripts/safe-supabase.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# safe-supabase.sh — wrapper around the `supabase` CLI that refuses
+# destructive operations when linked to a production project.
+#
+# DEC-009 (seeds): two-layer defense — discipline (never link prod locally)
+# plus this wrapper as belt-and-suspenders.
+#
+# Setup (per project):
+#   1. Copy this script to <project>/scripts/safe-supabase.sh
+#   2. chmod +x <project>/scripts/safe-supabase.sh
+#   3. Create <project>/.claude/prod-supabase-refs (one project ref per line):
+#        echo "your-prod-ref" > .claude/prod-supabase-refs
+#   4. Add to .gitignore:
+#        echo ".claude/prod-supabase-refs" >> .gitignore
+#   5. Optional shell alias for transparent protection:
+#        alias supabase='./scripts/safe-supabase.sh'
+#
+# Detection:
+#   - Reads the linked project ref from supabase/.temp/project-ref
+#   - Compares against .claude/prod-supabase-refs
+#     (blank lines and lines starting with # are ignored)
+#
+# What's blocked when linked to a prod ref:
+#   db reset, db push, db remote *, migration up, migration repair
+#
+# The matcher walks adjacent argument pairs so leading global flags
+# (--debug, --workdir, etc.) don't bypass the guard:
+#   `supabase --debug db push` is still blocked.
+#
+# Bypass surfaces NOT guarded (by design — discipline-plus-wrapper):
+#   - `supabase ... --db-url postgres://...` skips the linked-project
+#     entirely and writes to whatever URL is passed.
+#   - Direct `psql` against a prod URL.
+#   - Anything that doesn't go through the `supabase` binary.
+#
+# Everything else (db pull, db diff, db lint, migration list, gen types,
+# status, start, stop, login, projects list, etc.) passes through unchanged.
+#
+# Override the underlying CLI for testing: SAFE_SUPABASE_REAL=/path/to/fake-supabase
+
+set -eu
+
+PROD_REFS_FILE=".claude/prod-supabase-refs"
+LINK_REF_FILE="supabase/.temp/project-ref"
+REAL_SUPABASE="${SAFE_SUPABASE_REAL:-supabase}"
+
+repo_root() {
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+MATCHED_PAIR=""
+is_destructive() {
+  # Walk adjacent argument pairs so leading global flags don't shift
+  # the destructive subcommand out of the $1/$2 window. Sets
+  # MATCHED_PAIR so the refusal message can name the actual subcommand
+  # rather than echo back the leading flag.
+  MATCHED_PAIR=""
+  local prev=""
+  for arg in "$@"; do
+    case "$prev $arg" in
+      "db reset"|"db push"|"db remote"|"migration up"|"migration repair")
+        MATCHED_PAIR="$prev $arg"
+        return 0 ;;
+    esac
+    prev="$arg"
+  done
+  return 1
+}
+
+linked_ref() {
+  local path
+  path="$(repo_root)/$LINK_REF_FILE"
+  if [ -f "$path" ]; then
+    tr -d '[:space:]' < "$path"
+  fi
+}
+
+is_prod_ref() {
+  local ref="$1" path
+  path="$(repo_root)/$PROD_REFS_FILE"
+  [ -f "$path" ] || return 1
+  grep -v '^[[:space:]]*#' "$path" | grep -v '^[[:space:]]*$' | grep -qFx "$ref"
+}
+
+main() {
+  if [ $# -eq 0 ]; then
+    exec "$REAL_SUPABASE"
+  fi
+
+  if is_destructive "$@"; then
+    local ref
+    ref=$(linked_ref)
+    if [ -n "$ref" ] && is_prod_ref "$ref"; then
+      cat >&2 <<EOF
+
+safe-supabase: REFUSED — '$MATCHED_PAIR' is destructive and the linked
+project ref ($ref) is in $PROD_REFS_FILE.
+
+Production deploys read env vars (SUPABASE_URL, service-role key) from
+Vercel — never from a local link. To run this command:
+
+  $REAL_SUPABASE unlink
+  $REAL_SUPABASE link --project-ref <staging-ref>
+
+Then retry.
+
+EOF
+      exit 1
+    fi
+  fi
+
+  exec "$REAL_SUPABASE" "$@"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- **its-alive + read-the-tape:** `cd`-and-relative-glob form for JSONL lookup — fixes permission prompt on every session start (tree-sitter-bash chokes on `"$VAR"/*.glob`)
- **tape-reader P2:** adds built-in auto-allow list cross-reference so `ls`/`grep`/`cat` repeats don't false-positive as P2 hits
- **CLAUDE.md + scripts/safe-supabase.sh:** DEC-009 production write protection — wrapper script refuses destructive Supabase CLI ops when linked to a prod project ref

## Test plan
- [ ] Run `/its-alive` — confirm no permission prompt for JSONL glob
- [ ] Run `/read-the-tape` — confirm no permission prompt for JSONL listing
- [ ] Review `scripts/safe-supabase.sh` — one-time setup: `echo "<prod-ref>" > .claude/prod-supabase-refs && echo ".claude/prod-supabase-refs" >> .gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)