### PR TITLE
Phase 0.7 — brand tokens, customer status pages, design archive (closes #7)

### DIFF
--- a/.claude/agents/ui-reviewer.md
+++ b/.claude/agents/ui-reviewer.md
@@ -1,160 +1,161 @@
 ---
 name: ui-reviewer
-description: Reviews visual design quality for [Project] pages against the project's design system. Covers nav/layout consistency, color/brand adherence, mobile responsiveness, typography, shadcn component usage, and accessibility basics. Use after completing a page or significant component, at phase boundaries, or when something looks off.
+description: Reviews visual design quality for bushel pages against the Bay Branch Farm design system. Covers brand adherence (leaf greens, cream bg, Source Sans 3), mobile responsiveness for customer pages (375px), admin desktop layout, typography, shadcn component usage, and accessibility basics. Use after completing a page or significant component, at phase boundaries, or when something looks off.
 ---
 
-You are @ui-reviewer for [Project].
+You are @ui-reviewer for bushel — Bay Branch Farm's ordering system.
 
-[Project] is a [brief description]. Aesthetic priorities: clarity first, personality second. Function over form.
+Two surfaces. Different rules for each.
 
-## Active Theme
-
-**Fill in your shadcn theme details:**
-- Preset: [e.g., b7CSfQ4Xo]
-- Font: [e.g., Nunito Sans]
-- Base: [e.g., Mist]
-- Accent: [e.g., Sky]
-- Border radius: [e.g., xs]
-- Default mode: [e.g., Dark]
+**Customer** — mobile-first, 375px primary. The farmer texted you a link. Big tap targets, plain chrome, one column.
+**Admin** — desktop-only, 1440px primary. Annabel's working tool. Dense, table-driven, ink-900 sidebar.
 
 ---
 
-## Design System Reference
+## Brand Tokens
 
-### Color
+All bushel colors are defined as CSS custom properties in `globals.css`. Source of truth: `design/tokens.css`.
 
-Use shadcn CSS tokens backed by OKLCH values. Do **not** hardcode Tailwind color classes for surfaces or text.
+| Token | Hex | Tailwind semantic |
+|---|---|---|
+| `--leaf-600` | `#3B6D11` | `bg-primary` / `text-primary` |
+| `--leaf-700` | `#2C5310` | hover states, focus rings |
+| `--leaf-500` | `#4F8A1B` | badge-ready fill |
+| `--leaf-100` | `#EDF5E5` | badge-new bg, subtle highlight |
+| `--leaf-50` | `#F4F8EE` | `bg-secondary`, `bg-muted`, panel wash |
+| `--cream` | `#FBFAF5` | `bg-background` — page background |
+| `--paper` | `#FFFFFF` | `bg-card` — cards and inputs |
+| `--ink-900` | `#1A1A1A` | `text-foreground`, admin sidebar bg |
+| `--ink-700` | `#3A3A38` | secondary text |
+| `--ink-500` | `#6E6E6A` | `text-muted-foreground` |
+| `--ink-200` | `#E4E2DA` | `border-border`, row dividers |
+| `--amber-600` | `#E6A817` | `--warning` — needs_reconciliation, caution |
+| `--amber-50` | `#FFF7E0` | callout-warn background |
+| `--rose-600` | `#B23B2E` | `bg-destructive` — destructive only |
 
-| Token | Use |
-|-------|-----|
-| `bg-background` / `text-foreground` | Page base |
-| `bg-card` / `text-card-foreground` | Card surfaces |
-| `bg-primary` / `text-primary-foreground` | Primary actions, strong emphasis |
-| `bg-secondary` / `text-secondary-foreground` | Secondary actions, chips |
-| `text-muted-foreground` | Labels, metadata, supporting text |
-| `bg-muted` | Muted backgrounds (empty states, disabled) |
-| `bg-accent` / `text-accent-foreground` | Hover states, selected nav |
-| `text-destructive` | Error states, irreversible actions |
-| `border-border` | All borders |
-| `ring` | Focus rings |
+**Never:** pure white or black. Never above leaf-500 saturation. No gradients. Card shadows: `0 1px 0 rgba(0,0,0,0.04)` only.
 
-**Never:**
-- Raw `text-black` or `text-white` (use foreground/background tokens)
-- Hardcoded zinc, gray, slate, or neutral Tailwind classes for text or backgrounds
-- Color as the sole state indicator (must pair with icon or text label)
+---
 
-**Exceptions:** Semantic amber for warnings is OK — it's a UX signal, not brand color.
+## Typography
 
-### Typography
+- **Body / UI:** Source Sans 3 (loaded via `--font-sans`). 16px base, 1.55 leading. Weights: 300, 400, 600.
+- **Customer hero h1 only:** Playfair Display (loaded via `--font-display`). Only on the order page "What's available" title. Nowhere else.
+- **Eyebrows / labels:** Source Sans 3 600, uppercase, `letter-spacing: 0.08em`, `0.72rem`, leaf-600.
+- **Mono:** JetBrains Mono (loaded via `--font-mono`). Tokens, IDs, prices, tabular numbers.
 
-- **Font:** [Project font], loaded as `--font-sans`.
-- **Scale:** Max 3 font sizes per screen.
-  - Page heading: `text-2xl font-semibold` (h1)
-  - Section headings inside cards: `text-base font-semibold` (CardTitle)
-  - Body / labels: `text-sm font-medium`
-  - Meta / timestamps: `text-xs`
-  - Nothing smaller than `text-xs` (12px).
-- **Weight:** `font-semibold` for headings, `font-medium` for labels, default for body. Avoid `font-bold`.
-- **Muted text:** `text-muted-foreground` token only.
+**Scale:**
+- h1 status/admin: `1.85rem` (Source Sans)
+- h1 customer hero: `2rem` mobile / `2.5rem` desktop (Playfair)
+- body: `1rem`
+- small: `0.85rem` — minimum on customer pages
+- eyebrow: `0.72rem` — absolute minimum
 
-### Spacing
+**Flags:**
+- Playfair anywhere except customer order page h1 → High
+- Font size below 0.82rem on customer → High
+- `font-bold` anywhere → Medium (use `font-semibold`)
 
-- Tailwind 4px scale only. No arbitrary values (`p-[13px]`, `gap-[22px]`, etc.).
-- Page padding lives in layout.tsx, not individual pages.
+---
+
+## Spacing
+
+- 4px scale only. No arbitrary values (`p-[13px]`, `gap-[22px]`, etc.).
+- Page padding in layout.tsx only — not on individual pages.
 - Section spacing: `space-y-6` between major sections.
 
-### Border Radius
+---
 
-**[Set your radius convention — e.g., xs radius, consistent, never zero, never mixed.]**
+## Border Radius
 
-Use `rounded-lg` for cards and containers (shadcn default). Don't mix radii.
+`rounded-lg` (6px = `--r-sm`) everywhere. Customer CSS uses `--r-md` (10px) for cards — that's the design-defined exception. No other mixing.
 
-**Never:** `rounded-none`, `rounded-full` on non-pill/avatar elements, oversized overrides.
+**Never:** `rounded-none`, `rounded-full` on non-pill/badge elements, oversized overrides.
 
-### Shadows
+---
 
-- Cards: shadcn Card default (shadow-sm or none, per theme).
+## Shadows
+
+- Cards: `var(--hairline)` = `0 1px 0 rgba(0,0,0,0.04)` only.
 - Modals/overlays: `shadow-lg`.
-- Nothing else. No `shadow-md`, `drop-shadow`, or arbitrary shadows.
+- Nothing else.
 
-### Components
+---
 
-- **Card** (CardHeader, CardTitle, CardDescription, CardContent, CardFooter): primary content container.
-- **Badge** variants — semantics must match:
-  - `default`: confirmed, active, enrolled
-  - `secondary`: pending, neutral, informational
-  - `outline`: available spots, minor labels
-  - `destructive`: cancelled, error, irreversible
-- **Button** variants:
-  - `default`: primary action (one per screen)
+## Components (shadcn — admin/auth pages)
+
+- **Button** variants → semantics:
+  - `default`: leaf-600 primary action (one per screen)
   - `secondary`: secondary action
-  - `outline`: tertiary / back navigation
-  - `ghost`: nav items, icon-only buttons
-  - `destructive`: irreversible actions
-- **Tables:** plain HTML `<table>` with `w-full text-sm`. `border-b` between rows, `last:border-0`. `text-muted-foreground` headers with `font-medium`. No striped rows.
-- **Empty states:** `<EmptyState message="..." />` component — not raw `<p>` in the main content column.
+  - `outline`: tertiary
+  - `ghost`: nav items, icon-only
+  - `destructive`: irreversible, rose-600
+- **Badge** variants:
+  - New state: leaf-100 bg, leaf-700 text (use `secondary` variant or custom class)
+  - Ready state: leaf-500 bg, white text
+  - Picked Up / Delivered: ink-200 bg, ink-700 text
+  - Needs reconciliation: amber-50 bg + amber-600 left rule (custom — not a standard badge variant)
+- **Tables:** `w-full text-sm`, `text-muted-foreground` headers, `border-b` rows, no striping. Reconciliation rows: amber-50 bg, pinned top.
+- **Sidebar:** must use `bg-sidebar` token (ink-900) — never `bg-gray-*` or hardcoded dark colors.
 
-### Layout & Navigation
+---
 
-- Two-column layout: fixed-width sidebar + `flex-1 min-w-0 bg-background` main.
-- Sidebar uses `bg-sidebar` token — not `bg-white` (wrong in dark mode).
-- **Active nav links:** `bg-accent text-accent-foreground`. Inactive: `text-muted-foreground hover:text-foreground`.
+## Customer pages (plain CSS — no shadcn)
 
-### Dark Mode
+Customer routes (`/c/[token]/*`) use `src/styles/customer.css` with the design prototype classes. Do not apply Tailwind utilities or shadcn components to customer pages.
 
-Dark mode may be the default. Verify:
-- Sidebar uses `bg-sidebar` token (dark-aware), not `bg-white`.
-- Cards use `bg-card` (dark-aware), not `bg-white`.
-- No hardcoded white backgrounds on any surface.
-- Text contrast meets WCAG AA against dark backgrounds.
-- Borders are subtle but visible (`border-border` token).
+| Check | Rule |
+|---|---|
+| Touch targets | All interactive elements ≥ 44px height |
+| Single column | No multi-column layout on mobile |
+| Status art | SVG illustrations only (no generated images) |
+| Brand strip | Leaf mark + "Bay Branch Farm" in leaf-700, white background |
+| Footer | "Bay Branch Farm · 3612 W 114th St, Cleveland" in ink-500 |
+| Phone links | `sms:2162025718` (tap-to-text) — not `tel:` |
 
-### Mobile (375px)
+---
 
-- All views must work at 375px.
-- No horizontal scroll.
-- Touch targets: minimum 44px height for interactive elements.
-- Cards stack single-column on mobile (`grid-cols-1`), go multi-column at `sm:` or `lg:`.
+## Admin layout (desktop-only)
 
-### Visual Hierarchy
+- Sidebar: ink-900 bg (`bg-sidebar`), white text, leaf-600 active accent bar left edge.
+- Top bar: cream bg, week label right-aligned, sign-out button outlined.
+- Content: fills viewport, 24px padding, no max-width constraint.
+- Mobile: no mobile fallback required in V1 (DEC-019).
 
-- One `<h1>` per page (`text-2xl font-semibold`).
-- One primary CTA per screen. Multiple actions → one `default`, rest `secondary` or `outline`.
+---
 
-### Accessibility (Baseline)
+## Accessibility (baseline)
 
-- All interactive elements must have visible focus rings (shadcn manages this — don't override with bare `outline-none`).
-- Color must not be the sole state indicator.
-- Form fields must have visible `<label>` elements, not just placeholder text.
-- Decorative icons: `aria-hidden="true"`.
-- Images: meaningful `alt` text.
+- All interactive elements: visible focus rings (leaf-700, 2px, 2px offset). Never override with bare `outline-none`.
+- Color is not the sole state indicator — always pair with icon or text label.
+- Form fields: visible `<label>`, not placeholder-only.
+- Decorative icons and SVGs: `aria-hidden="true"`.
+- Customer status art: `aria-hidden="true"` on the SVG wrapper.
 
 ---
 
 ## What to Check
 
-For each page or component under review:
+For each page or component:
 
-1. **Color / tokens** — shadcn tokens in use; no hardcoded Tailwind color classes
-2. **Dark mode** — sidebar/card backgrounds use dark-aware tokens; no `bg-white` surfaces
-3. **Typography** — correct font applied; ≤3 sizes; min 12px; correct weights
-4. **Spacing** — 4px scale; no arbitrary values; page padding in layout not page
-5. **Border radius** — consistent; no `rounded-none`; no oversized overrides
-6. **Shadows** — Card default; shadow-lg for modals; nothing else
-7. **Component usage** — shadcn components used correctly; Badge/Button variants match semantics; one primary CTA
-8. **Tables** — `w-full text-sm`, muted headers, row borders, no striping
-9. **Empty states** — EmptyState component, not raw paragraph text
-10. **Layout** — sidebar uses `bg-sidebar`; padding not doubled; main fills `flex-1`
-11. **Mobile 375px** — no horizontal scroll; cards stack; touch targets ≥44px
-12. **Accessibility** — focus states intact; color + icon for state; visible labels; `aria-hidden` on decorative icons
+1. **Color / tokens** — raw hex in shadcn pages → flag. Customer pages: leaf/ink/cream vars only.
+2. **Typography** — Playfair only on customer hero h1; no font-bold; nothing below 0.82rem customer / 0.78rem admin.
+3. **Spacing** — 4px scale; no arbitrary values; page padding in layout.
+4. **Radius** — `rounded-lg` (shadcn pages); `--r-sm`/`--r-md` (customer pages); no mixing.
+5. **Shadows** — hairline on cards only; shadow-lg on modals.
+6. **Buttons/badges** — variant semantics correct; one primary per screen.
+7. **Customer 375px** — single column; 44px+ targets; no horizontal scroll.
+8. **Admin sidebar** — `bg-sidebar` token; not hardcoded.
+9. **Reconciliation rows** — amber-50 bg + amber-600 rule; pinned to top.
+10. **Accessibility** — focus rings intact; labels visible; aria-hidden on decorative SVGs.
 
 ---
 
 ## How to Review
 
 1. Read the component/page source file(s).
-2. Take Playwright screenshots at 375px, 768px, and 1440px (with dark mode active if applicable).
-3. Check each item in the checklist above against the source and screenshots.
+2. Take Playwright screenshots at 375px (customer) or 1440px (admin).
+3. Check each item above against source and screenshots.
 
 ---
 
@@ -169,19 +170,19 @@ Score: X/10
 
 | Priority | Issue | Location | Fix |
 |----------|-------|----------|-----|
-| High | [description] | [file:line or selector] | [exact change] |
+| High | [description] | [file:line] | [exact change] |
 | Medium | ... | ... | ... |
 | Low | ... | ... | ... |
 
 ### Notes
-[Broader observations — patterns to watch, things that are right and should be preserved, etc.]
+[Patterns to watch, things that are right and should be preserved.]
 ```
 
 **Priority definitions:**
-- **High** — breaks functionality, fails WCAG AA contrast, or creates a confusing UX
-- **Medium** — visible inconsistency with the design system; will accumulate if not caught
-- **Low** — minor polish; address at a polish phase unless trivial to fix now
+- **High** — breaks functionality, fails WCAG AA contrast, or creates confusing UX
+- **Medium** — visible inconsistency with the design system; accumulates if uncaught
+- **Low** — minor polish; address at a polish phase unless trivial
 
-Score rubric: start at 10, subtract 1 per High, 0.5 per Medium, 0.25 per Low (round to nearest 0.5).
+Score: start at 10, subtract 1 per High, 0.5 per Medium, 0.25 per Low (round to nearest 0.5).
 
-If there are no findings, say so explicitly — "No issues found" is a valid result.
+If there are no findings, say so explicitly.

--- a/design/admin-customers.css
+++ b/design/admin-customers.css
@@ -1,0 +1,301 @@
+/* Admin · Customers */
+
+.cust-page {}
+
+/* table */
+.cust-tableCard {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  overflow: hidden;
+  margin-bottom: 28px;
+}
+.cust-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--sans);
+  font-size: 0.92rem;
+}
+.cust-table thead th {
+  background: var(--cream);
+  text-align: left;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-500);
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--ink-200);
+  white-space: nowrap;
+}
+.cust-table tbody tr.cust-row {
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.cust-table tbody tr.cust-row:hover { background: var(--cream); }
+.cust-table tbody tr.cust-row td {
+  padding: 14px 14px;
+  border-top: 1px solid var(--ink-200);
+  vertical-align: top;
+}
+.cust-table tbody tr.cust-row:first-child td { border-top: 0; }
+.cust-table tbody tr.cust-row.is-unsub td { background: var(--ink-100); color: var(--ink-500); }
+.cust-table tbody tr.cust-row.is-unsub .cust-name { color: var(--ink-700); }
+
+.col-c-name    { width: 22%; min-width: 180px; }
+.col-c-contact { width: 200px; }
+.col-c-addr    { width: 22%; min-width: 200px; }
+.col-c-notify  { width: 80px; }
+.col-c-link    { width: 200px; }
+.col-c-sub     { width: 90px; text-align: center; }
+.col-c-actions { width: 32px; text-align: right; padding-right: 14px; }
+
+.cust-name { font-weight: 600; color: var(--ink-900); margin-bottom: 2px; }
+.cust-name-token { font-size: 0.75rem; color: var(--ink-500); white-space: nowrap; }
+.cust-email { color: var(--ink-900); margin-bottom: 2px; word-break: break-all; }
+.cust-phone { font-size: 0.85rem; color: var(--ink-500); white-space: nowrap; }
+.cust-addr {
+  font-size: 0.88rem; color: var(--ink-700);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-height: 1.4;
+}
+
+/* Notify chip */
+.chip {
+  display: inline-flex; align-items: center;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.chip-notify.chip-sms   { background: var(--leaf-50); color: var(--leaf-700); border-color: var(--leaf-100); }
+.chip-notify.chip-email { background: #FAF1DC; color: #8A6210; border-color: #EFD89A; }
+.chip-notify.chip-both  { background: var(--ink-100); color: var(--ink-700); border-color: var(--ink-200); }
+
+/* Copy / Regen buttons */
+.cust-copy {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-sm);
+  padding: 6px 10px;
+  font-family: var(--sans);
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--ink-700);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+.cust-copy:hover { background: var(--leaf-50); color: var(--leaf-700); border-color: var(--leaf-100); }
+.cust-copy.is-copied { background: var(--leaf-600); color: var(--paper); border-color: var(--leaf-600); }
+
+.cust-regen {
+  display: block;
+  background: transparent; border: none;
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--rose-600);
+  padding: 4px 0 0;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.cust-regen:hover { text-decoration: underline; }
+
+.cust-chev {
+  color: var(--ink-300);
+  display: inline-flex;
+}
+.cust-row:hover .cust-chev { color: var(--ink-700); }
+
+/* ── Drawer ──────────────────────────────────────────── */
+.drawer-scrim {
+  position: fixed; inset: 0;
+  background: rgba(31, 30, 26, 0.4);
+  z-index: 50;
+  animation: fade-in 0.18s ease;
+}
+.drawer {
+  position: fixed; top: 0; right: 0; bottom: 0;
+  width: 520px;
+  background: var(--paper);
+  z-index: 60;
+  display: flex; flex-direction: column;
+  box-shadow: -16px 0 40px -12px rgba(31,30,26,0.3);
+  animation: drawer-in 0.22s ease;
+}
+@keyframes drawer-in {
+  from { transform: translateX(40px); opacity: 0; }
+  to   { transform: translateX(0); opacity: 1; }
+}
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+
+.drawer-head {
+  padding: 22px 28px 18px;
+  border-bottom: 1px solid var(--ink-200);
+  display: flex; align-items: flex-start; justify-content: space-between;
+  gap: 16px;
+  flex-shrink: 0;
+}
+.drawer-title {
+  font-family: var(--serif);
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin-top: 4px;
+  line-height: 1.15;
+}
+.drawer-token { font-size: 0.78rem; color: var(--ink-500); margin-top: 6px; }
+.drawer-close {
+  width: 32px; height: 32px;
+  background: transparent;
+  border: none;
+  color: var(--ink-500);
+  border-radius: 6px;
+  cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.drawer-close:hover { background: var(--cream); color: var(--ink-900); }
+
+.drawer-body {
+  padding: 24px 28px;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.field { margin-bottom: 20px; }
+.field-label {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-700);
+  margin-bottom: 6px;
+}
+.field-control input[type="text"],
+.field-control input[type="email"],
+.field-control input[type="tel"],
+.field-control textarea {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--paper);
+  border: 1px solid var(--ink-300);
+  border-radius: var(--r-sm);
+  font-family: var(--sans);
+  font-size: 0.95rem;
+  color: var(--ink-900);
+  line-height: 1.4;
+  resize: vertical;
+}
+.field-control input:focus,
+.field-control textarea:focus {
+  outline: none;
+  border-color: var(--leaf-600);
+  box-shadow: 0 0 0 3px rgba(79,138,27,0.12);
+}
+.field-hint {
+  margin-top: 6px;
+  font-size: 0.82rem;
+  color: var(--ink-500);
+}
+.field-row {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+.field-row .field { margin-bottom: 20px; }
+
+.radio-group { display: flex; flex-direction: column; gap: 8px; }
+.radio-card {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 12px 14px;
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  transition: border-color 0.1s, background 0.1s;
+}
+.radio-card:hover { border-color: var(--leaf-100); }
+.radio-card.is-on {
+  border-color: var(--leaf-600);
+  background: var(--leaf-50);
+  box-shadow: 0 0 0 3px rgba(79,138,27,0.08);
+}
+.radio-card input[type="radio"] {
+  margin-top: 3px;
+  accent-color: var(--leaf-600);
+}
+.radio-card-label { font-weight: 600; color: var(--ink-900); margin-bottom: 2px; }
+.radio-card-sub { font-size: 0.85rem; color: var(--ink-500); }
+
+.drawer-foot {
+  padding: 16px 28px;
+  border-top: 1px solid var(--ink-200);
+  background: var(--cream);
+  display: flex; align-items: center; gap: 8px;
+  flex-shrink: 0;
+}
+
+.btn-destructive-solid {
+  background: var(--rose-600); color: var(--paper); border-color: var(--rose-600);
+}
+.btn-destructive-solid:hover { background: #931f15; border-color: #931f15; }
+
+/* ── Modal ─────────────────────────────────────────────── */
+.modal-scrim {
+  position: fixed; inset: 0;
+  background: rgba(31,30,26,0.5);
+  z-index: 80;
+  animation: fade-in 0.15s ease;
+}
+.modal {
+  position: fixed;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  width: 440px;
+  background: var(--paper);
+  border-radius: var(--r-md);
+  padding: 28px 28px 22px;
+  z-index: 90;
+  box-shadow: 0 30px 80px -20px rgba(31,30,26,0.5);
+  text-align: left;
+  animation: modal-in 0.18s ease;
+}
+@keyframes modal-in {
+  from { opacity: 0; transform: translate(-50%, -46%); }
+  to   { opacity: 1; transform: translate(-50%, -50%); }
+}
+.modal-icon {
+  width: 48px; height: 48px;
+  border-radius: 50%;
+  background: rgba(178,59,46,0.1);
+  color: var(--rose-600);
+  display: flex; align-items: center; justify-content: center;
+  margin-bottom: 16px;
+}
+.modal-title {
+  font-family: var(--serif);
+  font-size: 1.35rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+  letter-spacing: -0.005em;
+}
+.modal-body {
+  color: var(--ink-700);
+  font-size: 0.95rem;
+  line-height: 1.55;
+  margin-bottom: 22px;
+}
+.modal-actions {
+  display: flex; justify-content: flex-end;
+  gap: 8px;
+}

--- a/design/admin-customers.jsx
+++ b/design/admin-customers.jsx
@@ -1,0 +1,326 @@
+/* Admin · Customers */
+
+const { useState } = React;
+
+const SEED_CUSTOMERS = [
+  {
+    id: "c01", name: "West Side Market — Bay Stand",
+    email: "annabel@bayBranchfarm.com", phone: "216-202-5718",
+    address: "1979 W 25th St, Cleveland, OH 44113",
+    notify: "both", subscribed: true,
+    token: "k4f8x2-w7s",
+  },
+  {
+    id: "c02", name: "Lakewood Farmer's Market",
+    email: "manager@lakewoodfarmersmarket.org", phone: "216-555-0142",
+    address: "14532 Detroit Ave, Lakewood, OH 44107",
+    notify: "sms", subscribed: true,
+    token: "p2k9m1-lkw",
+  },
+  {
+    id: "c03", name: "Heinen's — Rocky River",
+    email: "produce@heinens.com", phone: "440-555-0188",
+    address: "20137 Center Ridge Rd, Rocky River, OH 44116",
+    notify: "email", subscribed: true,
+    token: "t8j3n2-hrr",
+  },
+  {
+    id: "c04", name: "Spice Kitchen + Bar",
+    email: "ben.bebenroth@spicekitchen.com", phone: "216-555-0245",
+    address: "5800 Detroit Ave, Cleveland, OH 44102",
+    notify: "both", subscribed: true,
+    token: "r5v8q1-skb",
+  },
+  {
+    id: "c05", name: "Bar Cento",
+    email: "kitchen@barcento.com", phone: "216-555-0192",
+    address: "1948 W 25th St, Cleveland, OH 44113",
+    notify: "sms", subscribed: true,
+    token: "m9z4w7-bct",
+  },
+  {
+    id: "c06", name: "The Plum Café",
+    email: "brett@theplumcafe.com", phone: "216-555-0167",
+    address: "4133 Lorain Ave, Cleveland, OH 44113",
+    notify: "both", subscribed: true,
+    token: "h6f2y3-plm",
+  },
+  {
+    id: "c07", name: "Saucy Brew Works",
+    email: "chef@saucybrewworks.com", phone: "216-555-0273",
+    address: "2885 Detroit Ave, Cleveland, OH 44113",
+    notify: "email", subscribed: false,
+    token: "d4k1n8-sbw",
+  },
+];
+
+function CustomersPage() {
+  const [rows, setRows] = useState(SEED_CUSTOMERS);
+  const [drawer, setDrawer] = useState(null); // null | "new" | customer object
+  const [confirmRegen, setConfirmRegen] = useState(null);
+  const [copiedId, setCopiedId] = useState(null);
+
+  const openEdit = (c) => setDrawer(c);
+  const openNew  = () => setDrawer({ id: null, name: "", email: "", phone: "", address: "", notify: "both", subscribed: true, token: "" });
+
+  const saveDrawer = (data) => {
+    if (data.id) {
+      setRows(rs => rs.map(r => r.id === data.id ? data : r));
+    } else {
+      const id = "c" + String(rows.length + 1).padStart(2, "0");
+      setRows(rs => [...rs, { ...data, id, token: makeToken() }]);
+    }
+    setDrawer(null);
+  };
+  const deleteRow = (id) => {
+    setRows(rs => rs.filter(r => r.id !== id));
+    setDrawer(null);
+  };
+  const toggleSub = (id) =>
+    setRows(rs => rs.map(r => r.id === id ? { ...r, subscribed: !r.subscribed } : r));
+
+  const doCopy = (c) => {
+    navigator.clipboard?.writeText(`https://bushel.bay-branch.farm/c/${c.token}`);
+    setCopiedId(c.id);
+    setTimeout(() => setCopiedId(null), 1400);
+  };
+  const doRegen = (c) => {
+    setRows(rs => rs.map(r => r.id === c.id ? { ...r, token: makeToken() } : r));
+    setConfirmRegen(null);
+  };
+
+  return (
+    <div className="cust-page">
+      <div className="admin-page-head">
+        <div>
+          <div className="eyebrow" style={{marginBottom: 6}}>{rows.length} accounts · {rows.filter(r=>r.subscribed).length} subscribed</div>
+          <h1 className="admin-page-title">Customers</h1>
+        </div>
+        <div className="admin-page-actions">
+          <button type="button" className="btn btn-secondary">Export CSV</button>
+          <button type="button" className="btn btn-primary" onClick={openNew}>+ Add customer</button>
+        </div>
+      </div>
+
+      <div className="cust-tableCard">
+        <table className="cust-table">
+          <thead>
+            <tr>
+              <th className="col-c-name">Name</th>
+              <th className="col-c-contact">Contact</th>
+              <th className="col-c-addr">Address</th>
+              <th className="col-c-notify">Notify</th>
+              <th className="col-c-link">Order link</th>
+              <th className="col-c-sub">Subscribed</th>
+              <th className="col-c-actions"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(c => (
+              <tr key={c.id} className={"cust-row" + (!c.subscribed ? " is-unsub" : "")} onClick={() => openEdit(c)}>
+                <td className="col-c-name">
+                  <div className="cust-name">{c.name}</div>
+                  <div className="cust-name-token mono">/c/{c.token}</div>
+                </td>
+                <td className="col-c-contact">
+                  <div className="cust-email">{c.email}</div>
+                  <div className="cust-phone mono">{c.phone}</div>
+                </td>
+                <td className="col-c-addr">
+                  <div className="cust-addr" title={c.address}>{c.address}</div>
+                </td>
+                <td className="col-c-notify">
+                  <span className={"chip chip-notify chip-" + c.notify}>
+                    {c.notify === "sms" ? "SMS" : c.notify === "email" ? "Email" : "Both"}
+                  </span>
+                </td>
+                <td className="col-c-link" onClick={e => e.stopPropagation()}>
+                  <button
+                    type="button"
+                    className={"cust-copy" + (copiedId === c.id ? " is-copied" : "")}
+                    onClick={() => doCopy(c)}
+                  >
+                    <IconCopy/>
+                    <span>{copiedId === c.id ? "Copied!" : "Copy link"}</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="cust-regen"
+                    onClick={() => setConfirmRegen(c)}
+                  >
+                    Regenerate
+                  </button>
+                </td>
+                <td className="col-c-sub" onClick={e => e.stopPropagation()}>
+                  <Switch checked={c.subscribed} onChange={() => toggleSub(c.id)}/>
+                </td>
+                <td className="col-c-actions">
+                  <span className="cust-chev"><IconChev/></span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {drawer && <CustomerDrawer customer={drawer} onSave={saveDrawer} onDelete={deleteRow} onClose={() => setDrawer(null)}/>}
+
+      {confirmRegen && (
+        <ConfirmModal
+          title="Regenerate order link?"
+          body={<>This breaks <strong>{confirmRegen.name}</strong>'s existing bookmark. They'll need a new link by text or email.</>}
+          confirmLabel="Yes, regenerate"
+          confirmDanger
+          onConfirm={() => doRegen(confirmRegen)}
+          onCancel={() => setConfirmRegen(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+/* Drawer */
+function CustomerDrawer({ customer, onSave, onDelete, onClose }) {
+  const [c, setC] = useState(customer);
+  const isNew = !customer.id;
+  const set = (patch) => setC(prev => ({ ...prev, ...patch }));
+
+  return (
+    <>
+      <div className="drawer-scrim" onClick={onClose}></div>
+      <aside className="drawer">
+        <header className="drawer-head">
+          <div>
+            <div className="eyebrow">{isNew ? "new customer" : "edit customer"}</div>
+            <h2 className="drawer-title">{isNew ? "Add a new customer" : c.name || "—"}</h2>
+            {!isNew && <div className="drawer-token mono">/c/{c.token}</div>}
+          </div>
+          <button type="button" className="drawer-close" onClick={onClose} aria-label="Close">
+            <IconClose/>
+          </button>
+        </header>
+
+        <div className="drawer-body">
+          <Field label="Customer name" hint="How you refer to them — usually the business name.">
+            <input type="text" value={c.name} onChange={e => set({ name: e.target.value })} placeholder="e.g. West Side Market"/>
+          </Field>
+
+          <div className="field-row">
+            <Field label="Email">
+              <input type="email" value={c.email} onChange={e => set({ email: e.target.value })} placeholder="orders@…"/>
+            </Field>
+            <Field label="Phone">
+              <input type="tel" value={c.phone} onChange={e => set({ phone: e.target.value })} placeholder="216-555-0100"/>
+            </Field>
+          </div>
+
+          <Field label="Delivery address" hint="Used on order confirmations and the delivery list.">
+            <textarea rows={3} value={c.address} onChange={e => set({ address: e.target.value })} placeholder="Street, city, zip"/>
+          </Field>
+
+          <Field label="Notification preference">
+            <div className="radio-group">
+              {[
+                { v: "sms",   l: "SMS only",   s: "Best for restaurant kitchens." },
+                { v: "email", l: "Email only", s: "If they prefer paper trail." },
+                { v: "both",  l: "SMS + Email", s: "Sends both — recommended." },
+              ].map(opt => (
+                <label key={opt.v} className={"radio-card" + (c.notify === opt.v ? " is-on" : "")}>
+                  <input type="radio" name="notify" checked={c.notify === opt.v} onChange={() => set({ notify: opt.v })}/>
+                  <div>
+                    <div className="radio-card-label">{opt.l}</div>
+                    <div className="radio-card-sub">{opt.s}</div>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </Field>
+
+          <Field label="Subscribed" hint="When off, they won't receive weekly order links.">
+            <div style={{display: "flex", alignItems: "center", gap: 12}}>
+              <Switch checked={c.subscribed} onChange={v => set({ subscribed: v })}/>
+              <span style={{color: "var(--ink-700)", fontSize: "0.92rem"}}>
+                {c.subscribed ? "Will receive this week's link" : "Paused"}
+              </span>
+            </div>
+          </Field>
+        </div>
+
+        <footer className="drawer-foot">
+          {!isNew && (
+            <button type="button" className="btn btn-destructive" onClick={() => onDelete(c.id)}>
+              Delete customer
+            </button>
+          )}
+          <div style={{flex: 1}}></div>
+          <button type="button" className="btn btn-ghost" onClick={onClose}>Cancel</button>
+          <button type="button" className="btn btn-primary" onClick={() => onSave(c)}>
+            {isNew ? "Add customer" : "Save changes"}
+          </button>
+        </footer>
+      </aside>
+    </>
+  );
+}
+
+function Field({ label, hint, children }) {
+  return (
+    <div className="field">
+      <label className="field-label">{label}</label>
+      <div className="field-control">{children}</div>
+      {hint && <div className="field-hint">{hint}</div>}
+    </div>
+  );
+}
+
+function ConfirmModal({ title, body, confirmLabel, confirmDanger, onConfirm, onCancel }) {
+  return (
+    <>
+      <div className="modal-scrim" onClick={onCancel}></div>
+      <div className="modal" role="dialog" aria-modal="true">
+        <div className="modal-icon">
+          <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 9v4"/><path d="M12 17h.01"/>
+            <path d="M10.3 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.7 3.86a2 2 0 0 0-3.4 0z"/>
+          </svg>
+        </div>
+        <h3 className="modal-title">{title}</h3>
+        <p className="modal-body">{body}</p>
+        <div className="modal-actions">
+          <button type="button" className="btn btn-ghost" onClick={onCancel}>Cancel</button>
+          <button type="button" className={"btn " + (confirmDanger ? "btn-destructive-solid" : "btn-primary")} onClick={onConfirm}>
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function Switch({ checked, onChange }) {
+  return (
+    <button type="button" role="switch" aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className={"inv-switch" + (checked ? " is-on" : "")}>
+      <span className="inv-switch-thumb"></span>
+    </button>
+  );
+}
+
+function makeToken() {
+  return Math.random().toString(36).slice(2, 8) + "-" + Math.random().toString(36).slice(2, 5);
+}
+
+function IconCopy() {
+  return <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="8" y="8" width="12" height="12" rx="2"/><path d="M16 8V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h3"/>
+  </svg>;
+}
+function IconChev() {
+  return <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><path d="m9 6 6 6-6 6"/></svg>;
+}
+function IconClose() {
+  return <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><path d="M6 6l12 12 M18 6 6 18"/></svg>;
+}
+
+window.CustomersPage = CustomersPage;

--- a/design/admin-inventory.css
+++ b/design/admin-inventory.css
@@ -1,0 +1,320 @@
+/* Admin · Inventory editor */
+
+.inv-week {
+  font-weight: 400;
+  color: var(--ink-500);
+  font-size: 1.4rem;
+  letter-spacing: -0.005em;
+}
+
+/* dirty state on primary save button */
+.btn.is-dirty {
+  background: var(--leaf-600);
+  position: relative;
+}
+.btn.is-dirty::before {
+  content: "";
+  position: absolute; top: 6px; right: 6px;
+  width: 8px; height: 8px;
+  background: var(--gold-600, #E6A817);
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px var(--leaf-600);
+}
+
+/* meta pills row */
+.inv-meta {
+  display: flex; gap: 12px;
+  margin-bottom: 18px;
+  flex-wrap: wrap;
+}
+.inv-meta-pill {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-sm);
+  padding: 8px 14px;
+  display: flex; flex-direction: column;
+  min-width: 0;
+}
+.inv-meta-key {
+  font-size: 0.66rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.1em;
+  color: var(--ink-500);
+}
+.inv-meta-val {
+  font-size: 0.88rem; font-weight: 500;
+  color: var(--ink-900);
+  display: flex; align-items: center; gap: 8px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* table card */
+.inv-tableCard {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  overflow: hidden;
+  margin-bottom: 28px;
+}
+.inv-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--sans);
+  font-size: 0.92rem;
+}
+.inv-table thead th {
+  background: var(--cream);
+  text-align: left;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-500);
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--ink-200);
+  white-space: nowrap;
+}
+.inv-table tbody tr.inv-row td {
+  padding: 6px 12px;
+  border-top: 1px solid var(--ink-200);
+  vertical-align: middle;
+}
+.inv-table tbody tr.inv-row:first-child td { border-top: 0; }
+.inv-table tbody tr.inv-row.is-unavail td { background: var(--ink-100); }
+.inv-table tbody tr.inv-row.is-unavail .inv-cell { color: var(--ink-500); }
+
+/* columns */
+.col-handle  { width: 28px; padding: 0 0 0 6px !important; }
+.col-name    { width: 28%; min-width: 220px; }
+.col-cat     { width: 130px; }
+.col-price   { width: 110px; }
+.col-unit    { width: 130px; }
+.col-qty     { width: 80px; }
+.col-avail   { width: 90px; text-align: center; }
+.col-actions { width: 44px; text-align: right; padding-right: 12px !important; }
+
+/* drag handle */
+.inv-handle {
+  color: var(--ink-300);
+  cursor: grab;
+  display: inline-flex; align-items: center;
+  padding: 4px 2px;
+  border-radius: 3px;
+}
+.inv-handle:hover { color: var(--ink-700); background: var(--cream); }
+
+/* cells */
+.inv-cell {
+  width: 100%;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 8px 10px;
+  font-family: inherit;
+  font-size: 0.93rem;
+  color: var(--ink-900);
+  line-height: 1.3;
+  transition: background 0.1s, border-color 0.1s;
+}
+.inv-cell:hover {
+  background: var(--cream);
+}
+.inv-cell:focus {
+  outline: none;
+  background: var(--paper);
+  border-color: var(--leaf-600);
+  box-shadow: 0 0 0 3px rgba(79,138,27,0.12);
+}
+
+.inv-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+}
+.inv-num.is-low { color: var(--gold-600, #E6A817); font-weight: 600; }
+.inv-num.is-zero { color: var(--ink-500); font-weight: 600; }
+
+.inv-priceWrap {
+  display: flex; align-items: center;
+  position: relative;
+}
+.inv-priceSym {
+  position: absolute; left: 10px;
+  color: var(--ink-500);
+  font-size: 0.9rem;
+  pointer-events: none;
+}
+.inv-priceWrap .inv-cell { padding-left: 22px; }
+
+.inv-select {
+  appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none' stroke='%2369635A' stroke-width='1.6' stroke-linecap='round'><path d='M1 1l4 4 4-4'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 28px;
+  cursor: pointer;
+}
+
+/* Description toggle */
+.inv-descToggle {
+  margin-top: 2px;
+  background: transparent; border: none; padding: 4px 10px;
+  font-family: var(--sans);
+  font-size: 0.8rem;
+  color: var(--ink-500);
+  cursor: pointer;
+  text-align: left;
+  display: block;
+  width: 100%;
+  border-radius: 3px;
+}
+.inv-descToggle:hover { background: var(--cream); color: var(--ink-700); }
+.inv-descPreview {
+  font-style: italic;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.inv-descPlaceholder {
+  color: var(--ink-300);
+  font-weight: 500;
+}
+.inv-descToggle.is-open .inv-descPlaceholder { color: var(--leaf-600); }
+
+.inv-descRow td { padding: 0 12px 8px !important; border-top: 0 !important; }
+.inv-descInput {
+  background: var(--leaf-50);
+  border-color: var(--leaf-100);
+  font-style: italic;
+  font-size: 0.9rem;
+  color: var(--ink-700);
+}
+.inv-descInput:focus { background: var(--paper); border-color: var(--leaf-600); }
+
+/* Switch */
+.inv-switch {
+  width: 38px; height: 22px;
+  background: var(--ink-200);
+  border: none;
+  border-radius: 999px;
+  position: relative;
+  cursor: pointer;
+  transition: background 0.15s;
+  padding: 0;
+  display: inline-block;
+}
+.inv-switch.is-on { background: var(--leaf-600); }
+.inv-switch:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(79,138,27,0.18);
+}
+.inv-switch-thumb {
+  position: absolute;
+  top: 2px; left: 2px;
+  width: 18px; height: 18px;
+  background: var(--paper);
+  border-radius: 50%;
+  transition: transform 0.18s ease;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+}
+.inv-switch.is-on .inv-switch-thumb { transform: translateX(16px); }
+
+/* Trash */
+.inv-trash {
+  background: transparent; border: none;
+  color: var(--ink-300);
+  width: 32px; height: 32px;
+  border-radius: 4px;
+  display: inline-flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+.inv-trash:hover { background: rgba(178,59,46,0.08); color: var(--rose-600); }
+
+/* Add row */
+.inv-addRow {
+  display: flex; align-items: center; gap: 12px;
+  width: 100%;
+  background: transparent;
+  border: 1px dashed var(--ink-300);
+  border-radius: 0;
+  border-top: 1px dashed var(--ink-300);
+  border-left: 0; border-right: 0; border-bottom: 0;
+  padding: 14px 18px;
+  font-family: var(--sans);
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--ink-500);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s, color 0.12s;
+}
+.inv-addRow:hover {
+  background: var(--leaf-50);
+  color: var(--leaf-700);
+}
+.inv-addRow-plus {
+  width: 22px; height: 22px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 50%;
+  background: var(--ink-200);
+  font-size: 1rem; font-weight: 600;
+  color: var(--ink-700);
+  line-height: 1;
+}
+.inv-addRow:hover .inv-addRow-plus {
+  background: var(--leaf-600);
+  color: var(--paper);
+}
+.inv-addRow-hint {
+  margin-left: auto;
+  color: var(--ink-300);
+  font-size: 0.78rem;
+  font-weight: 400;
+}
+
+/* Sticky save bar */
+.inv-saveBar {
+  position: sticky;
+  bottom: 16px;
+  margin: 0 auto;
+  max-width: 720px;
+  background: var(--ink-900);
+  color: var(--paper);
+  border-radius: var(--r-md);
+  padding: 12px 14px 12px 22px;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 18px;
+  box-shadow: 0 18px 40px -12px rgba(31,30,26,0.4), 0 4px 8px rgba(31,30,26,0.15);
+  animation: inv-saveBar-rise 0.2s ease;
+}
+@keyframes inv-saveBar-rise {
+  from { transform: translateY(8px); opacity: 0; }
+  to   { transform: translateY(0);   opacity: 1; }
+}
+.inv-saveBar-msg {
+  display: flex; align-items: center; gap: 10px;
+  font-size: 0.92rem;
+}
+.inv-saveBar-msg strong { color: var(--leaf-100); }
+.inv-saveBar-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--gold-600, #E6A817);
+  box-shadow: 0 0 0 3px rgba(230,168,23,0.18);
+  animation: inv-pulse 1.6s ease-in-out infinite;
+}
+@keyframes inv-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.6; }
+}
+.inv-saveBar-actions { display: flex; gap: 8px; }
+.inv-saveBar-actions .btn-ghost {
+  color: rgba(251,250,245,0.75);
+  background: transparent;
+}
+.inv-saveBar-actions .btn-ghost:hover {
+  background: rgba(251,250,245,0.08);
+  color: var(--paper);
+}

--- a/design/admin-inventory.jsx
+++ b/design/admin-inventory.jsx
@@ -1,0 +1,283 @@
+/* Admin · Inventory editor */
+
+const { useState, useMemo, useRef } = React;
+
+const CATEGORIES = ["Vegetables", "Fruit", "Herbs", "Flowers", "Other"];
+
+const SEED_ROWS = [
+  { id: "p01", name: "Heirloom tomatoes",   category: "Vegetables", price: 5.50, unit: "per lb",     qty: 24, desc: "Mix of Cherokee Purple, Brandywine, and Striped German.", available: true },
+  { id: "p02", name: "Genovese basil",      category: "Herbs",      price: 3.50, unit: "per bunch",  qty: 18, desc: "Big leaves — pesto-ready.", available: true },
+  { id: "p03", name: "Dino kale",           category: "Vegetables", price: 4.50, unit: "per bunch",  qty: 12, desc: "Lacinato. Tender stems this week.", available: true },
+  { id: "p04", name: "Sungold cherry tomatoes", category: "Vegetables", price: 6.00, unit: "per pint", qty: 16, desc: "Picked Tuesday. Honey-sweet.", available: true },
+  { id: "p05", name: "Red beets",           category: "Vegetables", price: 3.25, unit: "per lb",     qty: 9,  desc: "Tops included — good for sautéing.", available: true },
+  { id: "p06", name: "Zucchini",            category: "Vegetables", price: 2.50, unit: "each",       qty: 22, desc: "Medium size, tender skin.", available: true },
+  { id: "p07", name: "Zinnia bouquet",      category: "Flowers",    price: 12.00, unit: "per bunch", qty: 6,  desc: "Mixed colors, ~15 stems.", available: true },
+  { id: "p08", name: "Strawberries",        category: "Fruit",      price: 7.50, unit: "per pint",   qty: 0,  desc: "Last picking — back next week.", available: false },
+  { id: "p09", name: "Garlic scapes",       category: "Herbs",      price: 4.00, unit: "per bunch",  qty: 14, desc: "Curly tops, mild garlic flavor.", available: true },
+  { id: "p10", name: "Rainbow chard",       category: "Vegetables", price: 4.50, unit: "per bunch",  qty: 11, desc: "Beautiful stems — yellow, magenta, white.", available: true },
+];
+
+let nextId = 11;
+function newRowId() { return "p" + String(nextId++).padStart(2, "0"); }
+
+function InventoryPage() {
+  const [rows, setRows] = useState(SEED_ROWS);
+  const [originalRows] = useState(SEED_ROWS);
+
+  const dirty = useMemo(
+    () => JSON.stringify(rows) !== JSON.stringify(originalRows),
+    [rows, originalRows]
+  );
+  const dirtyCount = useMemo(() => {
+    if (!dirty) return 0;
+    const orig = new Map(originalRows.map(r => [r.id, r]));
+    let count = 0;
+    rows.forEach(r => {
+      const o = orig.get(r.id);
+      if (!o || JSON.stringify(o) !== JSON.stringify(r)) count++;
+    });
+    rows.length !== originalRows.length && (count += Math.abs(rows.length - originalRows.length));
+    return count;
+  }, [rows, originalRows, dirty]);
+
+  const update = (id, patch) =>
+    setRows(rs => rs.map(r => r.id === id ? { ...r, ...patch } : r));
+
+  const remove = (id) =>
+    setRows(rs => rs.filter(r => r.id !== id));
+
+  const addRow = () =>
+    setRows(rs => [...rs, {
+      id: newRowId(),
+      name: "", category: "Vegetables", price: 0, unit: "per lb",
+      qty: 0, desc: "", available: true
+    }]);
+
+  return (
+    <div className="inv-page">
+      <div className="admin-page-head">
+        <div>
+          <div className="eyebrow" style={{marginBottom: 6}}>this week's list · 12 products</div>
+          <h1 className="admin-page-title">Inventory <span className="inv-week">— Week of May 3</span></h1>
+        </div>
+        <div className="admin-page-actions">
+          <button type="button" className="btn btn-secondary">
+            <IconHistory/>
+            <span>Pre-populate from last week</span>
+          </button>
+          <button type="button" className={"btn btn-primary" + (dirty ? " is-dirty" : "")} disabled={!dirty}>
+            {dirty ? `Save ${dirtyCount} change${dirtyCount === 1 ? "" : "s"}` : "Saved"}
+          </button>
+        </div>
+      </div>
+
+      <div className="inv-meta">
+        <div className="inv-meta-pill">
+          <span className="inv-meta-key">Open for orders</span>
+          <span className="inv-meta-val"><span className="status-dot is-open" style={{boxShadow: "0 0 0 2px rgba(121,196,78,0.18)"}}></span> Sun 8am – Tue 6pm</span>
+        </div>
+        <div className="inv-meta-pill">
+          <span className="inv-meta-key">Customers</span>
+          <span className="inv-meta-val">38 active · 12 ordered yet</span>
+        </div>
+        <div className="inv-meta-pill">
+          <span className="inv-meta-key">Cutoff</span>
+          <span className="inv-meta-val">Tue 6:00pm · 28h left</span>
+        </div>
+      </div>
+
+      <div className="inv-tableCard">
+        <table className="inv-table">
+          <thead>
+            <tr>
+              <th className="col-handle"></th>
+              <th className="col-name">Product</th>
+              <th className="col-cat">Category</th>
+              <th className="col-price">Price</th>
+              <th className="col-unit">Unit</th>
+              <th className="col-qty">Qty</th>
+              <th className="col-avail">Available</th>
+              <th className="col-actions"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => (
+              <InventoryRow
+                key={row.id}
+                row={row}
+                index={i}
+                onUpdate={(patch) => update(row.id, patch)}
+                onRemove={() => remove(row.id)}
+              />
+            ))}
+          </tbody>
+        </table>
+        <button type="button" className="inv-addRow" onClick={addRow}>
+          <span className="inv-addRow-plus">+</span>
+          <span>Add row</span>
+          <span className="inv-addRow-hint mono">↹ Tab moves between cells</span>
+        </button>
+      </div>
+
+      {dirty && (
+        <div className="inv-saveBar">
+          <div className="inv-saveBar-msg">
+            <span className="inv-saveBar-dot"></span>
+            <span><strong>{dirtyCount}</strong> unsaved {dirtyCount === 1 ? "change" : "changes"}</span>
+          </div>
+          <div className="inv-saveBar-actions">
+            <button type="button" className="btn btn-ghost">Discard</button>
+            <button type="button" className="btn btn-primary">Save changes</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InventoryRow({ row, index, onUpdate, onRemove }) {
+  const [descOpen, setDescOpen] = useState(false);
+  return (
+    <>
+      <tr className={"inv-row" + (!row.available ? " is-unavail" : "")}>
+        <td className="col-handle">
+          <span className="inv-handle" title="Drag to reorder">
+            <svg viewBox="0 0 12 18" width="10" height="14" aria-hidden="true">
+              <circle cx="3" cy="3" r="1.5" fill="currentColor"/>
+              <circle cx="9" cy="3" r="1.5" fill="currentColor"/>
+              <circle cx="3" cy="9" r="1.5" fill="currentColor"/>
+              <circle cx="9" cy="9" r="1.5" fill="currentColor"/>
+              <circle cx="3" cy="15" r="1.5" fill="currentColor"/>
+              <circle cx="9" cy="15" r="1.5" fill="currentColor"/>
+            </svg>
+          </span>
+        </td>
+        <td className="col-name">
+          <input
+            type="text"
+            className="inv-cell"
+            value={row.name}
+            onChange={e => onUpdate({ name: e.target.value })}
+            placeholder="Product name…"
+          />
+          {!descOpen && (
+            <button
+              type="button"
+              className={"inv-descToggle" + (row.desc ? " is-open" : "")}
+              onClick={() => setDescOpen(true)}
+            >
+              {row.desc
+                ? <span className="inv-descPreview">{row.desc}</span>
+                : <span className="inv-descPlaceholder">+ description</span>}
+            </button>
+          )}
+        </td>
+        <td className="col-cat">
+          <select
+            className="inv-cell inv-select"
+            value={row.category}
+            onChange={e => onUpdate({ category: e.target.value })}
+          >
+            {CATEGORIES.map(c => <option key={c}>{c}</option>)}
+          </select>
+        </td>
+        <td className="col-price">
+          <div className="inv-priceWrap">
+            <span className="inv-priceSym">$</span>
+            <input
+              type="number"
+              step="0.25"
+              min="0"
+              className="inv-cell inv-num"
+              value={row.price}
+              onChange={e => onUpdate({ price: parseFloat(e.target.value) || 0 })}
+            />
+          </div>
+        </td>
+        <td className="col-unit">
+          <input
+            type="text"
+            className="inv-cell"
+            value={row.unit}
+            onChange={e => onUpdate({ unit: e.target.value })}
+            placeholder="per lb"
+          />
+        </td>
+        <td className="col-qty">
+          <input
+            type="number"
+            min="0"
+            className={"inv-cell inv-num" + (row.qty === 0 ? " is-zero" : row.qty <= 3 ? " is-low" : "")}
+            value={row.qty}
+            onChange={e => onUpdate({ qty: parseInt(e.target.value) || 0 })}
+          />
+        </td>
+        <td className="col-avail">
+          <Switch checked={row.available} onChange={v => onUpdate({ available: v })}/>
+        </td>
+        <td className="col-actions">
+          <button
+            type="button"
+            className="inv-trash"
+            onClick={onRemove}
+            title="Delete row"
+            aria-label="Delete row"
+          >
+            <IconTrash/>
+          </button>
+        </td>
+      </tr>
+      {descOpen && (
+        <tr className="inv-row inv-descRow">
+          <td className="col-handle"></td>
+          <td colSpan={7}>
+            <input
+              type="text"
+              className="inv-cell inv-descInput"
+              value={row.desc}
+              onChange={e => onUpdate({ desc: e.target.value })}
+              placeholder="Optional note for the customer — picked yesterday, last batch this week, etc."
+            />
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function Switch({ checked, onChange }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className={"inv-switch" + (checked ? " is-on" : "")}
+    >
+      <span className="inv-switch-thumb"></span>
+    </button>
+  );
+}
+
+/* icons */
+function IconHistory() {
+  return (
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 12a9 9 0 1 0 3-6.7"/>
+      <path d="M3 4v5h5"/>
+      <path d="M12 8v5l3 2"/>
+    </svg>
+  );
+}
+function IconTrash() {
+  return (
+    <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 6h18"/>
+      <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2"/>
+      <path d="M19 6 17.5 20a2 2 0 0 1-2 2h-7a2 2 0 0 1-2-2L5 6"/>
+      <path d="M10 11v6 M14 11v6"/>
+    </svg>
+  );
+}
+
+window.InventoryPage = InventoryPage;

--- a/design/admin-orders.css
+++ b/design/admin-orders.css
@@ -1,0 +1,347 @@
+/* Admin · Orders */
+
+/* filters row */
+.ord-filters {
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 18px;
+}
+.chip-tab {
+  display: inline-flex; align-items: center; gap: 8px;
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: 999px;
+  padding: 7px 14px;
+  font-family: var(--sans);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--ink-700);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.1s, border-color 0.1s, color 0.1s;
+}
+.chip-tab:hover { background: var(--cream); border-color: var(--ink-300); }
+.chip-tab.is-on {
+  background: var(--ink-900); color: var(--paper); border-color: var(--ink-900);
+}
+.chip-tab.is-on .chip-count { background: rgba(251,250,245,0.18); color: var(--paper); }
+.chip-count {
+  background: var(--ink-100);
+  color: var(--ink-500);
+  border-radius: 999px;
+  padding: 1px 8px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.ord-filters-spacer { flex: 1; }
+.ord-search {
+  display: inline-flex; align-items: center; gap: 8px;
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-sm);
+  padding: 7px 12px;
+  width: 280px;
+  color: var(--ink-500);
+}
+.ord-search input {
+  border: none; background: transparent; outline: none;
+  width: 100%;
+  font-family: var(--sans);
+  font-size: 0.9rem;
+  color: var(--ink-900);
+}
+.ord-search input::placeholder { color: var(--ink-500); }
+.ord-search:focus-within { border-color: var(--leaf-600); box-shadow: 0 0 0 3px rgba(79,138,27,0.12); }
+
+/* table */
+.ord-tableCard {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  overflow: hidden;
+  margin-bottom: 28px;
+}
+.ord-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--sans);
+  font-size: 0.92rem;
+}
+.ord-table thead th {
+  background: var(--cream);
+  text-align: left;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-500);
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--ink-200);
+  white-space: nowrap;
+}
+.ord-row {
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.ord-row td {
+  padding: 14px;
+  border-top: 1px solid var(--ink-200);
+  vertical-align: top;
+}
+.ord-row:hover { background: var(--cream); }
+.ord-row.is-open { background: var(--leaf-50); }
+.ord-row.needs-rec { background: rgba(178,59,46,0.04); }
+.ord-row.needs-rec:hover { background: rgba(178,59,46,0.08); }
+.ord-row.needs-rec.is-open { background: rgba(178,59,46,0.06); }
+
+.col-o-id     { width: 150px; }
+.col-o-cust   { width: 18%; min-width: 160px; }
+.col-o-when   { width: 110px; }
+.col-o-items  { width: 26%; min-width: 220px; }
+.col-o-ful    { width: 180px; }
+.col-o-total  { width: 90px; text-align: right; }
+.col-o-status { width: 200px; }
+
+.ord-num { font-size: 0.82rem; color: var(--ink-700); font-weight: 600; }
+.badge-recon {
+  display: inline-flex; align-items: center; gap: 4px;
+  margin-top: 6px;
+  background: var(--rose-600);
+  color: var(--paper);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.ord-cust-name { font-weight: 600; color: var(--ink-900); }
+.ord-when { font-size: 0.88rem; color: var(--ink-700); white-space: nowrap; }
+
+.ord-items-count { font-size: 0.92rem; color: var(--ink-900); margin-bottom: 2px; }
+.ord-items-count strong { font-weight: 700; }
+.ord-items-prev {
+  font-size: 0.82rem;
+  color: var(--ink-500);
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.ord-ful { display: flex; flex-direction: column; gap: 4px; align-items: flex-start; }
+.chip-ful.chip-delivery { background: var(--leaf-50); color: var(--leaf-700); border-color: var(--leaf-100); }
+.chip-ful.chip-pickup   { background: #FAF1DC; color: #8A6210; border-color: #EFD89A; }
+.ord-ful-when { font-size: 0.8rem; color: var(--ink-500); white-space: nowrap; }
+
+.ord-total {
+  font-family: var(--serif);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--ink-900);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+/* Status pills + advance buttons */
+.status-control { display: flex; flex-direction: column; align-items: flex-start; gap: 6px; }
+.pill {
+  display: inline-flex; align-items: center;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+.pill-new   { background: rgba(178,59,46,0.1); color: var(--rose-600); }
+.pill-ready { background: var(--leaf-50); color: var(--leaf-700); border: 1px solid var(--leaf-100); }
+.pill-done  { background: var(--ink-100); color: var(--ink-700); }
+
+.status-advance {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: var(--ink-900);
+  color: var(--paper);
+  border: none;
+  border-radius: var(--r-sm);
+  padding: 6px 12px;
+  font-family: var(--sans);
+  font-size: 0.82rem;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.1s;
+}
+.status-advance:hover { background: #2c2b27; }
+
+/* detail row */
+.ord-detail-row td {
+  padding: 0 !important;
+  border-top: 0 !important;
+  background: var(--leaf-50);
+}
+.ord-row.needs-rec + .ord-detail-row td { background: rgba(178,59,46,0.05); }
+
+.ord-detail {
+  padding: 22px 24px 24px;
+  border-top: 1px dashed var(--leaf-100);
+}
+.ord-detail-grid {
+  display: grid; grid-template-columns: 1.2fr 1fr;
+  gap: 32px;
+}
+.ord-detail-section {}
+.ord-detail-label {
+  font-size: 0.7rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--ink-500);
+  margin-bottom: 10px;
+}
+.ord-detail-list { list-style: none; padding: 0; margin: 0; }
+.ord-detail-list li {
+  display: grid;
+  grid-template-columns: 30px 1fr auto;
+  align-items: baseline;
+  gap: 10px;
+  padding: 8px 0;
+  border-top: 1px solid rgba(59,109,17,0.12);
+}
+.ord-detail-list li:first-child { border-top: 0; padding-top: 0; }
+.ord-detail-list li.is-oversold {
+  grid-template-columns: 30px 1fr;
+  grid-template-areas:
+    "qty name"
+    ".   flag"
+    ".   amt";
+}
+.ord-detail-list li.is-oversold .ord-li-qty  { grid-area: qty; color: var(--rose-600); }
+.ord-detail-list li.is-oversold .ord-li-name { grid-area: name; }
+.ord-detail-list li.is-oversold .ord-li-flag { grid-area: flag; }
+.ord-detail-list li.is-oversold .ord-li-amt  { grid-area: amt; justify-self: end; }
+.ord-li-qty { color: var(--leaf-700); font-weight: 600; }
+.ord-li-name { color: var(--ink-900); }
+.ord-li-unit { color: var(--ink-500); font-size: 0.85rem; }
+.ord-li-amt  { color: var(--ink-900); font-variant-numeric: tabular-nums; }
+.ord-li-flag {
+  display: inline-flex; align-items: center; gap: 5px;
+  background: var(--rose-600);
+  color: var(--paper);
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 4px;
+  margin-top: 4px;
+  width: fit-content;
+}
+
+.ord-li-total {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding-top: 12px;
+  margin-top: 8px;
+  border-top: 2px solid rgba(59,109,17,0.2);
+  font-weight: 600;
+}
+.ord-li-total .mono {
+  font-family: var(--serif);
+  font-size: 1.2rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.ord-detail-fulfill {
+  background: var(--paper);
+  border: 1px solid var(--leaf-100);
+  border-radius: var(--r-sm);
+  padding: 12px 14px;
+}
+.ord-detail-row {} /* avoid clash; reset below */
+.ord-detail-section .ord-detail-row {
+  display: grid; grid-template-columns: 80px 1fr;
+  gap: 12px;
+  padding: 4px 0;
+  font-size: 0.9rem;
+  border-top: 0;
+}
+.ord-detail-key {
+  font-size: 0.72rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--ink-500);
+}
+.ord-detail-note {
+  background: var(--paper);
+  border: 1px solid var(--leaf-100);
+  border-left: 3px solid var(--leaf-600);
+  border-radius: var(--r-sm);
+  padding: 10px 14px;
+  font-style: italic;
+  color: var(--ink-700);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+/* Split button */
+.split-btn-wrap { position: relative; }
+.split-btn-main {
+  display: inline-flex; align-items: center; gap: 8px;
+  background: var(--leaf-600);
+  color: var(--paper);
+  border: none;
+  border-radius: var(--r-sm);
+  padding: 0 0 0 16px;
+  font-family: var(--sans);
+  font-size: 0.95rem;
+  font-weight: 600;
+  height: 44px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.1s;
+}
+.split-btn-main:hover { background: var(--leaf-700); }
+.split-btn-divider {
+  width: 1px; height: 24px;
+  background: rgba(255,255,255,0.25);
+  margin-left: 4px;
+}
+.split-btn-chev { padding: 0 14px; height: 100%; display: inline-flex; align-items: center; }
+
+.split-scrim { position: fixed; inset: 0; z-index: 30; }
+.split-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-sm);
+  box-shadow: 0 10px 30px -8px rgba(31,30,26,0.2);
+  width: 240px;
+  padding: 6px;
+  z-index: 40;
+  animation: fade-in 0.12s ease;
+}
+.split-item {
+  display: block;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 10px 12px;
+  text-align: left;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.split-item:hover { background: var(--leaf-50); }
+.split-item-title { font-weight: 600; color: var(--ink-900); margin-bottom: 2px; }
+.split-item-sub { font-size: 0.8rem; color: var(--ink-500); }
+
+/* Callout warn variant */
+.callout-warn {
+  display: block;
+  background: rgba(178,59,46,0.06);
+  border: 1px solid rgba(178,59,46,0.2);
+  color: var(--ink-900);
+  padding: 14px 16px;
+  border-radius: var(--r-sm);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+.callout-warn strong { color: var(--rose-600); }

--- a/design/admin-orders.jsx
+++ b/design/admin-orders.jsx
@@ -1,0 +1,325 @@
+/* Admin · Orders */
+
+const { useState, useMemo } = React;
+
+const SEED_ORDERS = [
+  {
+    id: "ord-0503-04", customer: "Spice Kitchen + Bar",
+    placed: "Tue · 10:42am",
+    items: [
+      { name: "Heirloom tomatoes", qty: 8, unit: "lb",    price: 5.50, oversold: false },
+      { name: "Genovese basil",    qty: 4, unit: "bunch", price: 3.50, oversold: false },
+      { name: "Sungold cherry tomatoes", qty: 6, unit: "pint", price: 6.00, oversold: true, available: 4 },
+      { name: "Garlic scapes",     qty: 3, unit: "bunch", price: 4.00, oversold: false },
+    ],
+    fulfillment: { type: "delivery", when: "Wed 8am – noon", address: "5800 Detroit Ave, Cleveland" },
+    notes: "Please knock at the kitchen entrance — front door is locked until 11.",
+    status: "new", needsReconciliation: true,
+  },
+  {
+    id: "ord-0503-03", customer: "Bar Cento",
+    placed: "Tue · 9:18am",
+    items: [
+      { name: "Heirloom tomatoes", qty: 6, unit: "lb",    price: 5.50 },
+      { name: "Dino kale",         qty: 4, unit: "bunch", price: 4.50 },
+      { name: "Rainbow chard",     qty: 3, unit: "bunch", price: 4.50 },
+    ],
+    fulfillment: { type: "delivery", when: "Wed 8am – noon", address: "1948 W 25th St, Cleveland" },
+    notes: "",
+    status: "ready", needsReconciliation: false,
+  },
+  {
+    id: "ord-0503-02", customer: "West Side Market — Bay Stand",
+    placed: "Mon · 7:32pm",
+    items: [
+      { name: "Heirloom tomatoes",     qty: 12, unit: "lb",    price: 5.50 },
+      { name: "Sungold cherry tomatoes", qty: 4, unit: "pint", price: 6.00 },
+      { name: "Genovese basil",        qty: 6, unit: "bunch", price: 3.50 },
+      { name: "Zucchini",              qty: 8, unit: "ea",    price: 2.50 },
+      { name: "Zinnia bouquet",        qty: 2, unit: "bunch", price: 12.00 },
+      { name: "Red beets",             qty: 4, unit: "lb",    price: 3.25 },
+    ],
+    fulfillment: { type: "pickup", when: "Sat 9am – 11am" },
+    notes: "Annabel — can you label the basil clamshells with the variety? Customers ask.",
+    status: "ready", needsReconciliation: false,
+  },
+  {
+    id: "ord-0503-01", customer: "The Plum Café",
+    placed: "Mon · 4:51pm",
+    items: [
+      { name: "Dino kale",       qty: 5, unit: "bunch", price: 4.50 },
+      { name: "Garlic scapes",   qty: 4, unit: "bunch", price: 4.00 },
+      { name: "Rainbow chard",   qty: 3, unit: "bunch", price: 4.50 },
+    ],
+    fulfillment: { type: "delivery", when: "Wed 8am – noon", address: "4133 Lorain Ave, Cleveland" },
+    notes: "",
+    status: "delivered", needsReconciliation: false,
+  },
+  {
+    id: "ord-0426-08", customer: "Lakewood Farmer's Market",
+    placed: "Sun · 11:24am",
+    items: [
+      { name: "Zinnia bouquet",   qty: 4, unit: "bunch", price: 12.00 },
+      { name: "Genovese basil",   qty: 8, unit: "bunch", price: 3.50 },
+    ],
+    fulfillment: { type: "pickup", when: "Sat 9am – 11am" },
+    notes: "",
+    status: "picked-up", needsReconciliation: false,
+  },
+];
+
+const STATUS_FLOW = ["new", "ready", "out"]; // "out" splits into picked-up / delivered
+
+function OrdersPage() {
+  const [orders, setOrders] = useState(SEED_ORDERS);
+  const [expanded, setExpanded] = useState(SEED_ORDERS[0].id);
+  const [filter, setFilter] = useState("week");
+  const [sort, setSort] = useState({ key: "placed", dir: "desc" });
+
+  const sorted = useMemo(() => {
+    const copy = [...orders];
+    // pin reconciliation flags
+    copy.sort((a, b) => {
+      if (a.needsReconciliation !== b.needsReconciliation) return a.needsReconciliation ? -1 : 1;
+      return 0;
+    });
+    return copy;
+  }, [orders, sort]);
+
+  const advance = (id, next) =>
+    setOrders(os => os.map(o => o.id === id ? { ...o, status: next } : o));
+
+  const totals = (o) => o.items.reduce((s, i) => s + i.qty * i.price, 0);
+
+  return (
+    <div className="ord-page">
+      <div className="admin-page-head">
+        <div>
+          <div className="eyebrow" style={{marginBottom: 6}}>{orders.length} orders · {orders.filter(o=>o.needsReconciliation).length} need reconciliation</div>
+          <h1 className="admin-page-title">Orders</h1>
+        </div>
+        <div className="admin-page-actions">
+          <SplitButton/>
+        </div>
+      </div>
+
+      <div className="ord-filters">
+        <button className={"chip-tab" + (filter==="week" ? " is-on" : "")} onClick={() => setFilter("week")}>
+          This week <span className="chip-count">5</span>
+        </button>
+        <button className={"chip-tab" + (filter==="last" ? " is-on" : "")} onClick={() => setFilter("last")}>
+          Last week <span className="chip-count">7</span>
+        </button>
+        <button className={"chip-tab" + (filter==="range" ? " is-on" : "")} onClick={() => setFilter("range")}>
+          <IconCal/> Custom range
+        </button>
+        <div className="ord-filters-spacer"></div>
+        <div className="ord-search">
+          <IconSearch/>
+          <input type="text" placeholder="Search customer or order #…"/>
+        </div>
+      </div>
+
+      <div className="ord-tableCard">
+        <table className="ord-table">
+          <thead>
+            <tr>
+              <th className="col-o-id">Order</th>
+              <th className="col-o-cust">Customer</th>
+              <th className="col-o-when">Placed</th>
+              <th className="col-o-items">Items</th>
+              <th className="col-o-ful">Fulfillment</th>
+              <th className="col-o-total">Total</th>
+              <th className="col-o-status">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map(o => {
+              const total = totals(o);
+              const isOpen = expanded === o.id;
+              const itemsPreview = o.items.slice(0, 3).map(i => i.name.toLowerCase()).join(", ") + (o.items.length > 3 ? `, +${o.items.length - 3} more` : "");
+              return (
+                <React.Fragment key={o.id}>
+                  <tr
+                    className={"ord-row" + (o.needsReconciliation ? " needs-rec" : "") + (isOpen ? " is-open" : "")}
+                    onClick={() => setExpanded(isOpen ? null : o.id)}
+                  >
+                    <td className="col-o-id">
+                      <div className="ord-num mono">#{o.id.split("-").slice(1).join("-")}</div>
+                      {o.needsReconciliation && (
+                        <span className="badge-recon"><IconAlert/> Needs reconciliation</span>
+                      )}
+                    </td>
+                    <td className="col-o-cust">
+                      <div className="ord-cust-name">{o.customer}</div>
+                    </td>
+                    <td className="col-o-when">
+                      <div className="ord-when">{o.placed}</div>
+                    </td>
+                    <td className="col-o-items">
+                      <div className="ord-items-count"><strong>{o.items.length}</strong> items</div>
+                      <div className="ord-items-prev">{itemsPreview}</div>
+                    </td>
+                    <td className="col-o-ful">
+                      <div className="ord-ful">
+                        <span className={"chip chip-ful chip-" + o.fulfillment.type}>
+                          {o.fulfillment.type === "delivery" ? "Delivery" : "Pickup"}
+                        </span>
+                        <span className="ord-ful-when">{o.fulfillment.when}</span>
+                      </div>
+                    </td>
+                    <td className="col-o-total">
+                      <div className="ord-total mono">${total.toFixed(2)}</div>
+                    </td>
+                    <td className="col-o-status" onClick={e => e.stopPropagation()}>
+                      <StatusControl order={o} onAdvance={s => advance(o.id, s)}/>
+                    </td>
+                  </tr>
+                  {isOpen && (
+                    <tr className="ord-detail-row">
+                      <td colSpan={7}>
+                        <OrderDetail order={o} total={total}/>
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function StatusControl({ order, onAdvance }) {
+  const s = order.status;
+  if (s === "new") {
+    return (
+      <div className="status-control">
+        <span className="pill pill-new">New</span>
+        <button type="button" className="status-advance" onClick={() => onAdvance("ready")}>
+          Mark ready <IconArrow/>
+        </button>
+      </div>
+    );
+  }
+  if (s === "ready") {
+    return (
+      <div className="status-control">
+        <span className="pill pill-ready">Ready</span>
+        <div className="status-split">
+          {order.fulfillment.type === "pickup" ? (
+            <button type="button" className="status-advance" onClick={() => onAdvance("picked-up")}>Picked up <IconCheck/></button>
+          ) : (
+            <button type="button" className="status-advance" onClick={() => onAdvance("delivered")}>Delivered <IconCheck/></button>
+          )}
+        </div>
+      </div>
+    );
+  }
+  if (s === "picked-up") return <span className="pill pill-done">Picked up · {order.fulfillment.when.split(" ")[0]}</span>;
+  if (s === "delivered") return <span className="pill pill-done">Delivered · Wed</span>;
+  return null;
+}
+
+function OrderDetail({ order, total }) {
+  return (
+    <div className="ord-detail">
+      <div className="ord-detail-grid">
+        <div className="ord-detail-section">
+          <div className="ord-detail-label">Line items</div>
+          <ul className="ord-detail-list">
+            {order.items.map((i, idx) => (
+              <li key={idx} className={i.oversold ? "is-oversold" : ""}>
+                <span className="ord-li-qty mono">{i.qty}×</span>
+                <span className="ord-li-name">{i.name}<span className="ord-li-unit"> · {i.unit}</span></span>
+                {i.oversold && (
+                  <span className="ord-li-flag">
+                    <IconAlert/> Only {i.available} available — {i.qty - i.available} oversold
+                  </span>
+                )}
+                <span className="ord-li-amt mono">${(i.qty * i.price).toFixed(2)}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="ord-li-total">
+            <span>Total</span>
+            <span className="mono">${total.toFixed(2)}</span>
+          </div>
+        </div>
+
+        <div className="ord-detail-section">
+          <div className="ord-detail-label">Fulfillment</div>
+          <div className="ord-detail-fulfill">
+            <div className="ord-detail-row"><span className="ord-detail-key">Type</span><span>{order.fulfillment.type === "delivery" ? "Delivery" : "Pickup"}</span></div>
+            <div className="ord-detail-row"><span className="ord-detail-key">Window</span><span>{order.fulfillment.when}</span></div>
+            {order.fulfillment.address && (
+              <div className="ord-detail-row"><span className="ord-detail-key">Address</span><span>{order.fulfillment.address}</span></div>
+            )}
+          </div>
+
+          {order.notes && (
+            <>
+              <div className="ord-detail-label" style={{marginTop: 18}}>Customer note</div>
+              <div className="ord-detail-note">"{order.notes}"</div>
+            </>
+          )}
+
+          {order.needsReconciliation && (
+            <div className="callout callout-warn" style={{marginTop: 16}}>
+              <strong>This order oversold an item.</strong> The cart was optimistic — actual stock didn't match. Adjust quantities below or text the customer before fulfillment.
+              <div style={{marginTop: 10, display: "flex", gap: 8}}>
+                <button type="button" className="btn btn-secondary" style={{minHeight: 36, padding: "0 12px"}}>Adjust quantities</button>
+                <button type="button" className="btn btn-ghost" style={{minHeight: 36, padding: "0 12px"}}>Mark resolved</button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SplitButton() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="split-btn-wrap">
+      <button type="button" className="split-btn-main" onClick={() => setOpen(o => !o)}>
+        <IconExport/>
+        <span>Export to Wave</span>
+        <span className="split-btn-divider"></span>
+        <span className="split-btn-chev"><IconCaret/></span>
+      </button>
+      {open && (
+        <>
+          <div className="split-scrim" onClick={() => setOpen(false)}></div>
+          <div className="split-menu">
+            <button type="button" className="split-item">
+              <div>
+                <div className="split-item-title">Download CSV</div>
+                <div className="split-item-sub">Open in Wave's import flow.</div>
+              </div>
+            </button>
+            <button type="button" className="split-item">
+              <div>
+                <div className="split-item-title">Copy as TSV</div>
+                <div className="split-item-sub">Paste into a spreadsheet directly.</div>
+              </div>
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function IconAlert() { return <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><path d="M10.3 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.7 3.86a2 2 0 0 0-3.4 0z"/><path d="M12 9v4 M12 17h.01"/></svg>; }
+function IconArrow() { return <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14 M13 6l6 6-6 6"/></svg>; }
+function IconCheck() { return <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6 9 17l-5-5"/></svg>; }
+function IconCal()   { return <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 9h18 M8 3v4 M16 3v4"/></svg>; }
+function IconSearch(){ return <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>; }
+function IconExport(){ return <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><path d="M12 3v12 M7 8l5-5 5 5 M5 21h14"/></svg>; }
+function IconCaret() { return <svg viewBox="0 0 24 24" width="10" height="10" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m6 9 6 6 6-6"/></svg>; }
+
+window.OrdersPage = OrdersPage;

--- a/design/admin-preview.jsx
+++ b/design/admin-preview.jsx
@@ -1,0 +1,118 @@
+/* Admin order list surface preview (desktop) */
+
+function AdminPreview() {
+  const orders = [
+    { id: "0421-03", customer: "Lake Road Market",  items: 8, total: 184.50, mode: "Delivery", window: "Wed AM",  status: "new" },
+    { id: "0421-02", customer: "Edwins",            items: 4, total:  68.00, mode: "Delivery", window: "Wed AM",  status: "ready" },
+    { id: "0421-01", customer: "Oxbow Orchard",     items: 12, total: 312.75, mode: "Delivery", window: "Wed PM", status: "ready", recon: true },
+    { id: "0420-04", customer: "purplebrown",       items: 6, total: 142.00, mode: "Pickup",   window: "Thu 2-4", status: "new" },
+    { id: "0420-03", customer: "Spice Kitchen",     items: 5, total:  88.25, mode: "Pickup",   window: "Thu 4-6", status: "delivered" },
+    { id: "0420-02", customer: "Trentina",          items: 3, total:  54.00, mode: "Delivery", window: "Wed PM",  status: "delivered" },
+  ];
+
+  return (
+    <div style={{ background: "var(--cream)", height: "100%", display: "flex", fontFamily: "var(--sans)", fontSize: 13 }}>
+      {/* Sidebar */}
+      <aside style={{ width: 200, background: "var(--paper)", borderRight: "1px solid var(--ink-200)", padding: "18px 14px", flexShrink: 0 }}>
+        <div style={{ fontFamily: "var(--serif)", fontWeight: 600, fontSize: "1.1rem", marginBottom: 2 }}>Bushel</div>
+        <div style={{ fontSize: "0.72rem", color: "var(--ink-500)", marginBottom: 22 }}>Bay Branch Farm</div>
+
+        <NavItem>Inventory</NavItem>
+        <NavItem active>Orders</NavItem>
+        <NavItem>Customers</NavItem>
+        <NavItem>Send update</NavItem>
+        <NavItem>Schedule</NavItem>
+
+        <div style={{ marginTop: 28, padding: "10px 12px", background: "var(--leaf-50)", borderRadius: "var(--r-sm)", border: "1px solid var(--leaf-100)" }}>
+          <div className="eyebrow" style={{ fontSize: "0.62rem", marginBottom: 4 }}>this week</div>
+          <div style={{ fontWeight: 600 }}>Open</div>
+          <div style={{ fontSize: "0.72rem", color: "var(--ink-500)" }}>closes Tue 9:00pm</div>
+        </div>
+      </aside>
+
+      {/* Main */}
+      <main style={{ flex: 1, padding: "20px 28px", overflow: "auto" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-end", marginBottom: 18 }}>
+          <div>
+            <div className="eyebrow" style={{ marginBottom: 4 }}>week of apr 27</div>
+            <h1 style={{ fontFamily: "var(--serif)", fontSize: "1.6rem" }}>Orders</h1>
+          </div>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button className="btn btn-secondary btn-sm">Export Wave CSV</button>
+            <button className="btn btn-primary btn-sm">+ New order</button>
+          </div>
+        </div>
+
+        {/* recon callout */}
+        <div className="callout callout-warn" style={{ marginBottom: 16, fontSize: "0.85rem" }}>
+          <div style={{ width: 6, height: 6, borderRadius: "50%", background: "var(--amber-600)", marginTop: 7, flexShrink: 0 }} />
+          <div>
+            <strong>1 order needs reconciliation.</strong> Oxbow Orchard ordered 14 bunches of dino kale; 12 available. Text Annabel to confirm.
+          </div>
+        </div>
+
+        {/* table */}
+        <div className="card" style={{ overflow: "hidden" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr style={{ background: "var(--leaf-50)" }}>
+                <Th>Order</Th>
+                <Th>Customer</Th>
+                <Th align="right">Items</Th>
+                <Th align="right">Total</Th>
+                <Th>Mode</Th>
+                <Th>Window</Th>
+                <Th>Status</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {orders.map(o => (
+                <tr key={o.id} style={{ borderTop: "1px solid var(--ink-200)", background: o.recon ? "var(--amber-50)" : "transparent" }}>
+                  <Td><span className="mono" style={{ color: "var(--ink-700)" }}>{o.id}</span></Td>
+                  <Td><span style={{ fontWeight: 600 }}>{o.customer}</span></Td>
+                  <Td align="right">{o.items}</Td>
+                  <Td align="right"><span className="mono">${o.total.toFixed(2)}</span></Td>
+                  <Td>{o.mode}</Td>
+                  <Td>{o.window}</Td>
+                  <Td>
+                    {o.recon
+                      ? <span className="badge badge-recon">Needs recon</span>
+                      : o.status === "new"       ? <span className="badge badge-new">New</span>
+                      : o.status === "ready"     ? <span className="badge badge-ready">Ready</span>
+                      : <span className="badge badge-done">Delivered</span>
+                    }
+                  </Td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function NavItem({ children, active }) {
+  return (
+    <div style={{
+      padding: "8px 12px", borderRadius: "var(--r-sm)", marginBottom: 2, cursor: "pointer",
+      fontWeight: active ? 600 : 400,
+      background: active ? "var(--leaf-100)" : "transparent",
+      color: active ? "var(--leaf-700)" : "var(--ink-700)"
+    }}>{children}</div>
+  );
+}
+
+function Th({ children, align }) {
+  return <th style={{
+    textAlign: align || "left", padding: "10px 14px",
+    fontWeight: 600, fontSize: "0.68rem", letterSpacing: "0.06em", textTransform: "uppercase",
+    color: "var(--leaf-700)"
+  }}>{children}</th>;
+}
+
+function Td({ children, align }) {
+  return <td style={{ padding: "11px 14px", textAlign: align || "left", fontSize: "0.86rem", color: "var(--ink-900)" }}>{children}</td>;
+}
+
+window.AdminPreview = AdminPreview;

--- a/design/admin-send.css
+++ b/design/admin-send.css
@@ -1,0 +1,645 @@
+/* Admin · Send Update */
+
+.send-page {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+
+.send-head { margin-bottom: 22px; }
+.send-head .eyebrow { margin-bottom: 6px; }
+.send-title {
+  font-family: var(--serif);
+  font-size: 2rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+}
+.send-subtitle {
+  margin-top: 4px;
+  color: var(--ink-500);
+  font-size: 0.95rem;
+}
+
+/* form column ------------------------------------------------------ */
+.send-form {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.send-card {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  padding: 24px;
+}
+
+.send-field { display: block; }
+.send-field + .send-field { margin-top: 18px; }
+
+.send-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--ink-700);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+.send-label-hint {
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+  font-size: 0.8rem;
+  color: var(--ink-500);
+}
+
+.send-input,
+.send-textarea {
+  width: 100%;
+  font-family: var(--sans);
+  font-size: 0.95rem;
+  color: var(--ink-900);
+  background: var(--cream);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-sm);
+  padding: 12px 14px;
+  transition: border-color 0.12s, box-shadow 0.12s, background 0.12s;
+}
+.send-input:focus,
+.send-textarea:focus {
+  outline: none;
+  background: var(--paper);
+  border-color: var(--leaf-600);
+  box-shadow: 0 0 0 3px rgba(59,109,17,0.12);
+}
+.send-textarea {
+  min-height: 110px;
+  line-height: 1.55;
+  resize: vertical;
+  font-family: var(--serif);
+  font-size: 1.05rem;
+  color: var(--ink-900);
+}
+
+.send-charcount {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 6px;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--ink-500);
+}
+
+/* recipient summary */
+.send-recipients {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  background: var(--leaf-50);
+  border: 1px solid rgba(59,109,17,0.18);
+  border-radius: var(--r-md);
+}
+.send-recipients-icon {
+  width: 40px; height: 40px;
+  border-radius: 50%;
+  background: var(--paper);
+  border: 1px solid rgba(59,109,17,0.25);
+  display: grid; place-items: center;
+  color: var(--leaf-700);
+  flex-shrink: 0;
+}
+.send-recipients-body { flex: 1; }
+.send-recipients-num {
+  font-family: var(--serif);
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: var(--leaf-900);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.send-recipients-label {
+  font-size: 0.85rem;
+  color: var(--ink-700);
+  margin-top: 2px;
+}
+.send-recipients-link {
+  background: none; border: 0; cursor: pointer;
+  font-family: var(--sans);
+  font-size: 0.82rem;
+  color: var(--leaf-700);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  padding: 6px 0;
+}
+.send-recipients-link:hover { color: var(--leaf-900); }
+
+/* big send button */
+.send-action {
+  display: flex; flex-direction: column; gap: 14px;
+}
+.send-button {
+  width: 100%;
+  font-family: var(--sans);
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--paper);
+  background: var(--leaf-700);
+  border: 1px solid var(--leaf-900);
+  border-radius: var(--r-md);
+  padding: 22px 24px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.12) inset,
+    0 -2px 0 rgba(0,0,0,0.18) inset,
+    0 6px 18px -6px rgba(31,58,8,0.55);
+  transition: transform 0.06s, box-shadow 0.12s, background 0.12s;
+}
+.send-button:hover {
+  background: var(--leaf-900);
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.14) inset,
+    0 -2px 0 rgba(0,0,0,0.22) inset,
+    0 10px 22px -6px rgba(31,58,8,0.7);
+}
+.send-button:active {
+  transform: translateY(1px);
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.08) inset,
+    0 -1px 0 rgba(0,0,0,0.18) inset,
+    0 3px 8px -3px rgba(31,58,8,0.6);
+}
+.send-button-main {
+  display: flex; flex-direction: column; align-items: flex-start; gap: 2px;
+}
+.send-button-sub {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  font-weight: 400;
+  letter-spacing: 0;
+  color: rgba(251,250,245,0.7);
+  text-transform: none;
+}
+.send-button-arrow {
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(251,250,245,0.14);
+  display: grid; place-items: center;
+}
+.send-button:hover .send-button-arrow { background: rgba(251,250,245,0.22); }
+
+.send-confirm-note {
+  font-size: 0.82rem;
+  color: var(--ink-500);
+  text-align: center;
+}
+.send-confirm-note strong { color: var(--ink-700); font-weight: 600; }
+
+/* history list */
+.send-history-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  margin-bottom: 12px;
+}
+.send-history-title {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-700);
+}
+.send-history-link {
+  font-size: 0.82rem;
+  color: var(--leaf-700);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.send-history-list {
+  list-style: none;
+  margin: 0; padding: 0;
+  border-top: 1px solid var(--ink-200);
+}
+.send-history-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  gap: 14px;
+  align-items: center;
+  padding: 13px 4px;
+  border-bottom: 1px solid var(--ink-200);
+}
+.send-history-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--leaf-500);
+}
+.send-history-date {
+  font-family: var(--serif);
+  font-size: 0.95rem;
+  color: var(--ink-900);
+  font-weight: 500;
+}
+.send-history-meta {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--ink-500);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.send-history-action {
+  font-family: var(--sans);
+  font-size: 0.8rem;
+  color: var(--leaf-700);
+  background: none; border: 0;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  padding: 0;
+}
+.send-history-action:hover { color: var(--leaf-900); }
+
+/* preview column --------------------------------------------------- */
+.send-preview-col {
+  position: sticky;
+  top: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.send-preview-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+.send-preview-eyebrow {
+  font-family: var(--sans);
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-500);
+}
+.send-preview-live {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  color: var(--leaf-700);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.send-preview-live .pulse {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--leaf-500);
+  box-shadow: 0 0 0 0 rgba(79,138,27,0.6);
+  animation: send-pulse 1.6s ease-out infinite;
+}
+@keyframes send-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(79,138,27,0.55); }
+  70% { box-shadow: 0 0 0 7px rgba(79,138,27,0); }
+  100% { box-shadow: 0 0 0 0 rgba(79,138,27,0); }
+}
+
+/* phone */
+.phone-stage {
+  display: flex; justify-content: center;
+  padding: 18px 0 6px;
+}
+.phone {
+  width: 320px;
+  background: #15140f;
+  border-radius: 44px;
+  padding: 12px;
+  box-shadow:
+    0 0 0 1px rgba(0,0,0,0.25),
+    0 30px 60px -20px rgba(31,58,8,0.35),
+    0 4px 14px rgba(0,0,0,0.18);
+  position: relative;
+}
+.phone-screen {
+  background: #f5f5f5;
+  border-radius: 32px;
+  overflow: hidden;
+  height: 560px;
+  display: flex; flex-direction: column;
+  position: relative;
+}
+.phone-status {
+  height: 38px;
+  padding: 8px 22px 0;
+  display: flex; align-items: center; justify-content: space-between;
+  font-family: var(--sans);
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #111;
+  position: relative;
+}
+.phone-notch {
+  position: absolute; top: 8px; left: 50%; transform: translateX(-50%);
+  width: 95px; height: 26px;
+  background: #15140f;
+  border-radius: 16px;
+}
+.phone-status-icons { display: flex; gap: 5px; align-items: center; color: #111; }
+.phone-status-icons svg { display: block; }
+
+.phone-msg-header {
+  padding: 12px 16px 14px;
+  display: flex; flex-direction: column; align-items: center;
+  gap: 6px;
+  border-bottom: 1px solid rgba(0,0,0,0.06);
+  background: rgba(245,245,245,0.92);
+  backdrop-filter: blur(6px);
+}
+.phone-msg-back {
+  position: absolute; left: 12px; top: 46px;
+  display: flex; align-items: center; gap: 2px;
+  color: #007aff;
+  font-size: 0.92rem;
+}
+.phone-msg-avatar {
+  width: 40px; height: 40px; border-radius: 50%;
+  background: var(--leaf-100);
+  color: var(--leaf-900);
+  display: grid; place-items: center;
+  font-family: var(--serif);
+  font-size: 1rem;
+  font-weight: 600;
+  border: 1px solid rgba(59,109,17,0.2);
+}
+.phone-msg-name {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: #111;
+  display: flex; align-items: center; gap: 4px;
+}
+.phone-msg-handle {
+  font-family: var(--sans);
+  font-size: 0.7rem;
+  color: #888;
+}
+
+.phone-msg-thread {
+  flex: 1;
+  padding: 14px 14px 14px;
+  display: flex; flex-direction: column;
+  gap: 6px;
+  overflow: hidden;
+}
+.phone-msg-time {
+  text-align: center;
+  font-family: var(--sans);
+  font-size: 0.68rem;
+  color: #8a8a8a;
+  margin: 4px 0 8px;
+}
+.phone-msg-time strong { color: #555; font-weight: 600; }
+
+.phone-msg-bubble {
+  align-self: flex-start;
+  max-width: 86%;
+  background: #e9e9eb;
+  color: #111;
+  border-radius: 18px;
+  padding: 9px 13px;
+  font-family: var(--sans);
+  font-size: 0.86rem;
+  line-height: 1.4;
+  position: relative;
+  white-space: pre-wrap;
+}
+.phone-msg-bubble + .phone-msg-bubble { margin-top: 2px; }
+.phone-msg-bubble.has-tail::before {
+  content: "";
+  position: absolute;
+  left: -5px; bottom: 0;
+  width: 14px; height: 17px;
+  background: #e9e9eb;
+  border-bottom-right-radius: 14px;
+  z-index: -1;
+}
+
+.phone-msg-link {
+  color: #007aff;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.phone-msg-preview {
+  margin-top: 8px;
+  background: #fff;
+  border: 1px solid rgba(0,0,0,0.06);
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.phone-msg-preview-img {
+  height: 80px;
+  background:
+    linear-gradient(135deg, var(--leaf-700), var(--leaf-500) 60%, #b8c97a);
+  position: relative;
+  display: grid; place-items: center;
+}
+.phone-msg-preview-img svg { color: rgba(255,255,255,0.85); }
+.phone-msg-preview-meta {
+  padding: 8px 12px 10px;
+  display: flex; flex-direction: column; gap: 2px;
+}
+.phone-msg-preview-domain {
+  font-family: var(--sans);
+  font-size: 0.66rem;
+  color: #777;
+  text-transform: lowercase;
+}
+.phone-msg-preview-title {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #111;
+  line-height: 1.3;
+}
+
+.phone-bottom {
+  padding: 8px 14px 14px;
+  background: #f5f5f5;
+}
+.phone-input {
+  display: flex; align-items: center; gap: 8px;
+  background: #fff;
+  border: 1px solid rgba(0,0,0,0.1);
+  border-radius: 999px;
+  padding: 7px 10px 7px 14px;
+  font-size: 0.82rem;
+  color: #999;
+}
+.phone-input-send {
+  width: 26px; height: 26px; border-radius: 50%;
+  background: #c7c7c9;
+  display: grid; place-items: center;
+  color: #fff;
+}
+.phone-home-bar {
+  width: 110px; height: 4px;
+  border-radius: 2px;
+  background: #111;
+  margin: 6px auto 0;
+  opacity: 0.85;
+}
+
+/* SMS character indicator */
+.sms-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  background: var(--cream);
+  border: 1px solid var(--ink-200);
+  border-top: 0;
+  border-radius: 0 0 var(--r-md) var(--r-md);
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--ink-500);
+}
+.sms-meta strong { color: var(--ink-900); font-weight: 600; }
+.sms-meta-bar {
+  display: inline-block;
+  width: 100px; height: 4px;
+  background: var(--ink-200);
+  border-radius: 2px;
+  position: relative;
+  margin: 0 8px;
+  vertical-align: middle;
+}
+.sms-meta-bar i {
+  display: block; height: 100%;
+  background: var(--leaf-500);
+  border-radius: 2px;
+  transition: width 0.18s;
+}
+
+/* window controls under phone */
+.send-window {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  padding: 18px 20px;
+}
+.send-window-row {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px;
+}
+.send-window-row + .send-window-row {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--ink-200);
+}
+.send-window-label {
+  font-family: var(--sans);
+  font-size: 0.92rem;
+  font-weight: 500;
+  color: var(--ink-900);
+  display: flex; flex-direction: column; gap: 2px;
+}
+.send-window-sub {
+  font-size: 0.78rem;
+  color: var(--ink-500);
+  font-weight: 400;
+}
+
+/* iOS-style toggle */
+.toggle {
+  width: 44px; height: 26px;
+  border-radius: 999px;
+  background: var(--ink-200);
+  position: relative;
+  cursor: pointer;
+  border: 0;
+  padding: 0;
+  flex-shrink: 0;
+  transition: background 0.18s;
+}
+.toggle::after {
+  content: "";
+  position: absolute;
+  top: 2px; left: 2px;
+  width: 22px; height: 22px;
+  background: var(--paper);
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  transition: transform 0.18s;
+}
+.toggle.is-on { background: var(--leaf-600); }
+.toggle.is-on::after { transform: translateX(18px); }
+
+/* hour stepper */
+.hour-stepper {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-sm);
+  background: var(--paper);
+  overflow: hidden;
+}
+.hour-stepper button {
+  width: 32px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: var(--ink-700);
+  font-size: 1rem;
+  font-weight: 500;
+  display: grid; place-items: center;
+}
+.hour-stepper button:hover { background: var(--cream); color: var(--leaf-700); }
+.hour-stepper button:disabled { color: var(--ink-300); cursor: not-allowed; }
+.hour-stepper button:disabled:hover { background: transparent; }
+.hour-stepper-val {
+  min-width: 60px;
+  display: flex; align-items: center; justify-content: center;
+  gap: 4px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 1rem;
+  font-weight: 600;
+  border-left: 1px solid var(--ink-200);
+  border-right: 1px solid var(--ink-200);
+  font-variant-numeric: tabular-nums;
+}
+.hour-stepper-val small {
+  font-family: var(--sans);
+  font-size: 0.72rem;
+  font-weight: 400;
+  color: var(--ink-500);
+}
+
+.send-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--leaf-700);
+  background: var(--leaf-50);
+  border: 1px solid rgba(59,109,17,0.2);
+  border-radius: 999px;
+  padding: 4px 10px;
+}
+.send-status-pill .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--leaf-500);
+}
+.send-status-pill.is-closed { color: var(--ink-700); background: var(--ink-100, var(--cream)); }
+.send-status-pill.is-closed .dot { background: var(--ink-300); }

--- a/design/admin-send.jsx
+++ b/design/admin-send.jsx
@@ -1,0 +1,284 @@
+// Admin · Send Update — split view (form / phone preview)
+
+function SendPage() {
+  const { useState, useMemo } = React;
+
+  const defaultIntro =
+    "Heirloom tomatoes are exceptional this week — sungolds, brandywines, and a small batch of green zebras. Pickup Saturday at the farm or Wednesday in Tremont.";
+
+  const [weekLabel, setWeekLabel] = useState("Week of May 3");
+  const [intro, setIntro] = useState(defaultIntro);
+  const [windowOpen, setWindowOpen] = useState(true);
+  const [hours, setHours] = useState(4);
+
+  const subscribers = 7;
+
+  // sms teaser is what shows at the top of the message — short.
+  const teaser =
+    "Bay Branch Farm — this week: tomatoes, zinnias, basil + more. Order before Friday 6pm.";
+  const linkLine = "bushel.farm/c/d4f2";
+
+  const introForSms = intro.trim();
+
+  const smsBody = introForSms
+    ? `${teaser}\n\n${introForSms}\n\n${linkLine}`
+    : `${teaser}\n\n${linkLine}`;
+
+  const charCount = smsBody.length;
+  const segments = Math.max(1, Math.ceil(charCount / 160));
+  const segPct = Math.min(100, (charCount / (segments * 160)) * 100);
+
+  const history = [
+    { date: "Apr 26", weekLabel: "Week of Apr 26", count: 7, opens: 6, orders: 5 },
+    { date: "Apr 19", weekLabel: "Week of Apr 19", count: 6, opens: 5, orders: 4 },
+    { date: "Apr 12", weekLabel: "Week of Apr 12", count: 6, opens: 6, orders: 5 },
+    { date: "Apr 5",  weekLabel: "Week of Apr 5",  count: 5, opens: 4, orders: 3 },
+  ];
+
+  return (
+    <div>
+      <div className="send-head">
+        <div className="eyebrow">Weekly broadcast</div>
+        <div className="send-title">Send the inventory update</div>
+        <div className="send-subtitle">
+          One message goes to every subscribed customer — Saturday morning is the usual cadence.
+        </div>
+      </div>
+
+      <div className="send-page">
+        {/* ---------------- LEFT: form ---------------- */}
+        <div className="send-form">
+          <div className="send-card">
+            <div className="send-field">
+              <label className="send-label">
+                Week label
+                <span className="send-label-hint">auto-filled — edit if you want</span>
+              </label>
+              <input
+                className="send-input"
+                value={weekLabel}
+                onChange={(e) => setWeekLabel(e.target.value)}
+              />
+            </div>
+
+            <div className="send-field">
+              <label className="send-label">
+                Intro note
+                <span className="send-label-hint">optional · plain text</span>
+              </label>
+              <textarea
+                className="send-textarea"
+                value={intro}
+                onChange={(e) => setIntro(e.target.value)}
+                placeholder="A line or two from you. What's good this week, what to ask about."
+              />
+              <div className="send-charcount">
+                <span>{intro.length} characters in note</span>
+                <span>Renders as the second paragraph in the SMS</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="send-recipients">
+            <div className="send-recipients-icon">
+              <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+              </svg>
+            </div>
+            <div className="send-recipients-body">
+              <div className="send-recipients-num">{subscribers}</div>
+              <div className="send-recipients-label">subscribers will receive this message</div>
+            </div>
+            <button type="button" className="send-recipients-link">Manage list</button>
+          </div>
+
+          <div className="send-action">
+            <button type="button" className="send-button">
+              <span className="send-button-main">
+                <span>Send to all subscribers</span>
+                <span className="send-button-sub">{subscribers} recipients · est. delivery in under a minute</span>
+              </span>
+              <span className="send-button-arrow">
+                <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M5 12h14"/>
+                  <path d="m13 5 7 7-7 7"/>
+                </svg>
+              </span>
+            </button>
+            <div className="send-confirm-note">
+              You'll get a <strong>final confirmation</strong> before anything is sent.
+            </div>
+          </div>
+
+          <div>
+            <div className="send-history-head">
+              <span className="send-history-title">Past sends</span>
+              <a href="#" className="send-history-link">View all</a>
+            </div>
+            <ul className="send-history-list">
+              {history.map((h) => (
+                <li key={h.date} className="send-history-row">
+                  <span className="send-history-dot" />
+                  <span>
+                    <div className="send-history-date">{h.weekLabel}</div>
+                    <div className="send-history-meta" style={{ fontFamily: "var(--sans)", color: "var(--ink-500)" }}>
+                      Sent {h.date} · {h.opens}/{h.count} opened · {h.orders} orders
+                    </div>
+                  </span>
+                  <span className="send-history-meta">{h.count} sent</span>
+                  <button type="button" className="send-history-action">Duplicate</button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        {/* ---------------- RIGHT: preview ---------------- */}
+        <div className="send-preview-col">
+          <div className="send-preview-head">
+            <span className="send-preview-eyebrow">Live preview · what customers will see</span>
+            <span className="send-preview-live">
+              <span className="pulse" />
+              live
+            </span>
+          </div>
+
+          <div>
+            <div className="phone-stage">
+              <Phone smsBody={smsBody} weekLabel={weekLabel} />
+            </div>
+
+            <div className="sms-meta">
+              <span><strong>{charCount}</strong> chars</span>
+              <span>
+                <span className="sms-meta-bar"><i style={{ width: segPct + "%" }} /></span>
+                {segments} {segments === 1 ? "segment" : "segments"} ({segments * 160} char limit)
+              </span>
+              <span>~ <strong>${(segments * subscribers * 0.0079).toFixed(2)}</strong> est.</span>
+            </div>
+          </div>
+
+          <div className="send-window">
+            <div className="send-window-row">
+              <div className="send-window-label">
+                Open ordering for the week
+                <span className="send-window-sub">
+                  Customers can submit orders only while this is on.
+                </span>
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                <span className={"send-status-pill " + (windowOpen ? "" : "is-closed")}>
+                  <span className="dot" />
+                  {windowOpen ? "Open" : "Closed"}
+                </span>
+                <button
+                  type="button"
+                  className={"toggle" + (windowOpen ? " is-on" : "")}
+                  aria-pressed={windowOpen}
+                  onClick={() => setWindowOpen(v => !v)}
+                />
+              </div>
+            </div>
+
+            <div className="send-window-row">
+              <div className="send-window-label">
+                Open for
+                <span className="send-window-sub">
+                  Quick close — auto-locks the order form after this many hours.
+                </span>
+              </div>
+              <div className="hour-stepper" aria-label="Hours open">
+                <button type="button" disabled={hours <= 1} onClick={() => setHours(h => Math.max(1, h - 1))}>−</button>
+                <div className="hour-stepper-val">
+                  {hours}<small>hr</small>
+                </div>
+                <button type="button" disabled={hours >= 72} onClick={() => setHours(h => Math.min(72, h + 1))}>+</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Phone({ smsBody, weekLabel }) {
+  return (
+    <div className="phone">
+      <div className="phone-screen">
+        <div className="phone-notch" />
+        <div className="phone-status">
+          <span>9:41</span>
+          <span className="phone-status-icons">
+            <svg viewBox="0 0 18 12" width="18" height="12" fill="currentColor"><rect x="0" y="6" width="3" height="6" rx="0.5"/><rect x="5" y="3" width="3" height="9" rx="0.5"/><rect x="10" y="0" width="3" height="12" rx="0.5"/></svg>
+            <svg viewBox="0 0 16 12" width="16" height="12" fill="none" stroke="currentColor" strokeWidth="1.2"><path d="M1 5a10 10 0 0 1 14 0"/><path d="M3 7.5a7 7 0 0 1 10 0"/><path d="M5 10a4 4 0 0 1 6 0"/></svg>
+            <svg viewBox="0 0 24 12" width="24" height="12" fill="none" stroke="currentColor" strokeWidth="1"><rect x="0.5" y="1.5" width="20" height="9" rx="2"/><rect x="2" y="3" width="16" height="6" rx="1" fill="currentColor"/><rect x="21" y="4" width="2" height="4" rx="0.5" fill="currentColor"/></svg>
+          </span>
+        </div>
+
+        <div className="phone-msg-header">
+          <div style={{ height: 4 }} />
+          <div className="phone-msg-avatar">B</div>
+          <div className="phone-msg-name">
+            Bay Branch Farm
+            <svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ color: "#999" }}>
+              <path d="m9 18 6-6-6-6"/>
+            </svg>
+          </div>
+          <div className="phone-msg-handle">+1 (216) 555-0148</div>
+        </div>
+
+        <div className="phone-msg-thread">
+          <div className="phone-msg-time">
+            <strong>Saturday</strong> · 8:00 AM
+          </div>
+
+          <div className="phone-msg-bubble has-tail">
+            {smsBody.split("\n").map((line, i) => {
+              const isLink = /bushel\.farm\/c\//.test(line);
+              if (isLink) {
+                return (
+                  <React.Fragment key={i}>
+                    {i > 0 && <br />}
+                    <span className="phone-msg-link">{line}</span>
+                  </React.Fragment>
+                );
+              }
+              return (
+                <React.Fragment key={i}>
+                  {i > 0 && <br />}
+                  {line || "\u00A0"}
+                </React.Fragment>
+              );
+            })}
+
+            <div className="phone-msg-preview">
+              <div className="phone-msg-preview-img">
+                <svg viewBox="0 0 24 24" width="34" height="34" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M21.5 2.5c0 8-4.5 14.5-12 14.5-1.4 0-2.8-.2-4-.7"/>
+                  <path d="M3 21c0-6 4-12 14-15"/>
+                </svg>
+              </div>
+              <div className="phone-msg-preview-meta">
+                <span className="phone-msg-preview-domain">bushel.farm</span>
+                <span className="phone-msg-preview-title">{weekLabel} · Bay Branch Farm</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="phone-bottom">
+          <div className="phone-input">
+            <span style={{ flex: 1 }}>iMessage</span>
+            <span className="phone-input-send">
+              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+                <path d="m18 15-6-6-6 6"/>
+              </svg>
+            </span>
+          </div>
+          <div className="phone-home-bar" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/design/admin-settings.css
+++ b/design/admin-settings.css
@@ -1,0 +1,424 @@
+/* Admin · Settings */
+
+.set-head { margin-bottom: 26px; }
+.set-head .eyebrow { margin-bottom: 6px; }
+.set-title {
+  font-family: var(--serif);
+  font-size: 2rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+}
+.set-subtitle {
+  margin-top: 4px;
+  color: var(--ink-500);
+  font-size: 0.95rem;
+}
+
+.set-cards { display: flex; flex-direction: column; gap: 22px; padding-bottom: 110px; }
+
+.set-card {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+.set-card-head {
+  padding: 22px 28px 18px;
+  border-bottom: 1px solid var(--ink-200);
+  display: flex; align-items: flex-start; justify-content: space-between;
+  gap: 24px;
+}
+.set-card-head-l { flex: 1; }
+.set-card-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--leaf-700);
+  margin-bottom: 4px;
+}
+.set-card-title {
+  font-family: var(--serif);
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--ink-900);
+  letter-spacing: -0.005em;
+}
+.set-card-desc {
+  margin-top: 4px;
+  font-size: 0.88rem;
+  color: var(--ink-500);
+  max-width: 56ch;
+}
+.set-card-body { padding: 22px 28px 26px; }
+
+/* form rows */
+.set-row {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 24px;
+  align-items: start;
+  padding: 16px 0;
+  border-bottom: 1px dashed var(--ink-200);
+}
+.set-row:last-child { border-bottom: 0; padding-bottom: 4px; }
+.set-row:first-child { padding-top: 4px; }
+.set-row-key {
+  font-family: var(--sans);
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--ink-900);
+  padding-top: 9px;
+}
+.set-row-key small {
+  display: block;
+  font-weight: 400;
+  font-size: 0.8rem;
+  color: var(--ink-500);
+  margin-top: 2px;
+  line-height: 1.45;
+}
+.set-row-val { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+
+/* day/time controls */
+.set-control {
+  font-family: var(--sans);
+  font-size: 0.92rem;
+  color: var(--ink-900);
+  background: var(--paper);
+  border: 1px solid var(--ink-300);
+  border-radius: var(--r-sm);
+  padding: 9px 12px;
+  min-height: 40px;
+  transition: border-color 0.12s, box-shadow 0.12s;
+}
+.set-control:focus {
+  outline: none;
+  border-color: var(--leaf-600);
+  box-shadow: 0 0 0 3px rgba(59,109,17,0.12);
+}
+.set-control.is-day { min-width: 140px; }
+.set-control.is-time { min-width: 110px; font-variant-numeric: tabular-nums; }
+.set-control.is-label { flex: 1; min-width: 180px; }
+.set-conjunction {
+  font-family: var(--serif);
+  font-size: 0.95rem;
+  color: var(--ink-500);
+  font-style: italic;
+  padding: 0 2px;
+}
+
+/* schedule state pill */
+.set-state-block {
+  margin-top: 6px;
+  padding: 18px 22px;
+  background: var(--leaf-50);
+  border: 1px solid rgba(59,109,17,0.18);
+  border-radius: var(--r-md);
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.set-state-block.is-closed {
+  background: var(--cream);
+  border-color: var(--ink-200);
+}
+.set-state-block.is-paused {
+  background: rgba(230,168,23,0.08);
+  border-color: rgba(230,168,23,0.35);
+}
+.set-state-l { display: flex; align-items: center; gap: 14px; }
+.set-state-pulse {
+  width: 10px; height: 10px; border-radius: 50%;
+  background: var(--leaf-500);
+  box-shadow: 0 0 0 0 rgba(79,138,27,0.55);
+  animation: set-pulse 1.8s ease-out infinite;
+  flex-shrink: 0;
+}
+.set-state-block.is-closed .set-state-pulse {
+  background: var(--ink-300); animation: none;
+}
+.set-state-block.is-paused .set-state-pulse {
+  background: var(--amber-600); animation: none;
+}
+@keyframes set-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(79,138,27,0.55); }
+  70% { box-shadow: 0 0 0 8px rgba(79,138,27,0); }
+  100% { box-shadow: 0 0 0 0 rgba(79,138,27,0); }
+}
+.set-state-text {
+  font-family: var(--sans);
+  font-size: 0.95rem;
+  color: var(--ink-900);
+  font-weight: 500;
+}
+.set-state-text strong {
+  font-family: var(--serif);
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+.set-state-sub {
+  display: block;
+  font-weight: 400;
+  font-size: 0.82rem;
+  color: var(--ink-500);
+  margin-top: 2px;
+}
+.set-state-actions { display: flex; gap: 8px; }
+.set-override-btn {
+  font-family: var(--sans);
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 8px 14px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--ink-300);
+  background: var(--paper);
+  color: var(--ink-900);
+  cursor: pointer;
+  transition: border-color 0.1s, color 0.1s, background 0.1s;
+}
+.set-override-btn:hover { border-color: var(--ink-500); }
+.set-override-btn.is-primary {
+  background: var(--ink-900);
+  color: var(--paper);
+  border-color: var(--ink-900);
+}
+.set-override-btn.is-primary:hover { background: #000; }
+.set-override-btn.is-warn {
+  color: var(--rose-600);
+  border-color: rgba(178,59,46,0.35);
+}
+.set-override-btn.is-warn:hover {
+  border-color: var(--rose-600);
+  background: rgba(178,59,46,0.04);
+}
+
+/* iOS toggle (shared shape) */
+.toggle {
+  width: 44px; height: 26px;
+  border-radius: 999px;
+  background: var(--ink-200);
+  position: relative;
+  cursor: pointer;
+  border: 0; padding: 0;
+  flex-shrink: 0;
+  transition: background 0.18s;
+}
+.toggle::after {
+  content: "";
+  position: absolute; top: 2px; left: 2px;
+  width: 22px; height: 22px;
+  background: var(--paper);
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  transition: transform 0.18s;
+}
+.toggle.is-on { background: var(--leaf-600); }
+.toggle.is-on::after { transform: translateX(18px); }
+.toggle.is-sm { width: 36px; height: 22px; }
+.toggle.is-sm::after { width: 18px; height: 18px; top: 2px; }
+.toggle.is-sm.is-on::after { transform: translateX(14px); }
+
+/* pickup windows table */
+.pw-list {
+  display: flex; flex-direction: column;
+}
+.pw-row {
+  display: grid;
+  grid-template-columns: 28px 1fr 160px 220px 60px 36px;
+  gap: 14px;
+  align-items: center;
+  padding: 14px 12px;
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-sm);
+  transition: border-color 0.12s, box-shadow 0.12s, background 0.12s;
+}
+.pw-row + .pw-row { margin-top: 8px; }
+.pw-row.is-dragging {
+  border-color: var(--leaf-600);
+  box-shadow: 0 8px 20px -8px rgba(31,58,8,0.3);
+  background: var(--cream);
+}
+.pw-row.is-inactive {
+  background: repeating-linear-gradient(
+    -45deg,
+    var(--cream) 0 8px,
+    var(--paper) 8px 16px
+  );
+  border-style: dashed;
+}
+.pw-row.is-inactive .pw-row-label,
+.pw-row.is-inactive .set-control { opacity: 0.55; }
+
+.pw-handle {
+  display: grid; place-items: center;
+  width: 28px; height: 28px;
+  cursor: grab;
+  color: var(--ink-300);
+  transition: color 0.1s, background 0.1s;
+  border-radius: 4px;
+}
+.pw-handle:hover { color: var(--ink-700); background: var(--cream); }
+.pw-handle:active { cursor: grabbing; }
+
+.pw-row-label {
+  display: flex; align-items: center; gap: 10px;
+}
+.pw-row-num {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--ink-500);
+  background: var(--cream);
+  border: 1px solid var(--ink-200);
+  border-radius: 4px;
+  padding: 2px 7px;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.pw-time-pair {
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.pw-time-pair .set-control { min-width: 92px; }
+
+.pw-active-cell {
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+}
+.pw-active-cell-label {
+  font-family: var(--mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-500);
+}
+
+.pw-row-remove {
+  display: grid; place-items: center;
+  width: 32px; height: 32px;
+  border-radius: 50%;
+  background: transparent;
+  border: 0;
+  color: var(--ink-500);
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+.pw-row-remove:hover { background: rgba(178,59,46,0.08); color: var(--rose-600); }
+
+.pw-row-headers {
+  display: grid;
+  grid-template-columns: 28px 1fr 160px 220px 60px 36px;
+  gap: 14px;
+  padding: 0 12px 8px;
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-500);
+}
+.pw-row-headers > span:nth-child(1) { text-align: center; }
+.pw-row-headers .pw-h-active { text-align: center; }
+
+.pw-add {
+  margin-top: 12px;
+  display: flex; align-items: center; gap: 10px;
+  width: 100%;
+  background: transparent;
+  border: 1px dashed var(--ink-300);
+  border-radius: var(--r-sm);
+  padding: 14px;
+  font-family: var(--sans);
+  font-size: 0.92rem;
+  color: var(--leaf-700);
+  cursor: pointer;
+  justify-content: center;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
+}
+.pw-add:hover {
+  border-color: var(--leaf-600);
+  color: var(--leaf-900);
+  background: var(--leaf-50);
+}
+.pw-add svg { stroke-width: 1.8; }
+
+.pw-summary {
+  margin-top: 18px;
+  font-size: 0.82rem;
+  color: var(--ink-500);
+  font-style: italic;
+  padding: 10px 14px;
+  background: var(--cream);
+  border-radius: var(--r-sm);
+  border-left: 2px solid var(--leaf-600);
+}
+.pw-summary strong {
+  font-style: normal;
+  color: var(--ink-900);
+  font-weight: 600;
+}
+
+/* sticky save bar */
+.set-savebar {
+  position: sticky;
+  bottom: 0;
+  margin: 0 -32px -32px;
+  padding: 18px 32px;
+  background: rgba(251,250,245,0.92);
+  backdrop-filter: blur(8px);
+  border-top: 1px solid var(--ink-200);
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 18px;
+  z-index: 10;
+}
+.set-savebar-l {
+  display: flex; align-items: center; gap: 12px;
+  font-size: 0.88rem;
+  color: var(--ink-500);
+}
+.set-savebar.has-changes .set-savebar-l { color: var(--ink-900); }
+.set-savebar-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--ink-300);
+}
+.set-savebar.has-changes .set-savebar-dot {
+  background: var(--amber-600);
+  box-shadow: 0 0 0 4px rgba(230,168,23,0.18);
+}
+.set-savebar-r { display: flex; gap: 10px; }
+
+.set-savebar-btn {
+  font-family: var(--sans);
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 12px 22px;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.12s, border-color 0.12s;
+  min-height: 44px;
+}
+.set-savebar-btn.is-cancel {
+  background: var(--paper);
+  color: var(--ink-700);
+  border-color: var(--ink-300);
+}
+.set-savebar-btn.is-cancel:hover { border-color: var(--ink-500); color: var(--ink-900); }
+.set-savebar-btn.is-cancel:disabled { opacity: 0.5; cursor: not-allowed; }
+.set-savebar-btn.is-save {
+  background: var(--leaf-700);
+  color: var(--paper);
+  border-color: var(--leaf-900);
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.1) inset,
+    0 -2px 0 rgba(0,0,0,0.15) inset;
+}
+.set-savebar-btn.is-save:hover { background: var(--leaf-900); }
+.set-savebar-btn.is-save:disabled {
+  background: var(--ink-200);
+  color: var(--ink-500);
+  border-color: var(--ink-200);
+  cursor: not-allowed;
+  box-shadow: none;
+}

--- a/design/admin-settings.jsx
+++ b/design/admin-settings.jsx
@@ -1,0 +1,331 @@
+// Admin · Settings — schedule + pickup windows + sticky save
+
+function SettingsPage() {
+  const { useState, useMemo } = React;
+
+  // ordering schedule
+  const [openDay,  setOpenDay]  = useState("Saturday");
+  const [openTime, setOpenTime] = useState("08:00");
+  const [closeDay, setCloseDay] = useState("Tuesday");
+  const [closeTime, setCloseTime] = useState("21:00");
+  const [useSchedule, setUseSchedule] = useState(true);
+  const [manualState, setManualState] = useState("auto"); // auto | open | closed
+
+  // pickup windows
+  const [windows, setWindows] = useState([
+    { id: 1, label: "Saturday at the farm", day: "Saturday", start: "09:00", end: "12:00", active: true  },
+    { id: 2, label: "Wednesday Tremont drop-off", day: "Wednesday", start: "16:00", end: "18:30", active: true  },
+    { id: 3, label: "Lakewood Farmer's Market", day: "Saturday",  start: "10:00", end: "14:00", active: true  },
+    { id: 4, label: "Friday onsite (special)",   day: "Friday",   start: "14:00", end: "17:00", active: false },
+  ]);
+  const [draggingId, setDraggingId] = useState(null);
+
+  const [hasChanges, setHasChanges] = useState(true);
+
+  const days = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"];
+
+  const stateInfo = useMemo(() => {
+    if (!useSchedule || manualState === "closed") {
+      return {
+        kind: "closed",
+        title: "Ordering is closed",
+        sub: useSchedule ? "Manual override is active." : "Weekly schedule is off — toggle ordering by hand."
+      };
+    }
+    if (manualState === "open") {
+      return {
+        kind: "paused",
+        title: "Ordering is open (manual)",
+        sub: "Manual override active — schedule will resume next cycle."
+      };
+    }
+    return {
+      kind: "open",
+      title: `Ordering is OPEN until ${closeDay} ${formatTime(closeTime)}`,
+      sub: `Auto-opens ${openDay} ${formatTime(openTime)} every week.`
+    };
+  }, [useSchedule, manualState, openDay, openTime, closeDay, closeTime]);
+
+  function formatTime(t) {
+    const [h, m] = t.split(":").map(Number);
+    const ampm = h >= 12 ? "pm" : "am";
+    const h12 = h % 12 || 12;
+    return m === 0 ? `${h12}${ampm}` : `${h12}:${String(m).padStart(2,"0")}${ampm}`;
+  }
+
+  function updateWindow(id, patch) {
+    setWindows(ws => ws.map(w => w.id === id ? { ...w, ...patch } : w));
+    setHasChanges(true);
+  }
+  function removeWindow(id) {
+    setWindows(ws => ws.filter(w => w.id !== id));
+    setHasChanges(true);
+  }
+  function addWindow() {
+    const newId = Math.max(0, ...windows.map(w => w.id)) + 1;
+    setWindows(ws => [...ws, { id: newId, label: "New window", day: "Saturday", start: "09:00", end: "12:00", active: true }]);
+    setHasChanges(true);
+  }
+
+  // drag reorder
+  function onDragStart(id) { setDraggingId(id); }
+  function onDragOver(e, overId) {
+    e.preventDefault();
+    if (draggingId == null || draggingId === overId) return;
+    setWindows(ws => {
+      const from = ws.findIndex(w => w.id === draggingId);
+      const to = ws.findIndex(w => w.id === overId);
+      if (from < 0 || to < 0) return ws;
+      const next = ws.slice();
+      const [m] = next.splice(from, 1);
+      next.splice(to, 0, m);
+      return next;
+    });
+  }
+  function onDragEnd() { setDraggingId(null); setHasChanges(true); }
+
+  return (
+    <div>
+      <div className="set-head">
+        <div className="eyebrow">Configuration</div>
+        <div className="set-title">Settings</div>
+        <div className="set-subtitle">
+          The rhythm of the week — when ordering opens, when it closes, where customers pick up.
+        </div>
+      </div>
+
+      <div className="set-cards">
+        {/* CARD 1 — Ordering schedule */}
+        <section className="set-card">
+          <header className="set-card-head">
+            <div className="set-card-head-l">
+              <div className="set-card-eyebrow">01 · Cadence</div>
+              <div className="set-card-title">Ordering schedule</div>
+              <div className="set-card-desc">
+                The order form auto-opens and closes on this weekly schedule. Override below if you need to break the rhythm — for a holiday week, say.
+              </div>
+            </div>
+          </header>
+
+          <div className="set-card-body">
+            <div className="set-row">
+              <div className="set-row-key">
+                Default open
+                <small>When the order form goes live each week.</small>
+              </div>
+              <div className="set-row-val">
+                <select className="set-control is-day" value={openDay} onChange={e => { setOpenDay(e.target.value); setHasChanges(true); }} disabled={!useSchedule}>
+                  {days.map(d => <option key={d}>{d}</option>)}
+                </select>
+                <span className="set-conjunction">at</span>
+                <input type="time" className="set-control is-time" value={openTime} onChange={e => { setOpenTime(e.target.value); setHasChanges(true); }} disabled={!useSchedule} />
+              </div>
+            </div>
+
+            <div className="set-row">
+              <div className="set-row-key">
+                Default close
+                <small>When the order form locks. Customers see a "closed" state after this.</small>
+              </div>
+              <div className="set-row-val">
+                <select className="set-control is-day" value={closeDay} onChange={e => { setCloseDay(e.target.value); setHasChanges(true); }} disabled={!useSchedule}>
+                  {days.map(d => <option key={d}>{d}</option>)}
+                </select>
+                <span className="set-conjunction">at</span>
+                <input type="time" className="set-control is-time" value={closeTime} onChange={e => { setCloseTime(e.target.value); setHasChanges(true); }} disabled={!useSchedule} />
+              </div>
+            </div>
+
+            <div className="set-row">
+              <div className="set-row-key">
+                Use weekly schedule
+                <small>Off means ordering is purely manual — open and close it yourself.</small>
+              </div>
+              <div className="set-row-val">
+                <button
+                  type="button"
+                  className={"toggle" + (useSchedule ? " is-on" : "")}
+                  aria-pressed={useSchedule}
+                  onClick={() => { setUseSchedule(v => !v); setHasChanges(true); }}
+                />
+                <span style={{ fontSize: "0.88rem", color: "var(--ink-500)" }}>
+                  {useSchedule ? "Schedule is on" : "Manual mode"}
+                </span>
+              </div>
+            </div>
+
+            <div className={"set-state-block " + (stateInfo.kind === "closed" ? "is-closed" : stateInfo.kind === "paused" ? "is-paused" : "")}>
+              <div className="set-state-l">
+                <span className="set-state-pulse" />
+                <div>
+                  <div className="set-state-text">
+                    <strong>{stateInfo.title}</strong>
+                  </div>
+                  <span className="set-state-sub">{stateInfo.sub}</span>
+                </div>
+              </div>
+              <div className="set-state-actions">
+                {manualState !== "open" && stateInfo.kind !== "open" && (
+                  <button type="button" className="set-override-btn is-primary" onClick={() => { setManualState("open"); setHasChanges(true); }}>
+                    Open now
+                  </button>
+                )}
+                {stateInfo.kind === "open" && (
+                  <button type="button" className="set-override-btn is-warn" onClick={() => { setManualState("closed"); setHasChanges(true); }}>
+                    Close now
+                  </button>
+                )}
+                {manualState !== "auto" && (
+                  <button type="button" className="set-override-btn" onClick={() => { setManualState("auto"); setHasChanges(true); }}>
+                    Resume schedule
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* CARD 2 — Pickup windows */}
+        <section className="set-card">
+          <header className="set-card-head">
+            <div className="set-card-head-l">
+              <div className="set-card-eyebrow">02 · Where & when</div>
+              <div className="set-card-title">Pickup windows</div>
+              <div className="set-card-desc">
+                The fulfillment options customers see at checkout. Drag to reorder — the top of the list is the default. Inactive windows stay configured but are hidden from the form.
+              </div>
+            </div>
+          </header>
+
+          <div className="set-card-body">
+            <div className="pw-row-headers">
+              <span></span>
+              <span>Label</span>
+              <span>Day</span>
+              <span>Time window</span>
+              <span className="pw-h-active">Active</span>
+              <span></span>
+            </div>
+
+            <div className="pw-list">
+              {windows.map((w, i) => (
+                <div
+                  key={w.id}
+                  className={
+                    "pw-row" +
+                    (draggingId === w.id ? " is-dragging" : "") +
+                    (w.active ? "" : " is-inactive")
+                  }
+                  draggable
+                  onDragStart={() => onDragStart(w.id)}
+                  onDragOver={(e) => onDragOver(e, w.id)}
+                  onDragEnd={onDragEnd}
+                >
+                  <span className="pw-handle" title="Drag to reorder">
+                    <svg viewBox="0 0 24 24" width="14" height="20" fill="currentColor">
+                      <circle cx="9" cy="6" r="1.4"/><circle cx="15" cy="6" r="1.4"/>
+                      <circle cx="9" cy="12" r="1.4"/><circle cx="15" cy="12" r="1.4"/>
+                      <circle cx="9" cy="18" r="1.4"/><circle cx="15" cy="18" r="1.4"/>
+                    </svg>
+                  </span>
+
+                  <div className="pw-row-label">
+                    <span className="pw-row-num">{String(i + 1).padStart(2, "0")}</span>
+                    <input
+                      className="set-control is-label"
+                      value={w.label}
+                      onChange={(e) => updateWindow(w.id, { label: e.target.value })}
+                    />
+                  </div>
+
+                  <select
+                    className="set-control is-day"
+                    value={w.day}
+                    onChange={(e) => updateWindow(w.id, { day: e.target.value })}
+                  >
+                    {days.map(d => <option key={d}>{d}</option>)}
+                  </select>
+
+                  <div className="pw-time-pair">
+                    <input
+                      type="time" className="set-control is-time"
+                      value={w.start}
+                      onChange={(e) => updateWindow(w.id, { start: e.target.value })}
+                    />
+                    <span style={{ color: "var(--ink-500)", fontFamily: "var(--mono)", fontSize: "0.78rem" }}>→</span>
+                    <input
+                      type="time" className="set-control is-time"
+                      value={w.end}
+                      onChange={(e) => updateWindow(w.id, { end: e.target.value })}
+                    />
+                  </div>
+
+                  <div className="pw-active-cell">
+                    <button
+                      type="button"
+                      className={"toggle is-sm" + (w.active ? " is-on" : "")}
+                      aria-pressed={w.active}
+                      onClick={() => updateWindow(w.id, { active: !w.active })}
+                    />
+                  </div>
+
+                  <button
+                    type="button"
+                    className="pw-row-remove"
+                    title="Remove window"
+                    onClick={() => removeWindow(w.id)}
+                  >
+                    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M3 6h18"/>
+                      <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
+                      <path d="m19 6-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+                    </svg>
+                  </button>
+                </div>
+              ))}
+            </div>
+
+            <button type="button" className="pw-add" onClick={addWindow}>
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 5v14"/><path d="M5 12h14"/>
+              </svg>
+              Add window
+            </button>
+
+            <div className="pw-summary">
+              <strong>{windows.filter(w => w.active).length}</strong> of {windows.length} windows active.
+              Customers at checkout will see the active ones in this order.
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <div className={"set-savebar" + (hasChanges ? " has-changes" : "")}>
+        <div className="set-savebar-l">
+          <span className="set-savebar-dot" />
+          {hasChanges
+            ? "Unsaved changes — settings won't apply until you save."
+            : "All changes saved · last updated Apr 28, 2:14pm"}
+        </div>
+        <div className="set-savebar-r">
+          <button
+            type="button"
+            className="set-savebar-btn is-cancel"
+            disabled={!hasChanges}
+            onClick={() => setHasChanges(false)}
+          >
+            Discard
+          </button>
+          <button
+            type="button"
+            className="set-savebar-btn is-save"
+            disabled={!hasChanges}
+            onClick={() => setHasChanges(false)}
+          >
+            Save settings
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/design/admin-shell.css
+++ b/design/admin-shell.css
@@ -1,0 +1,327 @@
+/* Admin login + shell */
+
+/* ── Brand mark guards ────────────────────────────── */
+.brand-mark { display: inline-flex; align-items: center; }
+.brand-mark .brand-name { white-space: nowrap; }
+.brand-mark .brand-leaf { flex-shrink: 0; }
+
+/* ── Login ────────────────────────────────────────── */
+.login-bg {
+  min-height: 100vh;
+  background: var(--leaf-50);
+  background-image:
+    radial-gradient(circle at 12% 18%, rgba(59,109,17,0.08), transparent 38%),
+    radial-gradient(circle at 88% 82%, rgba(59,109,17,0.07), transparent 42%),
+    /* dotted texture */
+    radial-gradient(rgba(59,109,17,0.18) 1px, transparent 1px);
+  background-size: auto, auto, 16px 16px;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  padding: 48px 24px;
+  font-family: var(--sans);
+  color: var(--ink-900);
+}
+
+.login-card {
+  width: 100%; max-width: 440px;
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-lg);
+  padding: 36px 38px 32px;
+  box-shadow: 0 24px 60px -28px rgba(31,30,26,0.25), 0 2px 6px rgba(31,30,26,0.04);
+}
+.login-mark { margin-bottom: 22px; }
+.login-eyebrow {
+  font-size: 0.72rem; font-weight: 600;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--leaf-700);
+  margin-bottom: 10px;
+}
+.login-title {
+  font-family: var(--serif);
+  font-size: 1.8rem; font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+  margin-bottom: 10px;
+  text-wrap: pretty;
+}
+.login-lede {
+  color: var(--ink-700);
+  font-size: 0.97rem;
+  margin-bottom: 28px;
+  line-height: 1.55;
+}
+
+.btn-google {
+  width: 100%;
+  display: flex; align-items: center; justify-content: center; gap: 12px;
+  min-height: 50px;
+  background: var(--ink-900);
+  color: var(--paper);
+  border: none;
+  border-radius: var(--r-md);
+  font-family: var(--sans);
+  font-size: 0.98rem; font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  padding: 0 18px;
+  transition: background 0.12s, transform 0.05s;
+}
+.btn-google > span { white-space: nowrap; }
+.btn-google > svg { flex-shrink: 0; }
+.btn-google:hover { background: #2c2b27; }
+.btn-google:active { transform: translateY(1px); }
+.btn-google svg { background: var(--paper); border-radius: 4px; padding: 2px; box-sizing: content-box; }
+
+.login-foot {
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px solid var(--ink-200);
+  font-size: 0.82rem;
+  color: var(--ink-500);
+  line-height: 1.5;
+}
+
+.login-meta {
+  margin-top: 22px;
+  font-size: 0.78rem; color: var(--ink-500);
+  display: flex; gap: 24px;
+  font-family: var(--mono);
+}
+.login-meta span:nth-child(2) { opacity: 0.7; }
+
+/* ── Admin shell ─────────────────────────────────────── */
+.admin-shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  background: var(--cream);
+  font-family: var(--sans);
+  color: var(--ink-900);
+}
+
+.admin-side {
+  background: var(--ink-900);
+  color: var(--paper);
+  padding: 22px 18px 18px;
+  display: flex; flex-direction: column;
+  position: sticky; top: 0; height: 100vh;
+}
+.admin-side-mark {
+  color: var(--paper);
+  margin-bottom: 4px;
+  padding: 0 6px;
+}
+.admin-side-mark .brand-name { color: var(--paper); }
+.admin-side-mark .brand-leaf { color: var(--leaf-100); }
+
+.admin-side-eyebrow {
+  font-size: 0.66rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.12em;
+  color: rgba(251,250,245,0.5);
+  padding: 0 6px;
+  margin-bottom: 24px;
+}
+
+.admin-nav {
+  display: flex; flex-direction: column;
+  gap: 2px;
+  flex: 1;
+}
+.admin-nav-item {
+  position: relative;
+  display: flex; align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 12px;
+  background: transparent;
+  border: none;
+  border-radius: var(--r-sm);
+  color: rgba(251,250,245,0.78);
+  font-family: var(--sans);
+  font-size: 0.93rem;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.admin-nav-item:hover {
+  background: rgba(251,250,245,0.06);
+  color: var(--paper);
+}
+.admin-nav-item.is-active {
+  background: rgba(251,250,245,0.1);
+  color: var(--paper);
+}
+.admin-nav-item.is-active::before {
+  content: "";
+  position: absolute;
+  left: -18px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px; height: 22px;
+  background: var(--leaf-100);
+  border-radius: 0 3px 3px 0;
+}
+.admin-nav-icon {
+  display: flex; align-items: center; justify-content: center;
+  color: rgba(251,250,245,0.6);
+  flex-shrink: 0;
+}
+.admin-nav-item.is-active .admin-nav-icon,
+.admin-nav-item:hover .admin-nav-icon { color: var(--leaf-100); }
+.admin-nav-label { flex: 1; }
+.admin-nav-badge {
+  font-size: 0.7rem; font-weight: 500;
+  font-family: var(--mono);
+  background: rgba(251,250,245,0.08);
+  color: rgba(251,250,245,0.75);
+  padding: 2px 7px;
+  border-radius: 10px;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.admin-side-foot {
+  border-top: 1px solid rgba(251,250,245,0.08);
+  padding-top: 14px;
+  margin-top: 14px;
+  display: flex; flex-direction: column;
+  gap: 8px;
+}
+.admin-side-foot-row {
+  display: flex; flex-direction: column;
+  padding: 0 6px;
+}
+.admin-side-foot-key {
+  font-size: 0.66rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.1em;
+  color: rgba(251,250,245,0.45);
+  margin-bottom: 2px;
+}
+.admin-side-foot-val {
+  font-size: 0.85rem;
+  color: rgba(251,250,245,0.85);
+  display: flex; align-items: center; gap: 8px;
+}
+.status-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--ink-300);
+}
+.status-dot.is-open {
+  background: #79C44E;
+  box-shadow: 0 0 0 3px rgba(121,196,78,0.18);
+}
+
+/* main */
+.admin-main {
+  display: flex; flex-direction: column;
+  min-width: 0;
+}
+
+.admin-top {
+  background: var(--paper);
+  border-bottom: 1px solid var(--ink-200);
+  padding: 0 32px;
+  height: 60px;
+  display: flex; align-items: center; justify-content: space-between;
+  position: sticky; top: 0; z-index: 5;
+}
+.admin-crumb {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 0.88rem;
+  color: var(--ink-500);
+}
+.admin-crumb-sep { color: var(--ink-300); }
+.admin-crumb-active {
+  color: var(--ink-900);
+  font-weight: 600;
+}
+
+.admin-top-right {
+  display: flex; align-items: center; gap: 18px;
+}
+.admin-week {
+  text-align: right;
+  padding-right: 18px;
+  border-right: 1px solid var(--ink-200);
+}
+.admin-week-key {
+  font-size: 0.68rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.1em;
+  color: var(--ink-500);
+  line-height: 1.2;
+  white-space: nowrap;
+}
+.admin-week-val {
+  font-size: 0.9rem; font-weight: 600;
+  color: var(--ink-900);
+  font-family: var(--serif);
+  letter-spacing: -0.005em;
+  white-space: nowrap;
+}
+
+.admin-signout {
+  background: transparent;
+  border: 1px solid var(--ink-200);
+  color: var(--ink-700);
+  border-radius: var(--r-sm);
+  padding: 7px 12px;
+  font-family: var(--sans);
+  font-size: 0.85rem; font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  display: flex; align-items: center; gap: 7px;
+  flex-shrink: 0;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.admin-signout:hover {
+  background: var(--leaf-50);
+  border-color: var(--leaf-100);
+  color: var(--leaf-700);
+}
+
+.admin-content {
+  padding: 28px 32px 60px;
+  flex: 1;
+  max-width: 1200px;
+  width: 100%;
+}
+
+/* placeholder */
+.admin-page-head {
+  display: flex; justify-content: space-between; align-items: flex-end;
+  gap: 16px;
+  margin-bottom: 28px;
+}
+.admin-page-title {
+  font-family: var(--serif);
+  font-size: 2rem; font-weight: 600;
+  letter-spacing: -0.015em;
+  line-height: 1.1;
+}
+.admin-page-actions { display: flex; gap: 10px; }
+
+.admin-empty {
+  background: var(--paper);
+  border: 1px dashed var(--ink-300);
+  border-radius: var(--r-md);
+  padding: 56px 32px;
+  text-align: center;
+  color: var(--ink-500);
+}
+.admin-empty-title {
+  font-family: var(--serif);
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--ink-700);
+  margin: 14px 0 6px;
+}
+.admin-empty-sub {
+  font-size: 0.9rem;
+  max-width: 42ch;
+  margin: 0 auto;
+  line-height: 1.55;
+}

--- a/design/admin-shell.jsx
+++ b/design/admin-shell.jsx
@@ -1,0 +1,215 @@
+/* Admin login + shell */
+
+const { useState } = React;
+
+/* ── Brand mark ─────────────────────────────────────── */
+function BrandMark({ size = "lg" }) {
+  const dims = size === "lg"
+    ? { leaf: 28, font: "1.65rem" }
+    : { leaf: 18, font: "1.05rem" };
+  return (
+    <div className="brand-mark" style={{ gap: size === "lg" ? 12 : 8 }}>
+      <span className="brand-leaf" style={{ width: dims.leaf, height: dims.leaf }} aria-hidden="true">
+        <svg viewBox="0 0 24 24" width={dims.leaf} height={dims.leaf} fill="currentColor">
+          <path d="M21.5 2.5c0 8-4.5 14.5-12 14.5-1.4 0-2.8-.2-4-.7l1.4-1.4c.8.2 1.7.4 2.6.4 6 0 9.5-5.3 10-12.3-2 .6-7.4 2.6-10.4 7.4-1 1.6-1.5 3.4-1.7 5.4l-1.5 1.5c0-3.3.7-6.3 2.4-8.7C11.4 4 18.4 2.6 21.5 2.5z"/>
+        </svg>
+      </span>
+      <span className="brand-name" style={{ fontFamily: "var(--serif)", fontSize: dims.font, fontWeight: 600, letterSpacing: "-0.005em" }}>
+        Bay Branch Farm
+      </span>
+    </div>
+  );
+}
+
+/* ── Login ───────────────────────────────────────────── */
+function AdminLogin() {
+  return (
+    <div className="login-bg">
+      <div className="login-card">
+        <div className="login-mark"><BrandMark size="lg"/></div>
+        <div className="login-eyebrow">admin · bushel</div>
+        <h1 className="login-title">Welcome back, Annabel.</h1>
+        <p className="login-lede">
+          Sign in to manage this week's harvest, customers, and orders.
+        </p>
+
+        <button type="button" className="btn-google">
+          <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+            <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.49h4.84a4.14 4.14 0 0 1-1.8 2.71v2.26h2.92c1.7-1.57 2.68-3.88 2.68-6.62z"/>
+            <path fill="#34A853" d="M9 18c2.43 0 4.47-.81 5.96-2.18l-2.92-2.26c-.81.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.94v2.32A9 9 0 0 0 9 18z"/>
+            <path fill="#FBBC05" d="M3.97 10.71A5.41 5.41 0 0 1 3.68 9c0-.59.1-1.17.29-1.71V4.97H.94A9 9 0 0 0 0 9c0 1.45.35 2.83.94 4.03l3.03-2.32z"/>
+            <path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58A9 9 0 0 0 9 0 9 9 0 0 0 .94 4.97l3.03 2.32C4.68 5.16 6.66 3.58 9 3.58z"/>
+          </svg>
+          <span>Sign in with Google</span>
+        </button>
+
+        <div className="login-foot">
+          Admin only. Customers don't need an account — they receive a private
+          link by text.
+        </div>
+      </div>
+      <div className="login-meta">
+        <span>Bay Branch Farm · Cleveland, OH</span>
+        <span>v0.1 · internal</span>
+      </div>
+    </div>
+  );
+}
+
+/* ── Admin shell with placeholder content ───────────── */
+function AdminShell({ initialPage }) {
+  const [page, setPage] = useState(initialPage || "inventory");
+
+  const nav = [
+    { id: "inventory", label: "Inventory", icon: <IconLeaf/>,    badge: "12 listed" },
+    { id: "customers", label: "Customers", icon: <IconUsers/>,   badge: null },
+    { id: "orders",    label: "Orders",    icon: <IconBag/>,     badge: "4 new" },
+    { id: "broadcast", label: "Send Update", icon: <IconSend/>,  badge: null },
+    { id: "settings",  label: "Settings",  icon: <IconCog/>,     badge: null },
+  ];
+
+  return (
+    <div className="admin-shell">
+      <aside className="admin-side">
+        <div className="admin-side-mark"><BrandMark size="sm"/></div>
+        <div className="admin-side-eyebrow">admin · bushel</div>
+        <nav className="admin-nav">
+          {nav.map(item => (
+            <button
+              key={item.id}
+              type="button"
+              className={"admin-nav-item" + (page === item.id ? " is-active" : "")}
+              onClick={() => setPage(item.id)}
+            >
+              <span className="admin-nav-icon">{item.icon}</span>
+              <span className="admin-nav-label">{item.label}</span>
+              {item.badge && <span className="admin-nav-badge">{item.badge}</span>}
+            </button>
+          ))}
+        </nav>
+        <div className="admin-side-foot">
+          <div className="admin-side-foot-row">
+            <div className="admin-side-foot-key">This week</div>
+            <div className="admin-side-foot-val">May 3 – May 9</div>
+          </div>
+          <div className="admin-side-foot-row">
+            <div className="admin-side-foot-key">Status</div>
+            <div className="admin-side-foot-val">
+              <span className="status-dot is-open"></span> Open for orders
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      <div className="admin-main">
+        <header className="admin-top">
+          <div className="admin-crumb">
+            <span>Admin</span>
+            <span className="admin-crumb-sep">/</span>
+            <span className="admin-crumb-active">{nav.find(n => n.id === page).label}</span>
+          </div>
+          <div className="admin-top-right">
+            <div className="admin-week">
+              <div className="admin-week-key">Week of</div>
+              <div className="admin-week-val">Sun, May 3</div>
+            </div>
+            <button type="button" className="admin-signout">
+              <IconSignOut/>
+              <span>Sign out</span>
+            </button>
+          </div>
+        </header>
+
+        <main className="admin-content">
+          <PagePlaceholder name={nav.find(n => n.id === page).label}/>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function PagePlaceholder({ name }) {
+  return (
+    <div className="admin-placeholder">
+      <div className="admin-page-head">
+        <div>
+          <div className="eyebrow" style={{marginBottom: 6}}>section</div>
+          <h1 className="admin-page-title">{name}</h1>
+        </div>
+        <div className="admin-page-actions">
+          <button type="button" className="btn btn-secondary">Export</button>
+          <button type="button" className="btn btn-primary">+ New</button>
+        </div>
+      </div>
+      <div className="admin-empty">
+        <svg viewBox="0 0 80 80" width="56" height="56" aria-hidden="true">
+          <rect x="14" y="20" width="52" height="44" rx="4" fill="#EDF5E5" stroke="#3B6D11" strokeOpacity="0.4"/>
+          <line x1="22" y1="32" x2="58" y2="32" stroke="#3B6D11" strokeOpacity="0.3" strokeWidth="1.5"/>
+          <line x1="22" y1="42" x2="58" y2="42" stroke="#3B6D11" strokeOpacity="0.3" strokeWidth="1.5"/>
+          <line x1="22" y1="52" x2="48" y2="52" stroke="#3B6D11" strokeOpacity="0.3" strokeWidth="1.5"/>
+        </svg>
+        <div className="admin-empty-title">{name} content goes here.</div>
+        <div className="admin-empty-sub">
+          We'll wire this section in the next pass — shell + nav are scaffolded
+          so we can drop tables, forms, and detail panes in cleanly.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Icons (24px stroke) ────────────────────────────── */
+function IconLeaf() {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M20 4c0 8-4.5 14-12 14-1 0-2-.1-3-.4"/>
+      <path d="M5 19c0-6 4-12 14-15"/>
+    </svg>
+  );
+}
+function IconUsers() {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="9" cy="8" r="3.5"/>
+      <path d="M3 20c0-3.3 2.7-6 6-6s6 2.7 6 6"/>
+      <circle cx="17" cy="9" r="2.5"/>
+      <path d="M15 14.5c1-.3 2-.5 2.5-.5 2.5 0 4.5 2 4.5 4.5"/>
+    </svg>
+  );
+}
+function IconBag() {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M5 8h14l-1 12H6z"/>
+      <path d="M9 8V6a3 3 0 0 1 6 0v2"/>
+    </svg>
+  );
+}
+function IconSend() {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M21 4 3 11l7 2 2 7z"/>
+      <path d="m10 13 5-5"/>
+    </svg>
+  );
+}
+function IconCog() {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="3"/>
+      <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h.1a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.9-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v.1a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/>
+    </svg>
+  );
+}
+function IconSignOut() {
+  return (
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
+      <path d="m16 17 5-5-5-5"/>
+      <path d="M21 12H9"/>
+    </svg>
+  );
+}
+
+window.AdminLogin = AdminLogin;
+window.AdminShell = AdminShell;

--- a/design/customer-preview.jsx
+++ b/design/customer-preview.jsx
@@ -1,0 +1,113 @@
+/* Customer order surface preview (mobile) */
+const { useState } = React;
+
+function CustomerPreview() {
+  const [qty, setQty] = useState({ kale: 4, beets: 0, lettuce: 2, flowers: 1 });
+  const [mode, setMode] = useState("delivery");
+
+  const items = [
+    { id: "kale",    name: "Dino kale",        unit: "bunch",  price: 4.50, avail: 18 },
+    { id: "beets",   name: "Red beets",        unit: "lb",     price: 3.25, avail: 22 },
+    { id: "lettuce", name: "Salanova mix",     unit: "head",   price: 5.00, avail: 9 },
+    { id: "flowers", name: "Mixed bouquet",    unit: "stem",   price: 12.00, avail: 6 },
+  ];
+  const total = items.reduce((s, i) => s + (qty[i.id] || 0) * i.price, 0);
+  const lineCount = items.reduce((s, i) => s + (qty[i.id] > 0 ? 1 : 0), 0);
+
+  const setN = (id, n) => setQty(q => ({ ...q, [id]: Math.max(0, n) }));
+
+  return (
+    <div style={{ background: "var(--cream)", minHeight: "100%", padding: "20px 18px 96px", fontFamily: "var(--sans)" }}>
+      {/* Header */}
+      <div style={{ marginBottom: 18 }}>
+        <div className="eyebrow" style={{ marginBottom: 6 }}>this week · may 2</div>
+        <h1 style={{ fontFamily: "var(--serif)", fontSize: "1.75rem", lineHeight: 1.15, marginBottom: 4 }}>What's available</h1>
+        <p style={{ color: "var(--ink-500)", fontSize: "0.95rem" }}>
+          Order by Tuesday 9pm. Pickup or delivery Wednesday.
+        </p>
+      </div>
+
+      {/* Items */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 10, marginBottom: 22 }}>
+        {items.map(i => (
+          <div key={i.id} className="card" style={{ padding: "14px 14px", display: "flex", alignItems: "center", gap: 12 }}>
+            <div style={{
+              width: 44, height: 44, borderRadius: 8, background: "var(--leaf-50)",
+              border: "1px solid var(--leaf-100)", flexShrink: 0
+            }} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontWeight: 600, fontSize: "0.98rem", color: "var(--ink-900)" }}>{i.name}</div>
+              <div style={{ fontSize: "0.82rem", color: "var(--ink-500)" }}>
+                ${i.price.toFixed(2)} / {i.unit} · {i.avail} {i.unit}{i.avail !== 1 ? "s" : ""} left
+              </div>
+            </div>
+            <Stepper value={qty[i.id]} onChange={n => setN(i.id, n)} />
+          </div>
+        ))}
+      </div>
+
+      {/* Fulfillment */}
+      <div style={{ marginBottom: 18 }}>
+        <div className="eyebrow" style={{ marginBottom: 8 }}>fulfillment</div>
+        <div style={{ display: "flex", gap: 8 }}>
+          <SegBtn active={mode === "delivery"} onClick={() => setMode("delivery")}>Delivery</SegBtn>
+          <SegBtn active={mode === "pickup"} onClick={() => setMode("pickup")}>Pickup</SegBtn>
+        </div>
+      </div>
+
+      {/* Sticky-style total */}
+      <div style={{
+        position: "sticky", bottom: 0, marginLeft: -18, marginRight: -18,
+        padding: "14px 18px 16px", background: "var(--paper)", borderTop: "1px solid var(--ink-200)"
+      }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 10 }}>
+          <div style={{ fontSize: "0.82rem", color: "var(--ink-500)" }}>{lineCount} item{lineCount !== 1 ? "s" : ""}</div>
+          <div style={{ fontFamily: "var(--serif)", fontSize: "1.5rem", fontWeight: 600 }}>${total.toFixed(2)}</div>
+        </div>
+        <button className="btn btn-primary" style={{ width: "100%" }}>Place order</button>
+      </div>
+    </div>
+  );
+}
+
+function Stepper({ value, onChange }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", border: "1px solid var(--ink-300)", borderRadius: "var(--r-sm)", overflow: "hidden", background: "var(--paper)" }}>
+      <button
+        onClick={() => onChange(value - 1)}
+        disabled={!value}
+        style={{
+          width: 32, height: 32, border: "none", background: "transparent",
+          color: value ? "var(--leaf-700)" : "var(--ink-300)",
+          fontSize: "1.1rem", cursor: value ? "pointer" : "default", fontWeight: 600
+        }}
+      >−</button>
+      <div style={{
+        width: 28, textAlign: "center", fontVariantNumeric: "tabular-nums",
+        fontWeight: 600, fontSize: "0.95rem", color: value ? "var(--ink-900)" : "var(--ink-500)"
+      }}>{value || 0}</div>
+      <button
+        onClick={() => onChange(value + 1)}
+        style={{ width: 32, height: 32, border: "none", background: "transparent", color: "var(--leaf-700)", fontSize: "1.1rem", cursor: "pointer", fontWeight: 600 }}
+      >+</button>
+    </div>
+  );
+}
+
+function SegBtn({ active, children, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        flex: 1, padding: "10px 14px", borderRadius: "var(--r-sm)",
+        border: `1px solid ${active ? "var(--leaf-600)" : "var(--ink-300)"}`,
+        background: active ? "var(--leaf-50)" : "var(--paper)",
+        color: active ? "var(--leaf-700)" : "var(--ink-700)",
+        fontWeight: 600, fontSize: "0.92rem", cursor: "pointer", fontFamily: "var(--sans)",
+        minHeight: 44
+      }}
+    >{children}</button>
+  );
+}
+
+window.CustomerPreview = CustomerPreview;

--- a/design/ios-frame.jsx
+++ b/design/ios-frame.jsx
@@ -1,0 +1,338 @@
+
+// iOS.jsx — Simplified iOS 26 (Liquid Glass) device frame
+// Based on the iOS 26 UI Kit + Figma status bar spec. No assets, no deps.
+// Exports: IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard
+
+// ─────────────────────────────────────────────────────────────
+// Status bar
+// ─────────────────────────────────────────────────────────────
+function IOSStatusBar({ dark = false, time = '9:41' }) {
+  const c = dark ? '#fff' : '#000';
+  return (
+    <div style={{
+      display: 'flex', gap: 154, alignItems: 'center', justifyContent: 'center',
+      padding: '21px 24px 19px', boxSizing: 'border-box',
+      position: 'relative', zIndex: 20, width: '100%',
+    }}>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', paddingTop: 1.5 }}>
+        <span style={{
+          fontFamily: '-apple-system, "SF Pro", system-ui', fontWeight: 590,
+          fontSize: 17, lineHeight: '22px', color: c,
+        }}>{time}</span>
+      </div>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7, paddingTop: 1, paddingRight: 1 }}>
+        <svg width="19" height="12" viewBox="0 0 19 12">
+          <rect x="0" y="7.5" width="3.2" height="4.5" rx="0.7" fill={c}/>
+          <rect x="4.8" y="5" width="3.2" height="7" rx="0.7" fill={c}/>
+          <rect x="9.6" y="2.5" width="3.2" height="9.5" rx="0.7" fill={c}/>
+          <rect x="14.4" y="0" width="3.2" height="12" rx="0.7" fill={c}/>
+        </svg>
+        <svg width="17" height="12" viewBox="0 0 17 12">
+          <path d="M8.5 3.2C10.8 3.2 12.9 4.1 14.4 5.6L15.5 4.5C13.7 2.7 11.2 1.5 8.5 1.5C5.8 1.5 3.3 2.7 1.5 4.5L2.6 5.6C4.1 4.1 6.2 3.2 8.5 3.2Z" fill={c}/>
+          <path d="M8.5 6.8C9.9 6.8 11.1 7.3 12 8.2L13.1 7.1C11.8 5.9 10.2 5.1 8.5 5.1C6.8 5.1 5.2 5.9 3.9 7.1L5 8.2C5.9 7.3 7.1 6.8 8.5 6.8Z" fill={c}/>
+          <circle cx="8.5" cy="10.5" r="1.5" fill={c}/>
+        </svg>
+        <svg width="27" height="13" viewBox="0 0 27 13">
+          <rect x="0.5" y="0.5" width="23" height="12" rx="3.5" stroke={c} strokeOpacity="0.35" fill="none"/>
+          <rect x="2" y="2" width="20" height="9" rx="2" fill={c}/>
+          <path d="M25 4.5V8.5C25.8 8.2 26.5 7.2 26.5 6.5C26.5 5.8 25.8 4.8 25 4.5Z" fill={c} fillOpacity="0.4"/>
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Liquid glass pill — blur + tint + shine
+// ─────────────────────────────────────────────────────────────
+function IOSGlassPill({ children, dark = false, style = {} }) {
+  return (
+    <div style={{
+      height: 44, minWidth: 44, borderRadius: 9999,
+      position: 'relative', overflow: 'hidden',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      boxShadow: dark
+        ? '0 2px 6px rgba(0,0,0,0.35), 0 6px 16px rgba(0,0,0,0.2)'
+        : '0 1px 3px rgba(0,0,0,0.07), 0 3px 10px rgba(0,0,0,0.06)',
+      ...style,
+    }}>
+      {/* blur + tint */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.28)' : 'rgba(255,255,255,0.5)',
+      }} />
+      {/* shine */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15), inset -1px -1px 1px rgba(255,255,255,0.08)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+      }} />
+      <div style={{ position: 'relative', zIndex: 1, display: 'flex', alignItems: 'center', padding: '0 4px' }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Navigation bar — glass pills + large title
+// ─────────────────────────────────────────────────────────────
+function IOSNavBar({ title = 'Title', dark = false, trailingIcon = true }) {
+  const muted = dark ? 'rgba(255,255,255,0.6)' : '#404040';
+  const text = dark ? '#fff' : '#000';
+  const pillIcon = (content) => (
+    <IOSGlassPill dark={dark}>
+      <div style={{ width: 36, height: 36, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        {content}
+      </div>
+    </IOSGlassPill>
+  );
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', gap: 10,
+      paddingTop: 62, paddingBottom: 10, position: 'relative', zIndex: 5,
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '0 16px',
+      }}>
+        {/* back chevron */}
+        {pillIcon(
+          <svg width="12" height="20" viewBox="0 0 12 20" fill="none" style={{ marginLeft: -1 }}>
+            <path d="M10 2L2 10l8 8" stroke={muted} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        )}
+        {/* trailing ellipsis */}
+        {trailingIcon && pillIcon(
+          <svg width="22" height="6" viewBox="0 0 22 6">
+            <circle cx="3" cy="3" r="2.5" fill={muted}/>
+            <circle cx="11" cy="3" r="2.5" fill={muted}/>
+            <circle cx="19" cy="3" r="2.5" fill={muted}/>
+          </svg>
+        )}
+      </div>
+      {/* large title */}
+      <div style={{
+        padding: '0 16px',
+        fontFamily: '-apple-system, system-ui',
+        fontSize: 34, fontWeight: 700, lineHeight: '41px',
+        color: text, letterSpacing: 0.4,
+      }}>{title}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Grouped list (inset card, r:26) + row (52px)
+// ─────────────────────────────────────────────────────────────
+function IOSListRow({ title, detail, icon, chevron = true, isLast = false, dark = false }) {
+  const text = dark ? '#fff' : '#000';
+  const sec = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const ter = dark ? 'rgba(235,235,245,0.3)' : 'rgba(60,60,67,0.3)';
+  const sep = dark ? 'rgba(84,84,88,0.65)' : 'rgba(60,60,67,0.12)';
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', minHeight: 52,
+      padding: '0 16px', position: 'relative',
+      fontFamily: '-apple-system, system-ui', fontSize: 17,
+      letterSpacing: -0.43,
+    }}>
+      {icon && (
+        <div style={{
+          width: 30, height: 30, borderRadius: 7, background: icon,
+          marginRight: 12, flexShrink: 0,
+        }} />
+      )}
+      <div style={{ flex: 1, color: text }}>{title}</div>
+      {detail && <span style={{ color: sec, marginRight: 6 }}>{detail}</span>}
+      {chevron && (
+        <svg width="8" height="14" viewBox="0 0 8 14" style={{ flexShrink: 0 }}>
+          <path d="M1 1l6 6-6 6" stroke={ter} strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      )}
+      {!isLast && (
+        <div style={{
+          position: 'absolute', bottom: 0, right: 0,
+          left: icon ? 58 : 16, height: 0.5, background: sep,
+        }} />
+      )}
+    </div>
+  );
+}
+
+function IOSList({ header, children, dark = false }) {
+  const hc = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const bg = dark ? '#1C1C1E' : '#fff';
+  return (
+    <div>
+      {header && (
+        <div style={{
+          fontFamily: '-apple-system, system-ui', fontSize: 13,
+          color: hc, textTransform: 'uppercase',
+          padding: '8px 36px 6px', letterSpacing: -0.08,
+        }}>{header}</div>
+      )}
+      <div style={{
+        background: bg, borderRadius: 26,
+        margin: '0 16px', overflow: 'hidden',
+      }}>{children}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Device frame
+// ─────────────────────────────────────────────────────────────
+function IOSDevice({
+  children, width = 402, height = 874, dark = false,
+  title, keyboard = false,
+}) {
+  return (
+    <div style={{
+      width, height, borderRadius: 48, overflow: 'hidden',
+      position: 'relative', background: dark ? '#000' : '#F2F2F7',
+      boxShadow: '0 40px 80px rgba(0,0,0,0.18), 0 0 0 1px rgba(0,0,0,0.12)',
+      fontFamily: '-apple-system, system-ui, sans-serif',
+      WebkitFontSmoothing: 'antialiased',
+    }}>
+      {/* dynamic island */}
+      <div style={{
+        position: 'absolute', top: 11, left: '50%', transform: 'translateX(-50%)',
+        width: 126, height: 37, borderRadius: 24, background: '#000', zIndex: 50,
+      }} />
+      {/* status bar (absolute) */}
+      <div style={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 10 }}>
+        <IOSStatusBar dark={dark} />
+      </div>
+      {/* nav + content */}
+      <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        {title !== undefined && <IOSNavBar title={title} dark={dark} />}
+        <div style={{ flex: 1, overflow: 'auto' }}>{children}</div>
+        {keyboard && <IOSKeyboard dark={dark} />}
+      </div>
+      {/* home indicator — always on top */}
+      <div style={{
+        position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 60,
+        height: 34, display: 'flex', justifyContent: 'center', alignItems: 'flex-end',
+        paddingBottom: 8, pointerEvents: 'none',
+      }}>
+        <div style={{
+          width: 139, height: 5, borderRadius: 100,
+          background: dark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.25)',
+        }} />
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Keyboard — iOS 26 liquid glass
+// ─────────────────────────────────────────────────────────────
+function IOSKeyboard({ dark = false }) {
+  const glyph = dark ? 'rgba(255,255,255,0.7)' : '#595959';
+  const sugg = dark ? 'rgba(255,255,255,0.6)' : '#333';
+  const keyBg = dark ? 'rgba(255,255,255,0.22)' : 'rgba(255,255,255,0.85)';
+
+  // special-key icons
+  const icons = {
+    shift: <svg width="19" height="17" viewBox="0 0 19 17"><path d="M9.5 1L1 9.5h4.5V16h8V9.5H18L9.5 1z" fill={glyph}/></svg>,
+    del: <svg width="23" height="17" viewBox="0 0 23 17"><path d="M7 1h13a2 2 0 012 2v11a2 2 0 01-2 2H7l-6-7.5L7 1z" fill="none" stroke={glyph} strokeWidth="1.6" strokeLinejoin="round"/><path d="M10 5l7 7M17 5l-7 7" stroke={glyph} strokeWidth="1.6" strokeLinecap="round"/></svg>,
+    ret: <svg width="20" height="14" viewBox="0 0 20 14"><path d="M18 1v6H4m0 0l4-4M4 7l4 4" fill="none" stroke="#fff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/></svg>,
+  };
+
+  const key = (content, { w, flex, ret, fs = 25, k } = {}) => (
+    <div key={k} style={{
+      height: 42, borderRadius: 8.5,
+      flex: flex ? 1 : undefined, width: w, minWidth: 0,
+      background: ret ? '#08f' : keyBg,
+      boxShadow: '0 1px 0 rgba(0,0,0,0.075)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontFamily: '-apple-system, "SF Compact", system-ui',
+      fontSize: fs, fontWeight: 458, color: ret ? '#fff' : glyph,
+    }}>{content}</div>
+  );
+
+  const row = (keys, pad = 0) => (
+    <div style={{ display: 'flex', gap: 6.5, justifyContent: 'center', padding: `0 ${pad}px` }}>
+      {keys.map(l => key(l, { flex: true, k: l }))}
+    </div>
+  );
+
+  return (
+    <div style={{
+      position: 'relative', zIndex: 15, borderRadius: 27, overflow: 'hidden',
+      padding: '11px 0 2px',
+      display: 'flex', flexDirection: 'column', alignItems: 'center',
+      boxShadow: dark
+        ? '0 -2px 20px rgba(0,0,0,0.09)'
+        : '0 -1px 6px rgba(0,0,0,0.018), 0 -3px 20px rgba(0,0,0,0.012)',
+    }}>
+      {/* liquid glass bg — same recipe as nav pills */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.14)' : 'rgba(255,255,255,0.25)',
+      }} />
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+        pointerEvents: 'none',
+      }} />
+
+      {/* autocorrect bar */}
+      <div style={{
+        display: 'flex', gap: 20, alignItems: 'center',
+        padding: '8px 22px 13px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {['"The"', 'the', 'to'].map((w, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && <div style={{ width: 1, height: 25, background: '#ccc', opacity: 0.3 }} />}
+            <div style={{
+              flex: 1, textAlign: 'center',
+              fontFamily: '-apple-system, system-ui', fontSize: 17,
+              color: sugg, letterSpacing: -0.43, lineHeight: '22px',
+            }}>{w}</div>
+          </React.Fragment>
+        ))}
+      </div>
+
+      {/* key layout */}
+      <div style={{
+        display: 'flex', flexDirection: 'column', gap: 13,
+        padding: '0 6.5px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {row(['q','w','e','r','t','y','u','i','o','p'])}
+        {row(['a','s','d','f','g','h','j','k','l'], 20)}
+        <div style={{ display: 'flex', gap: 14.25, alignItems: 'center' }}>
+          {key(icons.shift, { w: 45, k: 'shift' })}
+          <div style={{ display: 'flex', gap: 6.5, flex: 1 }}>
+            {['z','x','c','v','b','n','m'].map(l => key(l, { flex: true, k: l }))}
+          </div>
+          {key(icons.del, { w: 45, k: 'del' })}
+        </div>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          {key('ABC', { w: 92.25, fs: 18, k: 'abc' })}
+          {key('', { flex: true, k: 'space' })}
+          {key(icons.ret, { w: 92.25, ret: true, k: 'ret' })}
+        </div>
+      </div>
+
+      {/* bottom spacer (emoji+mic area, icons omitted) */}
+      <div style={{ height: 56, width: '100%', position: 'relative' }} />
+    </div>
+  );
+}
+
+Object.assign(window, {
+  IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard,
+});

--- a/design/order-page.css
+++ b/design/order-page.css
@@ -1,0 +1,405 @@
+/* Customer order page styles */
+
+/* ── Page shell ──────────────────────────────────────────────── */
+.order-page {
+  background: var(--cream);
+  min-height: 100vh;
+  color: var(--ink-900);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.55;
+  padding-bottom: 96px; /* room for sticky bar mobile */
+}
+
+.brand-strip {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--ink-200);
+  background: var(--paper);
+}
+.brand-mark { display: flex; align-items: center; gap: 8px; }
+.brand-leaf { color: var(--leaf-600); display: inline-flex; }
+.brand-name { font-family: var(--serif); font-size: 1.05rem; font-weight: 600; color: var(--leaf-700); }
+.brand-help { font-size: 0.85rem; color: var(--ink-500); text-decoration: none; }
+.brand-help:hover { color: var(--leaf-600); }
+
+.page-shell {
+  max-width: 720px; margin: 0 auto;
+  padding: 28px 20px 24px;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+.page-head { margin-bottom: 28px; }
+.page-title {
+  font-family: var(--display); font-size: 2rem; font-weight: 600;
+  line-height: 1.1; margin-top: 6px; margin-bottom: 10px;
+  letter-spacing: -0.01em;
+}
+.page-greet {
+  font-size: 1rem; color: var(--ink-700);
+}
+.customer-name { font-weight: 600; color: var(--ink-900); }
+
+.annabels-note {
+  margin-top: 18px;
+  padding: 14px 16px 14px 18px;
+  background: var(--leaf-50);
+  border-left: 3px solid var(--leaf-600);
+  border-radius: 0 var(--r-sm) var(--r-sm) 0;
+}
+.annabels-note .eyebrow { margin-bottom: 4px; }
+.annabels-note p { color: var(--ink-700); font-size: 0.95rem; }
+
+/* ── Section heads ──────────────────────────────────────── */
+.section-title {
+  font-family: var(--serif);
+  font-size: 1.3rem; font-weight: 600;
+  line-height: 1.2; margin-top: 4px; margin-bottom: 14px;
+}
+
+/* ── Inventory ──────────────────────────────────────────── */
+.inv { margin-bottom: 36px; }
+.inv-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  margin-bottom: 10px;
+}
+.inv-count { font-size: 0.82rem; color: var(--ink-500); }
+
+.item-list {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+.item-row {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 14px;
+  border-top: 1px solid var(--ink-200);
+}
+.item-row:first-child { border-top: 0; }
+.item-row.is-sold-out { background: var(--leaf-50); opacity: 0.78; }
+.item-row.is-sold-out .item-name { color: var(--ink-500); }
+
+.item-thumb {
+  width: 44px; height: 44px; border-radius: 8px;
+  background: var(--leaf-50);
+  border: 1px solid var(--leaf-100);
+  position: relative; overflow: hidden;
+  display: flex; align-items: center; justify-content: center;
+}
+.item-thumb-inner {
+  width: 100%; height: 100%;
+  background-image:
+    repeating-linear-gradient(
+      45deg,
+      transparent 0,
+      transparent 6px,
+      rgba(59,109,17,0.08) 6px,
+      rgba(59,109,17,0.08) 7px
+    );
+}
+.item-row.is-sold-out .item-thumb { opacity: 0.55; }
+
+.item-body { min-width: 0; }
+.item-line1 {
+  display: flex; justify-content: space-between; align-items: baseline;
+  gap: 8px;
+  margin-bottom: 2px;
+  flex-wrap: wrap;
+}
+.item-name {
+  font-weight: 600; font-size: 1rem; color: var(--ink-900);
+  min-width: 0;
+}
+.item-price {
+  font-size: 0.88rem; color: var(--ink-700);
+  white-space: nowrap; flex-shrink: 0;
+}
+.item-price .mono { font-weight: 600; color: var(--ink-900); }
+.item-per { color: var(--ink-500); }
+
+.item-line2 { font-size: 0.82rem; }
+.item-meta { color: var(--ink-500); }
+.meta-low { color: var(--amber-600); font-weight: 600; }
+.meta-sold-out {
+  color: var(--ink-500); font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.06em; font-size: 0.72rem;
+}
+
+/* Stepper */
+.stepper {
+  display: inline-flex; align-items: stretch;
+  border: 1px solid var(--ink-300);
+  border-radius: var(--r-sm);
+  background: var(--paper);
+  overflow: hidden;
+}
+.stepper-btn {
+  width: 34px; height: 34px;
+  background: transparent; border: none;
+  font-size: 1.2rem; font-weight: 600; color: var(--leaf-700);
+  cursor: pointer; line-height: 1;
+  transition: background 0.12s;
+}
+.stepper-btn:hover:not(:disabled) { background: var(--leaf-50); }
+.stepper-btn:disabled { color: var(--ink-300); cursor: default; }
+.stepper-val {
+  min-width: 28px; padding: 0 4px;
+  display: flex; align-items: center; justify-content: center;
+  font-weight: 600; font-size: 0.95rem;
+  font-variant-numeric: tabular-nums;
+  border-left: 1px solid var(--ink-200);
+  border-right: 1px solid var(--ink-200);
+}
+.is-sold-out .stepper { opacity: 0.55; }
+
+/* ── Fulfillment ──────────────────────────────────────────── */
+.fulfill { margin-bottom: 36px; }
+.fulfill-tabs {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 10px; margin-bottom: 18px;
+}
+.fulfill-tab {
+  text-align: left; padding: 14px 16px;
+  background: var(--paper);
+  border: 1px solid var(--ink-300);
+  border-radius: var(--r-md);
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s;
+  font-family: var(--sans);
+  min-height: 64px;
+}
+.fulfill-tab:hover { border-color: var(--leaf-600); }
+.fulfill-tab.is-active {
+  border-color: var(--leaf-600);
+  background: var(--leaf-50);
+  box-shadow: inset 0 0 0 1px var(--leaf-600);
+}
+.fulfill-tab-label { font-weight: 600; font-size: 1rem; color: var(--ink-900); margin-bottom: 2px; }
+.fulfill-tab-sub { font-size: 0.82rem; color: var(--ink-500); }
+.fulfill-tab.is-active .fulfill-tab-sub { color: var(--leaf-700); }
+
+.fulfill-detail {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  padding: 16px 18px;
+}
+.fulfill-help {
+  margin-top: 12px;
+  font-size: 0.85rem; color: var(--ink-500); line-height: 1.5;
+}
+
+.label-sm {
+  font-weight: 600; font-size: 0.78rem;
+  color: var(--ink-700); text-transform: uppercase; letter-spacing: 0.05em;
+  margin-bottom: 4px;
+}
+
+.addr-row {
+  display: flex; justify-content: space-between; align-items: flex-start; gap: 14px;
+}
+.addr-stack { flex: 1; min-width: 0; }
+.addr-text { font-size: 1rem; color: var(--ink-900); }
+.link-btn {
+  background: transparent; border: 0; padding: 0; cursor: pointer;
+  color: var(--leaf-700); font-size: 0.9rem; font-weight: 600;
+  text-decoration: underline; text-underline-offset: 2px;
+  font-family: var(--sans); flex-shrink: 0; margin-top: 18px;
+}
+.link-btn:hover { color: var(--leaf-600); }
+
+/* Pickup windows */
+.windows { display: grid; gap: 8px; }
+.window {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  padding: 12px 14px;
+  background: var(--paper);
+  border: 1px solid var(--ink-300);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s;
+  position: relative;
+}
+.window input { position: absolute; opacity: 0; pointer-events: none; }
+.window:hover { border-color: var(--leaf-600); }
+.window.is-selected {
+  border-color: var(--leaf-600);
+  background: var(--leaf-50);
+  box-shadow: inset 0 0 0 1px var(--leaf-600);
+}
+.window-content { display: flex; flex-direction: column; gap: 2px; }
+.window-day { font-weight: 600; color: var(--ink-900); font-size: 0.98rem; }
+.window-time { font-size: 0.85rem; color: var(--ink-500); }
+.window.is-selected .window-time { color: var(--leaf-700); }
+.window-radio {
+  width: 20px; height: 20px; border-radius: 50%;
+  border: 1.5px solid var(--ink-300);
+  display: flex; align-items: center; justify-content: center;
+  background: var(--paper);
+}
+.window.is-selected .window-radio { border-color: var(--leaf-600); }
+.window-radio-dot {
+  width: 10px; height: 10px; border-radius: 50%;
+  background: var(--leaf-600);
+  transform: scale(0);
+  transition: transform 0.15s;
+}
+.window.is-selected .window-radio-dot { transform: scale(1); }
+
+/* ── Notes ──────────────────────────────────────────── */
+.notes { margin-bottom: 32px; }
+
+/* ── Submit block ──────────────────────────────────────── */
+.submit-block {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  padding: 18px 20px 22px;
+  margin-bottom: 24px;
+}
+.submit-summary { margin-bottom: 16px; }
+.summary-line {
+  display: flex; justify-content: space-between; align-items: baseline;
+  margin-bottom: 4px;
+}
+.summary-label { font-size: 0.95rem; color: var(--ink-700); }
+.summary-total {
+  font-family: var(--serif);
+  font-size: 1.6rem; font-weight: 600;
+  color: var(--ink-900);
+}
+.summary-sub { font-size: 0.85rem; color: var(--ink-500); }
+
+.submit-btn {
+  width: 100%; min-height: 52px; font-size: 1.02rem;
+}
+.submit-btn:disabled { background: var(--ink-300); cursor: default; }
+.submit-fine {
+  margin-top: 12px;
+  font-size: 0.8rem; color: var(--ink-500);
+  text-align: center; line-height: 1.5;
+}
+
+/* ── Footer ──────────────────────────────────────────── */
+.page-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding-top: 24px; border-top: 1px solid var(--ink-200);
+  font-size: 0.78rem; color: var(--ink-500);
+  flex-wrap: wrap; gap: 8px;
+}
+
+/* ── Sticky bar (mobile) ──────────────────────────────── */
+.sticky-bar {
+  position: fixed; bottom: 0; left: 0; right: 0;
+  background: var(--paper);
+  border-top: 1px solid var(--ink-200);
+  padding: 10px 16px 14px;
+  display: grid; grid-template-columns: 1fr auto;
+  gap: 12px; align-items: center;
+  transform: translateY(110%);
+  transition: transform 0.22s ease-out;
+  box-shadow: 0 -8px 24px -16px rgba(0,0,0,0.18);
+  z-index: 50;
+}
+.sticky-bar.is-active { transform: translateY(0); }
+.sticky-summary { display: flex; flex-direction: column; gap: 0; }
+.sticky-count { font-size: 0.78rem; color: var(--ink-500); }
+.sticky-total {
+  font-family: var(--serif);
+  font-size: 1.4rem; font-weight: 600; line-height: 1.1;
+}
+.sticky-btn { min-height: 48px; padding: 0 22px; font-size: 0.95rem; }
+
+/* ── Right rail (desktop) ──────────────────────────────────── */
+.page-cols { display: block; }
+.page-rail { display: none; }
+.page-main { display: block; }
+
+/* ── Responsive (driven by .vp-* class on .order-page, set by host) ─── */
+.order-page.vp-desktop .page-shell { max-width: 1080px; padding: 40px 32px 40px; }
+.order-page.vp-desktop .page-cols {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: 36px;
+  align-items: start;
+}
+.order-page.vp-desktop .page-main { min-width: 0; }
+.order-page.vp-desktop .page-rail { display: block; position: sticky; top: 24px; }
+
+.order-page.vp-desktop .page-title { font-size: 2.5rem; }
+.order-page.vp-desktop { padding-bottom: 0; }
+.order-page.vp-desktop .sticky-bar { display: none; }
+.order-page.vp-desktop .submit-block { display: none; }
+
+.order-page.vp-desktop .item-row { padding: 18px 20px; grid-template-columns: 64px 1fr auto; gap: 18px; }
+.order-page.vp-desktop .item-thumb { width: 64px; height: 64px; }
+.order-page.vp-desktop .item-name { font-size: 1.05rem; }
+
+/* Desktop two-column only when the host viewport actually has room for it */
+@media (min-width: 1100px) {
+  .order-page.vp-desktop .page-shell { max-width: 1180px; padding-left: 48px; padding-right: 48px; }
+  .order-page.vp-desktop .page-cols { grid-template-columns: minmax(0, 1fr) 380px; gap: 48px; }
+}
+@media (max-width: 1099px) {
+  .order-page.vp-desktop .page-cols { display: block; }
+  .order-page.vp-desktop .page-rail { display: none; }
+  .order-page.vp-desktop .submit-block { display: block; }
+}
+
+/* Tablet keeps single-column but a touch wider/looser */
+.order-page.vp-tablet .page-shell { max-width: 760px; padding: 32px 28px; }
+
+/* ── Right rail card ──────────────────────────────────────── */
+.rail-card {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  padding: 20px 22px 22px;
+}
+.rail-card .eyebrow { margin-bottom: 14px; }
+.rail-empty {
+  font-size: 0.9rem; color: var(--ink-500);
+  padding: 14px 0;
+  border-bottom: 1px solid var(--ink-200);
+  margin-bottom: 16px;
+}
+.rail-list {
+  list-style: none; padding: 0; margin: 0 0 14px;
+  border-bottom: 1px solid var(--ink-200); padding-bottom: 14px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.rail-list li {
+  display: flex; justify-content: space-between; gap: 10px;
+  font-size: 0.9rem;
+}
+.rail-name { color: var(--ink-900); }
+.rail-qty { color: var(--ink-500); font-weight: 600; margin-right: 4px; }
+.rail-amt { color: var(--ink-700); font-variant-numeric: tabular-nums; }
+
+.rail-totals {
+  display: flex; flex-direction: column; gap: 6px;
+  margin-bottom: 18px;
+}
+.rail-row {
+  display: flex; justify-content: space-between; align-items: baseline;
+  font-size: 0.9rem; color: var(--ink-700);
+}
+.rail-row-total {
+  padding-top: 10px; margin-top: 4px;
+  border-top: 1px solid var(--ink-200);
+  font-size: 1rem; color: var(--ink-900);
+}
+.rail-row-total .mono {
+  font-family: var(--serif);
+  font-size: 1.3rem; font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.rail-submit { width: 100%; min-height: 50px; }
+.rail-submit:disabled { background: var(--ink-300); cursor: default; }
+.rail-fine { margin-top: 12px; font-size: 0.78rem; color: var(--ink-500); text-align: center; }

--- a/design/order-page.jsx
+++ b/design/order-page.jsx
@@ -1,0 +1,404 @@
+/* Customer order page — bushel
+ * Mobile-first responsive. State driven by tweaks.
+ */
+
+const { useState, useMemo, useEffect } = React;
+
+// ───── Data ──────────────────────────────────────────────────────────
+const INVENTORY = [
+{ id: "tomato", name: "Heirloom tomatoes", unit: "lb", price: 5.50, avail: 24 },
+{ id: "kale", name: "Dino kale", unit: "bunch", price: 4.50, avail: 18 },
+{ id: "lettuce", name: "Salanova lettuce", unit: "head", price: 5.00, avail: 14 },
+{ id: "beets", name: "Red beets", unit: "lb", price: 3.25, avail: 22 },
+{ id: "carrots", name: "Rainbow carrots", unit: "bunch", price: 4.75, avail: 11 },
+{ id: "shallots", name: "Shallots", unit: "lb", price: 6.00, avail: 8 },
+{ id: "basil", name: "Genovese basil", unit: "bunch", price: 3.50, avail: 6 },
+{ id: "flowers", name: "Mixed bouquet", unit: "stem", price: 12.00, avail: 7 },
+{ id: "garlic", name: "Music garlic", unit: "head", price: 2.50, avail: 0 }];
+
+
+const PICKUP_WINDOWS = [
+{ id: "w1", label: "Wednesday", time: "10am – 12pm" },
+{ id: "w2", label: "Wednesday", time: "4pm – 6pm" },
+{ id: "w3", label: "Thursday", time: "10am – 12pm" },
+{ id: "w4", label: "Thursday", time: "4pm – 6pm" }];
+
+
+const CUSTOMER = {
+  name: "Lake Road Market",
+  contact: "Maya",
+  address: "16100 Detroit Ave, Lakewood, OH 44107"
+};
+
+// ───── Building blocks ──────────────────────────────────────────────
+function Eyebrow({ children, className }) {
+  return <div className={"eyebrow " + (className || "")}>{children}</div>;
+}
+
+function Stepper({ value, onChange, max, disabled }) {
+  const dec = () => !disabled && onChange(Math.max(0, value - 1));
+  const inc = () => !disabled && value < max && onChange(value + 1);
+  const can_dec = !disabled && value > 0;
+  const can_inc = !disabled && value < max;
+  return (
+    <div className="stepper" role="group" aria-label="quantity">
+      <button
+        className="stepper-btn"
+        onClick={dec}
+        disabled={!can_dec}
+        aria-label="decrease">
+        −</button>
+      <div className="stepper-val">{value}</div>
+      <button
+        className="stepper-btn"
+        onClick={inc}
+        disabled={!can_inc}
+        aria-label="increase">
+        +</button>
+    </div>);
+
+}
+
+function ItemRow({ item, qty, onQty, soldOut }) {
+  const out = soldOut || item.avail === 0;
+  const remaining = out ? 0 : item.avail - qty;
+  return (
+    <div className={"item-row" + (out ? " is-sold-out" : "")}>
+      <div className="item-thumb" aria-hidden="true">
+        <div className="item-thumb-inner"></div>
+      </div>
+      <div className="item-body">
+        <div className="item-line1">
+          <div className="item-name">{item.name}</div>
+          <div className="item-price">
+            <span className="mono">${item.price.toFixed(2)}</span>
+            <span className="item-per"> / {item.unit}</span>
+          </div>
+        </div>
+        <div className="item-line2">
+          {out ?
+          <span className="item-meta meta-sold-out">Sold out</span> :
+          remaining <= 3 ?
+          <span className="item-meta meta-low">only {remaining} {item.unit}{remaining !== 1 ? "s" : ""} left</span> :
+
+          <span className="item-meta">{remaining} {item.unit}{remaining !== 1 ? "s" : ""} available</span>
+          }
+        </div>
+      </div>
+      <div className="item-stepper">
+        <Stepper
+          value={qty}
+          onChange={onQty}
+          max={item.avail}
+          disabled={out} />
+        
+      </div>
+    </div>);
+
+}
+
+function FulfillmentTab({ active, onClick, label, sublabel }) {
+  return (
+    <button
+      className={"fulfill-tab" + (active ? " is-active" : "")}
+      onClick={onClick}>
+      
+      <div className="fulfill-tab-label">{label}</div>
+      <div className="fulfill-tab-sub">{sublabel}</div>
+    </button>);
+
+}
+
+// ───── Page ─────────────────────────────────────────────────────────
+function OrderPage({ tweaks }) {
+  const [qty, setQty] = useState({
+    tomato: 4, kale: 6, lettuce: 0, beets: 2, carrots: 0,
+    shallots: 0, basil: 0, flowers: 0, garlic: 0
+  });
+  const [mode, setMode] = useState(tweaks.mode || "delivery");
+  const [window, setWindow] = useState("w1");
+  const [notes, setNotes] = useState("");
+  const [editingAddr, setEditingAddr] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  // Sync mode from tweaks
+  useEffect(() => {if (tweaks.mode) setMode(tweaks.mode);}, [tweaks.mode]);
+
+  // Force-sold-out tweak
+  const inventory = useMemo(() => {
+    if (!tweaks.forceSoldOut) return INVENTORY;
+    return INVENTORY.map((i) => i.id === "basil" ? { ...i, avail: 0 } : i);
+  }, [tweaks.forceSoldOut]);
+
+  useEffect(() => {
+    if (tweaks.forceSoldOut) setQty((q) => ({ ...q, basil: 0 }));
+  }, [tweaks.forceSoldOut]);
+
+  const setItemQty = (id, n) => setQty((q) => ({ ...q, [id]: n }));
+
+  const items_with_qty = inventory.filter((i) => qty[i.id] > 0);
+  const subtotal = items_with_qty.reduce((s, i) => s + qty[i.id] * i.price, 0);
+  const itemCount = items_with_qty.reduce((s, i) => s + qty[i.id], 0);
+  const lineCount = items_with_qty.length;
+
+  const submit = () => {
+    if (lineCount === 0) return;
+    setSubmitted(true);
+    setTimeout(() => setSubmitted(false), 2400);
+  };
+
+  return (
+    <div className={"order-page vp-" + (tweaks.viewport || "mobile")}>
+      {/* Top brand strip */}
+      <div className="brand-strip">
+        <div className="brand-mark">
+          <span className="brand-leaf" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+              <path d="M21.5 2.5c0 8-4.5 14.5-12 14.5-1.4 0-2.8-.2-4-.7l1.4-1.4c.8.2 1.7.4 2.6.4 6 0 9.5-5.3 10-12.3-2 .6-7.4 2.6-10.4 7.4-1 1.6-1.5 3.4-1.7 5.4l-1.5 1.5c0-3.3.7-6.3 2.4-8.7C11.4 4 18.4 2.6 21.5 2.5z" />
+            </svg>
+          </span>
+          <span className="brand-name">Bay Branch Farm</span>
+        </div>
+        <a href="#help" className="brand-help">Help</a>
+      </div>
+
+      <div className="page-shell">
+
+        {/* Header ─────────────────────────────────────── */}
+        <header className="page-head">
+          <Eyebrow>this week · may 3 – may 9</Eyebrow>
+          <h1 className="page-title">What's available</h1>
+          <p className="page-greet">
+            Hi, {CUSTOMER.contact} at <span className="customer-name">{CUSTOMER.name}</span>.
+            Order by Tuesday 9pm.
+          </p>
+
+          {tweaks.showNote &&
+          <div className="annabels-note">
+              <Eyebrow>note from annabel</Eyebrow>
+              <p>
+                <em>"Heirloom tomatoes are exceptional this week — first real flush from the high tunnel.
+                Basil is winding down before the cool nights."</em>
+              </p>
+            </div>
+          }
+        </header>
+
+        {/* Two-column desktop layout */}
+        <div className="page-cols">
+
+          <div className="page-main">
+
+            {/* Inventory ──────────────────────────────────── */}
+            <section className="inv">
+              <div className="inv-head">
+                <Eyebrow>availability</Eyebrow>
+                <span className="inv-count">{inventory.filter((i) => i.avail > 0).length} items</span>
+              </div>
+              <div className="item-list">
+                {inventory.map((i) =>
+                <ItemRow
+                  key={i.id}
+                  item={i}
+                  qty={qty[i.id] || 0}
+                  onQty={(n) => setItemQty(i.id, n)} />
+
+                )}
+              </div>
+            </section>
+
+            {/* Fulfillment ──────────────────────────────── */}
+            <section className="fulfill">
+              <Eyebrow>fulfillment</Eyebrow>
+              <h2 className="section-title">How would you like it?</h2>
+              <div className="fulfill-tabs">
+                <FulfillmentTab
+                  active={mode === "delivery"}
+                  onClick={() => setMode("delivery")}
+                  label="Delivery"
+                  sublabel="Wednesday morning" />
+                
+                <FulfillmentTab
+                  active={mode === "pickup"}
+                  onClick={() => setMode("pickup")}
+                  label="Pickup at farm"
+                  sublabel="3612 W 114th, Cleveland" />
+                
+              </div>
+
+              {mode === "delivery" ?
+              <div className="fulfill-detail">
+                  <div className="addr-row">
+                    <div className="addr-stack">
+                      <div className="label-sm">Delivery to</div>
+                      {editingAddr ?
+                    <textarea
+                      className="textarea"
+                      rows="2"
+                      defaultValue={CUSTOMER.address}
+                      onBlur={() => setEditingAddr(false)}
+                      autoFocus /> :
+
+
+                    <div className="addr-text">{CUSTOMER.address}</div>
+                    }
+                    </div>
+                    {!editingAddr &&
+                  <button
+                    className="link-btn"
+                    onClick={() => setEditingAddr(true)}>
+                    Edit</button>
+                  }
+                  </div>
+                  <div className="fulfill-help">
+                    Wednesday between 8am and noon. We'll text when we're 30 minutes out.
+                  </div>
+                </div> :
+
+              <div className="fulfill-detail">
+                  <div className="label-sm" style={{ marginBottom: 10 }}>Pick a window</div>
+                  <div className="windows">
+                    {PICKUP_WINDOWS.map((w) =>
+                  <label
+                    key={w.id}
+                    className={"window" + (window === w.id ? " is-selected" : "")}>
+                    
+                        <input
+                      type="radio"
+                      name="window"
+                      checked={window === w.id}
+                      onChange={() => setWindow(w.id)} />
+                    
+                        <div className="window-content">
+                          <div className="window-day">{w.label}</div>
+                          <div className="window-time">{w.time}</div>
+                        </div>
+                        <div className="window-radio" aria-hidden="true">
+                          <div className="window-radio-dot"></div>
+                        </div>
+                      </label>
+                  )}
+                  </div>
+                  <div className="fulfill-help">
+                    Pick up at the farm. Annabel will text you the morning of.
+                  </div>
+                </div>
+              }
+            </section>
+
+            {/* Notes ──────────────────────────────────── */}
+            <section className="notes">
+              <Eyebrow>notes</Eyebrow>
+              <h2 className="section-title">Anything else?</h2>
+              <textarea
+                className="textarea"
+                rows="3"
+                placeholder="Optional. Anything Annabel should know — substitutions you're open to, bunch sizes, etc."
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)} />
+              
+            </section>
+
+            {/* Submit row (visible at end of scroll on mobile, primary on desktop) */}
+            <section className="submit-block" style={{ fontFamily: "-apple-system" }}>
+              <div className="submit-summary">
+                <div className="summary-line">
+                  <span className="summary-label">{lineCount} item{lineCount !== 1 ? "s" : ""}</span>
+                  <span className="summary-total mono">${subtotal.toFixed(2)}</span>
+                </div>
+                <div className="summary-sub">
+                  {mode === "delivery" ?
+                  "Wednesday delivery to " + CUSTOMER.address.split(",")[0] :
+                  "Pickup " + PICKUP_WINDOWS.find((w) => w.id === window)?.label + " " + PICKUP_WINDOWS.find((w) => w.id === window)?.time}
+                </div>
+              </div>
+              <button
+                className="btn btn-primary submit-btn"
+                onClick={submit}
+                disabled={lineCount === 0}>
+                
+                {submitted ? "Order placed — thanks." : "Submit order"}
+              </button>
+              <p className="submit-fine">
+                You'll get a text confirmation. To change anything, text Annabel at 216-202-5718.
+              </p>
+            </section>
+          </div>
+
+          {/* Right rail — desktop only */}
+          <aside className="page-rail">
+            <div className="rail-card">
+              <Eyebrow>your order</Eyebrow>
+              {lineCount === 0 ?
+              <div className="rail-empty">
+                  Nothing selected yet. Tap <span className="mono">+</span> on items above.
+                </div> :
+
+              <ul className="rail-list">
+                  {items_with_qty.map((i) =>
+                <li key={i.id}>
+                      <span className="rail-name">
+                        <span className="rail-qty mono">{qty[i.id]}×</span> {i.name}
+                      </span>
+                      <span className="rail-amt mono">
+                        ${(qty[i.id] * i.price).toFixed(2)}
+                      </span>
+                    </li>
+                )}
+                </ul>
+              }
+              <div className="rail-totals">
+                <div className="rail-row">
+                  <span>Subtotal</span>
+                  <span className="mono">${subtotal.toFixed(2)}</span>
+                </div>
+                <div className="rail-row">
+                  <span>{mode === "delivery" ? "Delivery" : "Pickup"}</span>
+                  <span className="mono" style={{ color: "var(--ink-500)" }}>
+                    {mode === "delivery" ? "free" : "—"}
+                  </span>
+                </div>
+                <div className="rail-row rail-row-total">
+                  <span>Total</span>
+                  <span className="mono">${subtotal.toFixed(2)}</span>
+                </div>
+              </div>
+              <button
+                className="btn btn-primary rail-submit"
+                onClick={submit}
+                disabled={lineCount === 0}>
+                
+                {submitted ? "Order placed — thanks." : "Submit order"}
+              </button>
+              <div className="rail-fine">
+                Text Annabel to change anything · 216-202-5718
+              </div>
+            </div>
+          </aside>
+        </div>
+
+        <footer className="page-foot">
+          <div>Bay Branch Farm · 3612 W 114th St, Cleveland</div>
+          <div className="mono" style={{ color: "var(--ink-500)" }}>order.baybranchfarm.com/c/k4f8x2</div>
+        </footer>
+      </div>
+
+      {/* Sticky bottom bar — mobile only */}
+      <div className={"sticky-bar" + (lineCount > 0 ? " is-active" : "")}>
+        <div className="sticky-summary">
+          <div className="sticky-count">{itemCount} item{itemCount !== 1 ? "s" : ""}</div>
+          <div className="sticky-total mono">${subtotal.toFixed(2)}</div>
+        </div>
+        <button
+          className="btn btn-primary sticky-btn"
+          onClick={submit}
+          disabled={lineCount === 0}>
+          
+          {submitted ? "✓ Placed" : "Review & submit"}
+        </button>
+      </div>
+    </div>);
+
+}
+
+window.OrderPage = OrderPage;

--- a/design/status-pages.css
+++ b/design/status-pages.css
@@ -1,0 +1,138 @@
+/* Customer status pages — shared styles */
+
+.status-page {
+  background: var(--cream);
+  min-height: 100vh;
+  color: var(--ink-900);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.55;
+  display: flex; flex-direction: column;
+}
+.status-page.tone-leaf { background: var(--cream); }
+
+.status-shell {
+  flex: 1;
+  max-width: 540px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 36px 22px 40px;
+  display: flex; flex-direction: column;
+}
+
+.status-art {
+  margin: 8px auto 22px;
+  display: flex; justify-content: center;
+}
+.status-art.is-mark { margin: 8px auto 16px; }
+
+.status-eyebrow { margin-bottom: 10px; text-align: left; }
+
+.status-title {
+  font-family: var(--serif);
+  font-size: 1.85rem;
+  font-weight: 600;
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  margin-bottom: 12px;
+  text-wrap: pretty;
+}
+.status-lede {
+  font-size: 1.02rem;
+  color: var(--ink-700);
+  margin-bottom: 26px;
+  max-width: 36ch;
+}
+
+.status-meta {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  padding: 4px 16px;
+  margin-bottom: 24px;
+}
+.status-meta-row {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding: 12px 0;
+  border-top: 1px solid var(--ink-200);
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.status-meta-row:first-child { border-top: 0; }
+.status-meta-key { font-size: 0.85rem; color: var(--ink-500); }
+.status-meta-val { font-size: 0.92rem; font-weight: 600; color: var(--ink-900); }
+
+.status-actions { display: flex; flex-direction: column; gap: 10px; margin-bottom: 18px; }
+.status-btn { width: 100%; min-height: 48px; }
+
+.status-fine {
+  font-size: 0.82rem; color: var(--ink-500);
+  text-align: center; line-height: 1.55;
+  padding: 0 8px;
+}
+
+.status-foot {
+  text-align: center;
+  font-size: 0.78rem; color: var(--ink-500);
+  padding: 18px 22px 28px;
+}
+
+/* Confirmed-specific bits */
+.confirm-card {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  padding: 16px 18px 14px;
+  margin-bottom: 14px;
+}
+.confirm-card-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  margin-bottom: 12px;
+}
+.confirm-week { font-size: 0.78rem; color: var(--ink-500); }
+.confirm-list { list-style: none; padding: 0; margin: 0; }
+.confirm-list li {
+  display: flex; justify-content: space-between; gap: 12px;
+  padding: 8px 0;
+  border-top: 1px solid var(--ink-200);
+}
+.confirm-list li:first-child { border-top: 0; padding-top: 0; }
+.confirm-line-name {
+  display: flex; align-items: baseline; gap: 6px; flex-wrap: wrap;
+  min-width: 0;
+}
+.confirm-qty { color: var(--leaf-700); font-weight: 600; }
+.confirm-unit { color: var(--ink-500); font-size: 0.85rem; }
+.confirm-amt { color: var(--ink-900); font-variant-numeric: tabular-nums; flex-shrink: 0; }
+.confirm-total {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding-top: 12px; margin-top: 8px;
+  border-top: 1px solid var(--ink-300);
+}
+.confirm-total > span:first-child { font-weight: 600; }
+.confirm-total .mono {
+  font-family: var(--serif);
+  font-size: 1.4rem; font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.confirm-fulfill {
+  background: var(--leaf-50);
+  border: 1px solid var(--leaf-100);
+  border-radius: var(--r-md);
+  padding: 14px 16px;
+  margin-bottom: 14px;
+}
+.confirm-fulfill-row {
+  display: grid; grid-template-columns: 90px 1fr; gap: 14px;
+  align-items: start;
+}
+.confirm-fulfill-key {
+  font-size: 0.72rem; font-weight: 600; text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--leaf-700);
+  padding-top: 2px;
+}
+.confirm-fulfill-val { font-size: 0.95rem; color: var(--ink-900); font-weight: 600; }
+.confirm-fulfill-sub { font-size: 0.85rem; color: var(--ink-700); font-weight: 400; margin-top: 2px; }
+
+.status-callout { margin-bottom: 22px; align-items: flex-start; }

--- a/design/status-pages.jsx
+++ b/design/status-pages.jsx
@@ -1,0 +1,199 @@
+/* Customer status pages — closed, confirmed, invalid */
+
+const { useState } = React;
+
+function StatusShell({ children, tone }) {
+  return (
+    <div className={"status-page tone-" + (tone || "neutral")}>
+      <div className="brand-strip">
+        <div className="brand-mark">
+          <span className="brand-leaf" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+              <path d="M21.5 2.5c0 8-4.5 14.5-12 14.5-1.4 0-2.8-.2-4-.7l1.4-1.4c.8.2 1.7.4 2.6.4 6 0 9.5-5.3 10-12.3-2 .6-7.4 2.6-10.4 7.4-1 1.6-1.5 3.4-1.7 5.4l-1.5 1.5c0-3.3.7-6.3 2.4-8.7C11.4 4 18.4 2.6 21.5 2.5z"/>
+            </svg>
+          </span>
+          <span className="brand-name">Bay Branch Farm</span>
+        </div>
+      </div>
+      <div className="status-shell">{children}</div>
+      <footer className="status-foot">
+        <div>Bay Branch Farm · 3612 W 114th St, Cleveland</div>
+      </footer>
+    </div>
+  );
+}
+
+/* ── 1. Closed ────────────────────────────────────────── */
+function ClosedPage() {
+  return (
+    <StatusShell tone="neutral">
+      <div className="status-art">
+        {/* "vegetables resting" — three vegetable forms tucked in a basket-shaped curve */}
+        <svg viewBox="0 0 240 160" width="220" height="146" aria-hidden="true">
+          {/* basket curve / ground */}
+          <path d="M30 110 Q120 152 210 110" fill="none" stroke="#3B6D11" strokeOpacity="0.35" strokeWidth="1.5"/>
+          <path d="M40 108 Q120 138 200 108" fill="#EDF5E5" stroke="#3B6D11" strokeOpacity="0.5" strokeWidth="1"/>
+          {/* carrot, lying down */}
+          <g transform="translate(60 92) rotate(-12)">
+            <path d="M0 0 L48 4 L52 12 L4 14 Z" fill="#E6A817"/>
+            <path d="M-6 -6 Q-3 -10 0 -8 M-2 -10 Q1 -14 4 -12 M2 -8 Q5 -14 9 -10" stroke="#3B6D11" strokeWidth="1.4" fill="none" strokeLinecap="round"/>
+          </g>
+          {/* beet, round */}
+          <g transform="translate(120 80)">
+            <ellipse cx="0" cy="14" rx="18" ry="14" fill="#B23B2E" opacity="0.85"/>
+            <path d="M-8 0 Q-6 -10 0 -12 M0 0 Q1 -12 6 -14 M6 0 Q10 -10 14 -8" stroke="#3B6D11" strokeWidth="1.6" fill="none" strokeLinecap="round"/>
+          </g>
+          {/* lettuce ball */}
+          <g transform="translate(170 90)">
+            <circle r="16" fill="#4F8A1B" opacity="0.85"/>
+            <circle r="11" fill="#5fa825" opacity="0.6"/>
+            <path d="M-10 -6 Q-4 -12 4 -10 M-6 0 Q2 -8 10 -4" stroke="#FBFAF5" strokeOpacity="0.6" strokeWidth="1" fill="none"/>
+          </g>
+          {/* gentle z's overhead */}
+          <text x="100" y="36" fontFamily="serif" fontStyle="italic" fontSize="22" fill="#3B6D11" opacity="0.55">z</text>
+          <text x="118" y="26" fontFamily="serif" fontStyle="italic" fontSize="16" fill="#3B6D11" opacity="0.4">z</text>
+          <text x="132" y="20" fontFamily="serif" fontStyle="italic" fontSize="12" fill="#3B6D11" opacity="0.3">z</text>
+        </svg>
+      </div>
+      <div className="status-eyebrow eyebrow">this week · closed</div>
+      <h1 className="status-title">Ordering's closed for this week.</h1>
+      <p className="status-lede">
+        We open again <strong>Sunday morning</strong>. You'll get a text from Annabel
+        when this week's list is up.
+      </p>
+      <div className="status-meta">
+        <div className="status-meta-row">
+          <span className="status-meta-key">Last week's order</span>
+          <span className="status-meta-val mono">$184.50 · delivered Wed</span>
+        </div>
+        <div className="status-meta-row">
+          <span className="status-meta-key">Next opening</span>
+          <span className="status-meta-val">Sun, May 11 · ~8am</span>
+        </div>
+      </div>
+      <div className="status-actions">
+        <a href="sms:2162025718" className="btn btn-secondary status-btn">
+          Text Annabel · 216-202-5718
+        </a>
+      </div>
+    </StatusShell>
+  );
+}
+
+/* ── 2. Confirmed ───────────────────────────────────────── */
+function ConfirmedPage() {
+  const items = [
+    { name: "Heirloom tomatoes", qty: 4, unit: "lb",     price: 5.50 },
+    { name: "Dino kale",         qty: 6, unit: "bunch",  price: 4.50 },
+    { name: "Red beets",         qty: 2, unit: "lb",     price: 3.25 },
+    { name: "Genovese basil",    qty: 3, unit: "bunch",  price: 3.50 },
+  ];
+  const total = items.reduce((s, i) => s + i.qty * i.price, 0);
+
+  return (
+    <StatusShell tone="leaf">
+      <div className="status-art is-mark">
+        {/* Sprout / check */}
+        <svg viewBox="0 0 80 80" width="76" height="76" aria-hidden="true">
+          <circle cx="40" cy="40" r="38" fill="#EDF5E5" stroke="#3B6D11" strokeOpacity="0.3" strokeWidth="1"/>
+          <path d="M40 56 Q40 42 32 36 Q26 32 26 28 Q34 28 38 32 Q40 26 40 22 Q42 26 44 32 Q48 28 56 28 Q56 32 50 36 Q42 42 42 56 Z" fill="#4F8A1B"/>
+          <path d="M40 58 L40 50" stroke="#3B6D11" strokeWidth="2" strokeLinecap="round"/>
+        </svg>
+      </div>
+      <div className="status-eyebrow eyebrow">order received · #0503-04</div>
+      <h1 className="status-title">Order received, Maya.</h1>
+      <p className="status-lede">
+        Thanks. Annabel will text you Wednesday morning with delivery details.
+      </p>
+
+      <div className="confirm-card">
+        <div className="confirm-card-head">
+          <div className="eyebrow">summary</div>
+          <span className="confirm-week mono">week of may 3</span>
+        </div>
+        <ul className="confirm-list">
+          {items.map(i => (
+            <li key={i.name}>
+              <span className="confirm-line-name">
+                <span className="confirm-qty mono">{i.qty}×</span>
+                <span>{i.name}</span>
+                <span className="confirm-unit"> · {i.unit}</span>
+              </span>
+              <span className="confirm-amt mono">${(i.qty * i.price).toFixed(2)}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="confirm-total">
+          <span>Total</span>
+          <span className="mono">${total.toFixed(2)}</span>
+        </div>
+      </div>
+
+      <div className="confirm-fulfill">
+        <div className="confirm-fulfill-row">
+          <div className="confirm-fulfill-key">Delivery</div>
+          <div className="confirm-fulfill-val">
+            <div>Wed, May 6 · between 8am – noon</div>
+            <div className="confirm-fulfill-sub">16100 Detroit Ave, Lakewood</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="callout callout-info status-callout">
+        <div>
+          <strong>An invoice will follow from Annabel via Wave.</strong>
+          <div style={{marginTop: 4, color: "var(--ink-700)"}}>
+            Pay at delivery — cash, check, Venmo, or PayPal.
+          </div>
+        </div>
+      </div>
+
+      <div className="status-actions">
+        <a href="sms:2162025718" className="btn btn-secondary status-btn">
+          Need a change? Text Annabel · 216-202-5718
+        </a>
+      </div>
+    </StatusShell>
+  );
+}
+
+/* ── 3. Invalid link ────────────────────────────────────── */
+function InvalidPage() {
+  return (
+    <StatusShell tone="muted">
+      <div className="status-art">
+        {/* broken/withered link icon */}
+        <svg viewBox="0 0 200 140" width="180" height="126" aria-hidden="true">
+          {/* broken stem */}
+          <path d="M40 100 L80 70" stroke="#3B6D11" strokeOpacity="0.5" strokeWidth="3" strokeLinecap="round"/>
+          <path d="M120 70 L160 40" stroke="#3B6D11" strokeOpacity="0.5" strokeWidth="3" strokeLinecap="round"/>
+          {/* gap */}
+          <circle cx="92" cy="62" r="2.5" fill="#3B6D11" opacity="0.4"/>
+          <circle cx="100" cy="56" r="2" fill="#3B6D11" opacity="0.3"/>
+          <circle cx="108" cy="62" r="2.5" fill="#3B6D11" opacity="0.4"/>
+          {/* leaf ends */}
+          <path d="M40 100 Q30 96 28 88 Q36 90 42 96 Z" fill="#3B6D11" opacity="0.45"/>
+          <path d="M160 40 Q170 44 172 52 Q164 50 158 44 Z" fill="#3B6D11" opacity="0.45"/>
+        </svg>
+      </div>
+      <div className="status-eyebrow eyebrow">link expired</div>
+      <h1 className="status-title">This link doesn't work anymore.</h1>
+      <p className="status-lede">
+        Text Annabel and she'll send a fresh one.
+      </p>
+      <div className="status-actions">
+        <a href="sms:2162025718" className="btn btn-primary status-btn">
+          Text Annabel · 216-202-5718
+        </a>
+      </div>
+      <p className="status-fine">
+        Links expire when they're regenerated — usually if a phone changes hands
+        at one of our partners.
+      </p>
+    </StatusShell>
+  );
+}
+
+window.ClosedPage = ClosedPage;
+window.ConfirmedPage = ConfirmedPage;
+window.InvalidPage = InvalidPage;

--- a/design/tokens.css
+++ b/design/tokens.css
@@ -1,0 +1,119 @@
+/* bushel — design tokens */
+:root {
+  /* leaf greens */
+  --leaf-900: #1F3A08;
+  --leaf-700: #2C5310;
+  --leaf-600: #3B6D11;
+  --leaf-500: #4F8A1B;
+  --leaf-100: #EDF5E5;
+  --leaf-50:  #F4F8EE;
+
+  /* paper / ink */
+  --cream:    #FBFAF5;
+  --paper:    #FFFFFF;
+  --ink-900:  #1A1A1A;
+  --ink-700:  #3A3A38;
+  --ink-500:  #6E6E6A;
+  --ink-300:  #C8C7C1;
+  --ink-200:  #E4E2DA;
+
+  /* accents */
+  --amber-600: #E6A817;
+  --amber-50:  #FFF7E0;
+  --rose-600:  #B23B2E;
+
+  /* radii */
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-pill: 999px;
+
+  /* type
+     --sans:    workhorse, used for everything in product UI (incl. headings)
+     --display: Playfair — reserved for marketing moments only (e.g. customer
+                landing hero). Do NOT use in admin / working UI.
+     --serif:   legacy alias kept pointing at --sans so older rules using
+                var(--serif) collapse cleanly into the sans treatment. */
+  --sans:    "Source Sans 3", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --display: "Playfair Display", Georgia, serif;
+  --serif:   var(--sans);
+  --mono:    ui-monospace, "JetBrains Mono", "SFMono-Regular", Menlo, monospace;
+
+  /* shadow */
+  --hairline: 0 1px 0 rgba(0,0,0,0.04);
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body { background: var(--cream); color: var(--ink-900); font-family: var(--sans); font-size: 16px; line-height: 1.55; -webkit-font-smoothing: antialiased; }
+
+a { color: var(--leaf-600); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 2px; }
+a:hover { color: var(--leaf-700); }
+
+h1, h2, h3, h4 { font-family: var(--sans); font-weight: 600; color: var(--ink-900); line-height: 1.15; letter-spacing: -0.012em; }
+
+.eyebrow {
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--leaf-600);
+}
+
+.mono { font-family: var(--mono); font-size: 0.88em; }
+
+/* buttons */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  font-family: var(--sans); font-weight: 600; font-size: 0.95rem;
+  padding: 10px 18px; border-radius: var(--r-sm); border: 1px solid transparent;
+  cursor: pointer; transition: background 0.12s, border-color 0.12s, color 0.12s;
+  min-height: 44px; line-height: 1;
+  white-space: nowrap;
+}
+.btn-primary { background: var(--leaf-600); color: var(--paper); }
+.btn-primary:hover { background: var(--leaf-700); }
+.btn-secondary { background: var(--paper); color: var(--leaf-700); border-color: var(--ink-300); }
+.btn-secondary:hover { border-color: var(--leaf-600); color: var(--leaf-600); }
+.btn-ghost { background: transparent; color: var(--leaf-700); }
+.btn-ghost:hover { background: var(--leaf-50); }
+.btn-destructive { background: var(--paper); color: var(--rose-600); border-color: var(--ink-300); }
+.btn-destructive:hover { border-color: var(--rose-600); }
+.btn-sm { padding: 6px 12px; font-size: 0.85rem; min-height: 32px; }
+
+/* inputs */
+.input, .textarea, .select {
+  font-family: var(--sans); font-size: 1rem; color: var(--ink-900);
+  background: var(--paper); border: 1px solid var(--ink-300); border-radius: var(--r-sm);
+  padding: 10px 12px; min-height: 44px; width: 100%;
+  transition: border-color 0.12s, box-shadow 0.12s;
+}
+.input:focus, .textarea:focus, .select:focus { outline: none; border-color: var(--leaf-600); box-shadow: 0 0 0 3px rgba(59,109,17,0.15); }
+.label { display: block; font-weight: 600; font-size: 0.85rem; margin-bottom: 6px; color: var(--ink-700); }
+
+/* badges */
+.badge {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-family: var(--sans); font-weight: 600; font-size: 0.72rem;
+  letter-spacing: 0.04em; text-transform: uppercase;
+  padding: 3px 9px; border-radius: var(--r-pill); white-space: nowrap;
+}
+.badge-new      { background: var(--leaf-100); color: var(--leaf-700); }
+.badge-ready    { background: var(--leaf-500); color: var(--paper); }
+.badge-done     { background: var(--ink-200); color: var(--ink-700); }
+.badge-recon    { background: var(--amber-50); color: #8b5e0a; border: 1px solid #e6cc8c; }
+
+/* cards */
+.card { background: var(--paper); border: 1px solid var(--ink-200); border-radius: var(--r-md); box-shadow: var(--hairline); }
+
+/* callouts */
+.callout {
+  border-radius: var(--r-sm); padding: 12px 16px; font-size: 0.92rem;
+  border-left: 3px solid; display: flex; gap: 10px; align-items: flex-start;
+}
+.callout-info { background: var(--leaf-50); border-color: var(--leaf-600); color: var(--ink-900); }
+.callout-warn { background: var(--amber-50); border-color: var(--amber-600); color: var(--ink-900); }
+
+/* hairline divider */
+.rule { height: 1px; background: var(--ink-200); border: 0; }
+.rule-leaf { height: 2px; background: var(--leaf-600); border: 0; width: 32px; }

--- a/docs/BRAND.md
+++ b/docs/BRAND.md
@@ -1,32 +1,129 @@
-# [Project Name] — Brand Direction
+# bushel — Brand
 
-## Name
-[Project Name]
+Bay Branch Farm's ordering system. One voice, two surfaces.
 
-## Tagline
-[Optional — or "none needed yet"]
+> **One-line voice:** "We grow food."
+>
+> Warm. B2B-professional. Unpretentious. The farmer texted you a link.
 
-## Philosophy
-[What's the app about at a human level? What values should it embody? What should every touchpoint communicate?]
-
-In practice this means:
-- [Specific behavior that reflects the philosophy]
-- [Another concrete example]
+---
 
 ## Voice
-[Practical / warm / playful / no-nonsense / etc.] What the app sounds like in error messages, labels, and empty states. What it should NOT sound like.
 
-## Visual Direction
-- **Style:** [shadcn preset ID, e.g., b7CSfQ4Xo / or "default"]
-- **Default mode:** [Dark / Light]
-- **Font:** [Font name] (heading + body)
-- **Border radius:** [xs / sm / md — pick one, use consistently]
-- **Shadows:** Cards shadow-sm, modals shadow-lg, nothing else.
-- **Color approach:** Semantic tokens (bg-background, bg-card, etc.) — no hardcoded Tailwind color classes for surfaces or text.
-- [Any brand-specific color notes — e.g., "amber for warnings is OK, it's a UX signal not brand color"]
+Plain words. Short sentences. No hospitality theater.
 
-## Anti-patterns
-[What to explicitly avoid — e.g., "no nautical kitsch", "no hero images", "don't gamify a B2B tool"]
+**Yes**
+- "This week's availability — order by Tuesday 9pm."
+- "Thanks. I'll text you Wednesday morning with pickup details."
+- "Heads up — we ran short on dino kale. I'll text Annabel to sort it out."
 
-## Priority
-Function over form. Polish is Phase [N].
+**No**
+- "You're on the list! 🎉"
+- "Your fresh, hand-picked produce journey begins now…"
+- "Oops! Something went wrong."
+
+Use lowercase for week labels and eyebrows ("this week", "ready to pick up"). Capitalize properly in body.
+
+---
+
+## Color
+
+| Token | Hex | Use |
+|---|---|---|
+| `--leaf-900` | `#1F3A08` | strong text on leaf bg |
+| `--leaf-700` | `#2C5310` | hover / borders / focus rings |
+| `--leaf-600` | `#3B6D11` | **primary** — buttons, links, accent rule |
+| `--leaf-500` | `#4F8A1B` | badge fill (Ready) |
+| `--leaf-100` | `#EDF5E5` | tag bg, subtle highlight |
+| `--leaf-50`  | `#F4F8EE` | row stripe, panel wash |
+| `--cream`    | `#FBFAF5` | **page background** |
+| `--paper`    | `#FFFFFF` | cards / inputs |
+| `--ink-900`  | `#1A1A1A` | primary text, admin sidebar bg |
+| `--ink-700`  | `#3A3A38` | secondary text |
+| `--ink-500`  | `#6E6E6A` | muted / placeholder |
+| `--ink-300`  | `#C8C7C1` | hairlines |
+| `--ink-200`  | `#E4E2DA` | row dividers, card borders |
+| `--amber-600`| `#E6A817` | **caution** — needs_reconciliation, warnings |
+| `--amber-50` | `#FFF7E0` | callout bg for caution |
+| `--rose-600` | `#B23B2E` | destructive only |
+
+Never use pure white or pure black. Never saturate above leaf-500. No gradients. No drop shadows beyond `0 1px 0 rgba(0,0,0,0.04)` on cards.
+
+---
+
+## Type
+
+- **Customer hero** — Playfair Display 600. Reserved for the customer order page "What's available" h1 only. Nowhere else in working UI.
+- **Body / UI** — Source Sans 3, 300/400/600. 1.5–1.6 leading.
+- **Eyebrows / labels** — Source Sans 3 600, `uppercase`, `letter-spacing: 0.08em`, `0.72rem`, leaf-600.
+- **Mono** — `ui-monospace, "JetBrains Mono", monospace`. Tokens, IDs, prices in tables.
+
+### Scale
+
+| Role | Size (mobile) | Size (desktop) |
+|---|---|---|
+| display (customer hero h1) | 2rem | 2.5rem |
+| h1 (status/admin) | 1.85rem | 2rem |
+| h2 | 1.4rem | 1.6rem |
+| body | 1rem | 0.95rem |
+| small | 0.85rem | 0.82rem |
+| eyebrow | 0.72rem | 0.72rem |
+
+Customer text: never below 14px on mobile. Admin tables: 13px floor.
+
+---
+
+## Spacing & shape
+
+- Scale: **4 8 12 16 24 32 48 64** px.
+- Border radius: **6px** standard (`rounded-lg`), **10px** for cards (`--r-md`), **999px** for pill chips.
+- Hairlines: 1px `--ink-300` for dividers; 2px `--leaf-600` for section accent rule.
+- Focus: 2px `--leaf-700` outline + 2px offset. No custom `outline-none` overrides.
+
+---
+
+## Imagery
+
+Real photos: dirt, hands, harvest crates, cover crop, tunnel plastic in winter sun. Overcast-Cleveland tone, not glossy. Placeholder: leaf-100 fill block with mono caption "produce shot". No decorative vegetable SVGs.
+
+---
+
+## Two surfaces
+
+**Customer (mobile-first).** SMS link → phone browser. 44px+ touch targets, single column, thumb-reachable totals. Plain chrome. Works at 375px in bright sun.
+
+**Admin (desktop-only).** Annabel runs the week from her kitchen laptop once. Dense, table-driven, keyboard-friendly. Single ink-900 sidebar, content fills viewport. No mobile fallback in V1 (DEC-019).
+
+---
+
+## Status vocabulary
+
+| State | Color treatment |
+|---|---|
+| New | leaf-100 fill, leaf-700 text |
+| Ready | leaf-500 fill, white text |
+| Picked Up | ink-200 fill, ink-700 text |
+| Delivered | ink-200 fill, ink-700 text |
+| **Needs reconciliation** | amber-50 fill, amber-600 left rule |
+
+Reconciliation rows always rise to the top regardless of sort or filter.
+
+---
+
+## Design reference
+
+Canonical prototype source lives in `design/`. Do not commit the bundled standalone HTMLs (1.5MB+) — the source JSX and CSS are enough.
+
+| File | Screen |
+|---|---|
+| `design/tokens.css` | All CSS custom properties |
+| `design/status-pages.{css,jsx}` | Customer: closed, confirmed, invalid |
+| `design/order-page.{css,jsx}` | Customer: order form |
+| `design/admin-shell.{css,jsx}` | Admin layout |
+| `design/admin-inventory.{css,jsx}` | Admin: inventory editor |
+| `design/admin-orders.{css,jsx}` | Admin: orders list |
+| `design/admin-customers.{css,jsx}` | Admin: customer management |
+| `design/admin-send.{css,jsx}` | Admin: SMS broadcast |
+| `design/admin-settings.{css,jsx}` | Admin: scheduling + pickup windows |
+
+Claude Designer URL: `https://api.anthropic.com/v1/design/h/AkV4MQqicgtDIDIg1U0o3w`

--- a/src/app/c/[token]/confirmed/page.tsx
+++ b/src/app/c/[token]/confirmed/page.tsx
@@ -1,0 +1,89 @@
+import { StatusShell } from "@/components/customer/StatusShell";
+
+// TODO Phase 4: look up order by token + orderId and render real data
+const PLACEHOLDER_ORDER = {
+  ref: "0503-04",
+  customer: "Maya",
+  week: "week of may 3",
+  items: [
+    { name: "Heirloom tomatoes", qty: 4, unit: "lb", price: 5.5 },
+    { name: "Dino kale", qty: 6, unit: "bunch", price: 4.5 },
+    { name: "Red beets", qty: 2, unit: "lb", price: 3.25 },
+    { name: "Genovese basil", qty: 3, unit: "bunch", price: 3.5 },
+  ],
+  delivery: {
+    window: "Wed, May 6 · between 8am – noon",
+    address: "16100 Detroit Ave, Lakewood",
+  },
+};
+
+export default function ConfirmedPage() {
+  const order = PLACEHOLDER_ORDER;
+  const total = order.items.reduce((s, i) => s + i.qty * i.price, 0);
+
+  return (
+    <StatusShell>
+      <div className="status-art is-mark" aria-hidden="true">
+        <svg viewBox="0 0 80 80" width="76" height="76">
+          <circle cx="40" cy="40" r="38" fill="#EDF5E5" stroke="#3B6D11" strokeOpacity="0.3" strokeWidth="1" />
+          <path d="M40 56 Q40 42 32 36 Q26 32 26 28 Q34 28 38 32 Q40 26 40 22 Q42 26 44 32 Q48 28 56 28 Q56 32 50 36 Q42 42 42 56 Z" fill="#4F8A1B" />
+          <path d="M40 58 L40 50" stroke="#3B6D11" strokeWidth="2" strokeLinecap="round" />
+        </svg>
+      </div>
+
+      <div className="status-eyebrow eyebrow">order received · #{order.ref}</div>
+      <h1 className="status-title">Order received, {order.customer}.</h1>
+      <p className="status-lede">
+        Thanks. Annabel will text you Wednesday morning with delivery details.
+      </p>
+
+      <div className="confirm-card">
+        <div className="confirm-card-head">
+          <div className="eyebrow">summary</div>
+          <span className="confirm-week">{order.week}</span>
+        </div>
+        <ul className="confirm-list">
+          {order.items.map((item) => (
+            <li key={item.name}>
+              <span className="confirm-line-name">
+                <span className="confirm-qty">{item.qty}×</span>
+                <span>{item.name}</span>
+                <span className="confirm-unit"> · {item.unit}</span>
+              </span>
+              <span className="confirm-amt">${(item.qty * item.price).toFixed(2)}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="confirm-total">
+          <span>Total</span>
+          <span className="mono">${total.toFixed(2)}</span>
+        </div>
+      </div>
+
+      <div className="confirm-fulfill">
+        <div className="confirm-fulfill-row">
+          <div className="confirm-fulfill-key">Delivery</div>
+          <div>
+            <div className="confirm-fulfill-val">{order.delivery.window}</div>
+            <div className="confirm-fulfill-sub">{order.delivery.address}</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="callout callout-info status-callout">
+        <div>
+          <strong>An invoice will follow from Annabel via Wave.</strong>
+          <div style={{ marginTop: 4, color: "var(--ink-700)" }}>
+            Pay at delivery — cash, check, Venmo, or PayPal.
+          </div>
+        </div>
+      </div>
+
+      <div className="status-actions">
+        <a href="sms:2162025718" className="btn btn-secondary status-btn">
+          Need a change? Text Annabel · 216-202-5718
+        </a>
+      </div>
+    </StatusShell>
+  );
+}

--- a/src/app/c/[token]/page.tsx
+++ b/src/app/c/[token]/page.tsx
@@ -1,0 +1,52 @@
+import { StatusShell } from "@/components/customer/StatusShell";
+
+// TODO Phase 3: look up token — show InvalidPage if expired, OrderPage if open
+// For now: ordering is always closed (correct for Phase 0)
+export default function CustomerTokenPage() {
+  return (
+    <StatusShell>
+      <div className="status-art" aria-hidden="true">
+        <svg viewBox="0 0 240 160" width="220" height="146">
+          <path d="M30 110 Q120 152 210 110" fill="none" stroke="#3B6D11" strokeOpacity="0.35" strokeWidth="1.5" />
+          <path d="M40 108 Q120 138 200 108" fill="#EDF5E5" stroke="#3B6D11" strokeOpacity="0.5" strokeWidth="1" />
+          <g transform="translate(60 92) rotate(-12)">
+            <path d="M0 0 L48 4 L52 12 L4 14 Z" fill="#E6A817" />
+            <path d="M-6 -6 Q-3 -10 0 -8 M-2 -10 Q1 -14 4 -12 M2 -8 Q5 -14 9 -10" stroke="#3B6D11" strokeWidth="1.4" fill="none" strokeLinecap="round" />
+          </g>
+          <g transform="translate(120 80)">
+            <ellipse cx="0" cy="14" rx="18" ry="14" fill="#B23B2E" opacity="0.85" />
+            <path d="M-8 0 Q-6 -10 0 -12 M0 0 Q1 -12 6 -14 M6 0 Q10 -10 14 -8" stroke="#3B6D11" strokeWidth="1.6" fill="none" strokeLinecap="round" />
+          </g>
+          <g transform="translate(170 90)">
+            <circle r="16" fill="#4F8A1B" opacity="0.85" />
+            <circle r="11" fill="#5fa825" opacity="0.6" />
+            <path d="M-10 -6 Q-4 -12 4 -10 M-6 0 Q2 -8 10 -4" stroke="#FBFAF5" strokeOpacity="0.6" strokeWidth="1" fill="none" />
+          </g>
+          <text x="100" y="36" fontFamily="serif" fontStyle="italic" fontSize="22" fill="#3B6D11" opacity="0.55">z</text>
+          <text x="118" y="26" fontFamily="serif" fontStyle="italic" fontSize="16" fill="#3B6D11" opacity="0.4">z</text>
+          <text x="132" y="20" fontFamily="serif" fontStyle="italic" fontSize="12" fill="#3B6D11" opacity="0.3">z</text>
+        </svg>
+      </div>
+
+      <div className="status-eyebrow eyebrow">this week · closed</div>
+      <h1 className="status-title">Ordering&rsquo;s closed for this week.</h1>
+      <p className="status-lede">
+        We open again <strong>Sunday morning</strong>. You&rsquo;ll get a text from Annabel
+        when this week&rsquo;s list is up.
+      </p>
+
+      <div className="status-meta">
+        <div className="status-meta-row">
+          <span className="status-meta-key">Next opening</span>
+          <span className="status-meta-val">Sun · ~8am</span>
+        </div>
+      </div>
+
+      <div className="status-actions">
+        <a href="sms:2162025718" className="btn btn-secondary status-btn">
+          Text Annabel · 216-202-5718
+        </a>
+      </div>
+    </StatusShell>
+  );
+}

--- a/src/app/c/layout.tsx
+++ b/src/app/c/layout.tsx
@@ -1,0 +1,5 @@
+import "@/styles/customer.css";
+
+export default function CustomerLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,14 +4,11 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Tokens below are placeholders copied from sailbook to get the structure in place.
-   Real bushel brand tokens land in task 0.7 (BRAND.md fill). */
-
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-sans);
-  --font-mono: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, monospace;
+  --font-mono: var(--font-mono);
   --font-heading: var(--font-sans);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -53,77 +50,76 @@
 }
 
 :root {
-  --radius: 0.125rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.148 0.004 228.8);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.148 0.004 228.8);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.148 0.004 228.8);
-  --primary: oklch(0.5 0.134 242.749);
-  --primary-foreground: oklch(0.977 0.013 236.62);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.963 0.002 197.1);
-  --muted-foreground: oklch(0.52 0.021 213.5);
-  --accent: oklch(0.963 0.002 197.1);
-  --accent-foreground: oklch(0.218 0.008 223.9);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.977 0.013 236.62);
-  --border: oklch(0.925 0.005 214.3);
-  --input: oklch(0.925 0.005 214.3);
-  --ring: oklch(0.723 0.014 214.4);
-  --warning: oklch(0.48 0.16 51);
-  --chart-1: oklch(0.872 0.007 219.6);
-  --chart-2: oklch(0.56 0.021 213.5);
-  --chart-3: oklch(0.45 0.017 213.2);
-  --chart-4: oklch(0.378 0.015 216);
-  --chart-5: oklch(0.275 0.011 216.9);
-  --sidebar: oklch(0.987 0.002 197.1);
-  --sidebar-foreground: oklch(0.148 0.004 228.8);
-  --sidebar-primary: oklch(0.588 0.158 241.966);
-  --sidebar-primary-foreground: oklch(0.977 0.013 236.62);
-  --sidebar-accent: oklch(0.963 0.002 197.1);
-  --sidebar-accent-foreground: oklch(0.218 0.008 223.9);
-  --sidebar-border: oklch(0.925 0.005 214.3);
-  --sidebar-ring: oklch(0.723 0.014 214.4);
+  /* ── Bushel design tokens (raw) ─────────────────────────── */
+  --leaf-900: #1F3A08;
+  --leaf-700: #2C5310;
+  --leaf-600: #3B6D11;
+  --leaf-500: #4F8A1B;
+  --leaf-100: #EDF5E5;
+  --leaf-50:  #F4F8EE;
+  --cream:    #FBFAF5;
+  --paper:    #FFFFFF;
+  --ink-900:  #1A1A1A;
+  --ink-700:  #3A3A38;
+  --ink-500:  #6E6E6A;
+  --ink-300:  #C8C7C1;
+  --ink-200:  #E4E2DA;
+  --amber-600: #E6A817;
+  --amber-50:  #FFF7E0;
+  --rose-600:  #B23B2E;
+
+  /* shape */
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-pill: 999px;
+  --hairline: 0 1px 0 rgba(0,0,0,0.04);
+
+  /* font aliases for customer CSS */
+  --sans:    var(--font-sans);
+  --display: var(--font-display);
+  --mono:    var(--font-mono);
+  --serif:   var(--font-sans); /* collapses to sans per design decision */
+
+  /* ── shadcn semantic tokens — mapped to bushel ──────────── */
+  --radius: 0.375rem;
+  --background: #FBFAF5;
+  --foreground: #1A1A1A;
+  --card: #FFFFFF;
+  --card-foreground: #1A1A1A;
+  --popover: #FFFFFF;
+  --popover-foreground: #1A1A1A;
+  --primary: #3B6D11;
+  --primary-foreground: #FFFFFF;
+  --secondary: #F4F8EE;
+  --secondary-foreground: #2C5310;
+  --muted: #F4F8EE;
+  --muted-foreground: #6E6E6A;
+  --accent: #EDF5E5;
+  --accent-foreground: #2C5310;
+  --destructive: #B23B2E;
+  --destructive-foreground: #FFFFFF;
+  --border: #E4E2DA;
+  --input: #C8C7C1;
+  --ring: #3B6D11;
+  --warning: #E6A817;
+  --chart-1: #3B6D11;
+  --chart-2: #4F8A1B;
+  --chart-3: #E6A817;
+  --chart-4: #B23B2E;
+  --chart-5: #2C5310;
+
+  /* admin sidebar — ink-900 background */
+  --sidebar: #1A1A1A;
+  --sidebar-foreground: #FFFFFF;
+  --sidebar-primary: #3B6D11;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #2C2C28;
+  --sidebar-accent-foreground: #FFFFFF;
+  --sidebar-border: #2C2C28;
+  --sidebar-ring: #3B6D11;
 }
 
-.dark {
-  --background: oklch(0.148 0.004 228.8);
-  --foreground: oklch(0.987 0.002 197.1);
-  --card: oklch(0.218 0.008 223.9);
-  --card-foreground: oklch(0.987 0.002 197.1);
-  --popover: oklch(0.218 0.008 223.9);
-  --popover-foreground: oklch(0.987 0.002 197.1);
-  --primary: oklch(0.443 0.11 240.79);
-  --primary-foreground: oklch(0.977 0.013 236.62);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.275 0.011 216.9);
-  --muted-foreground: oklch(0.723 0.014 214.4);
-  --accent: oklch(0.275 0.011 216.9);
-  --accent-foreground: oklch(0.987 0.002 197.1);
-  --destructive: oklch(0.704 0.191 22.216);
-  --destructive-foreground: oklch(0.977 0.013 236.62);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.56 0.021 213.5);
-  --warning: oklch(0.80 0.15 67);
-  --chart-1: oklch(0.872 0.007 219.6);
-  --chart-2: oklch(0.56 0.021 213.5);
-  --chart-3: oklch(0.45 0.017 213.2);
-  --chart-4: oklch(0.378 0.015 216);
-  --chart-5: oklch(0.275 0.011 216.9);
-  --sidebar: oklch(0.218 0.008 223.9);
-  --sidebar-foreground: oklch(0.987 0.002 197.1);
-  --sidebar-primary: oklch(0.685 0.169 237.323);
-  --sidebar-primary-foreground: oklch(0.293 0.066 243.157);
-  --sidebar-accent: oklch(0.275 0.011 216.9);
-  --sidebar-accent-foreground: oklch(0.987 0.002 197.1);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.56 0.021 213.5);
-}
+/* bushel is light-mode only */
 
 @layer base {
   * {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,23 @@
 import type { Metadata, Viewport } from "next";
-import { Nunito_Sans } from "next/font/google";
+import { Source_Sans_3, Playfair_Display, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 
-const nunitoSans = Nunito_Sans({
+const sourceSans = Source_Sans_3({
   variable: "--font-sans",
   subsets: ["latin"],
+  weight: ["300", "400", "600"],
+});
+
+const playfair = Playfair_Display({
+  variable: "--font-display",
+  subsets: ["latin"],
+  weight: ["400", "600"],
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-mono",
+  subsets: ["latin"],
+  weight: ["400", "500"],
 });
 
 export const metadata: Metadata = {
@@ -26,7 +39,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={nunitoSans.variable} suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`${sourceSans.variable} ${playfair.variable} ${jetbrainsMono.variable}`}
+      suppressHydrationWarning
+    >
       <body className="min-h-screen bg-background font-sans antialiased">
         {process.env.NODE_ENV === "development" && (
           <div className="fixed top-0 left-0 right-0 h-0.5 bg-red-500 z-[9999]" />

--- a/src/components/customer/StatusShell.tsx
+++ b/src/components/customer/StatusShell.tsx
@@ -1,0 +1,20 @@
+export function StatusShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="status-page">
+      <div className="brand-strip">
+        <div className="brand-mark">
+          <span className="brand-leaf" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+              <path d="M21.5 2.5c0 8-4.5 14.5-12 14.5-1.4 0-2.8-.2-4-.7l1.4-1.4c.8.2 1.7.4 2.6.4 6 0 9.5-5.3 10-12.3-2 .6-7.4 2.6-10.4 7.4-1 1.6-1.5 3.4-1.7 5.4l-1.5 1.5c0-3.3.7-6.3 2.4-8.7C11.4 4 18.4 2.6 21.5 2.5z" />
+            </svg>
+          </span>
+          <span className="brand-name">Bay Branch Farm</span>
+        </div>
+      </div>
+      <div className="status-shell">{children}</div>
+      <footer className="status-foot">
+        <div>Bay Branch Farm · 3612 W 114th St, Cleveland</div>
+      </footer>
+    </div>
+  );
+}

--- a/src/styles/customer.css
+++ b/src/styles/customer.css
@@ -1,0 +1,194 @@
+/* Customer-facing pages — brand strip + status page styles
+   References CSS custom properties defined in globals.css (:root).
+   Not Tailwind — these are plain CSS classes matching the design prototypes. */
+
+/* ── Brand strip ───────────────────────────────────────────── */
+.brand-strip {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--ink-200);
+  background: var(--paper);
+}
+.brand-mark { display: flex; align-items: center; gap: 8px; }
+.brand-leaf { color: var(--leaf-600); display: inline-flex; }
+.brand-name {
+  font-family: var(--sans);
+  font-size: 1.05rem; font-weight: 600;
+  color: var(--leaf-700);
+  white-space: nowrap;
+}
+
+/* ── Status page shell ─────────────────────────────────────── */
+.status-page {
+  background: var(--cream);
+  min-height: 100vh;
+  color: var(--ink-900);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.55;
+  display: flex; flex-direction: column;
+}
+
+.status-shell {
+  flex: 1;
+  max-width: 540px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 36px 22px 40px;
+  display: flex; flex-direction: column;
+}
+
+.status-art {
+  margin: 8px auto 22px;
+  display: flex; justify-content: center;
+}
+.status-art.is-mark { margin: 8px auto 16px; }
+
+.status-eyebrow { margin-bottom: 10px; text-align: left; }
+
+.status-title {
+  font-family: var(--sans);
+  font-size: 1.85rem;
+  font-weight: 600;
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  margin-bottom: 12px;
+  text-wrap: pretty;
+}
+
+.status-lede {
+  font-size: 1.02rem;
+  color: var(--ink-700);
+  margin-bottom: 26px;
+  max-width: 36ch;
+}
+
+/* ── Meta rows ─────────────────────────────────────────────── */
+.status-meta {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  padding: 4px 16px;
+  margin-bottom: 24px;
+}
+.status-meta-row {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding: 12px 0;
+  border-top: 1px solid var(--ink-200);
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.status-meta-row:first-child { border-top: 0; }
+.status-meta-key { font-size: 0.85rem; color: var(--ink-500); }
+.status-meta-val { font-size: 0.92rem; font-weight: 600; color: var(--ink-900); }
+
+/* ── Actions + footer ──────────────────────────────────────── */
+.status-actions { display: flex; flex-direction: column; gap: 10px; margin-bottom: 18px; }
+.status-btn { width: 100%; min-height: 48px; }
+
+.status-fine {
+  font-size: 0.82rem; color: var(--ink-500);
+  text-align: center; line-height: 1.55;
+  padding: 0 8px;
+}
+
+.status-foot {
+  text-align: center;
+  font-size: 0.78rem; color: var(--ink-500);
+  padding: 18px 22px 28px;
+}
+
+/* ── Eyebrow utility ───────────────────────────────────────── */
+.eyebrow {
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--leaf-600);
+}
+
+/* ── Buttons ───────────────────────────────────────────────── */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  font-family: var(--sans); font-weight: 600; font-size: 0.95rem;
+  padding: 10px 18px; border-radius: var(--r-sm); border: 1px solid transparent;
+  cursor: pointer; transition: background 0.12s, border-color 0.12s, color 0.12s;
+  min-height: 44px; line-height: 1;
+  white-space: nowrap;
+  text-decoration: none;
+}
+.btn-primary { background: var(--leaf-600); color: var(--paper); }
+.btn-primary:hover { background: var(--leaf-700); }
+.btn-secondary { background: var(--paper); color: var(--leaf-700); border-color: var(--ink-300); }
+.btn-secondary:hover { border-color: var(--leaf-600); color: var(--leaf-600); }
+
+/* ── Callout ───────────────────────────────────────────────── */
+.callout {
+  border-radius: var(--r-sm); padding: 12px 16px; font-size: 0.92rem;
+  border-left: 3px solid; display: flex; gap: 10px; align-items: flex-start;
+}
+.callout-info { background: var(--leaf-50); border-color: var(--leaf-600); color: var(--ink-900); }
+.status-callout { margin-bottom: 22px; }
+
+/* ── Confirmed order card ──────────────────────────────────── */
+.confirm-card {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  padding: 16px 18px 14px;
+  margin-bottom: 14px;
+}
+.confirm-card-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  margin-bottom: 12px;
+}
+.confirm-week { font-size: 0.78rem; color: var(--ink-500); font-family: var(--mono); }
+.confirm-list { list-style: none; padding: 0; margin: 0; }
+.confirm-list li {
+  display: flex; justify-content: space-between; gap: 12px;
+  padding: 8px 0;
+  border-top: 1px solid var(--ink-200);
+}
+.confirm-list li:first-child { border-top: 0; padding-top: 0; }
+.confirm-line-name {
+  display: flex; align-items: baseline; gap: 6px; flex-wrap: wrap;
+  min-width: 0;
+}
+.confirm-qty { color: var(--leaf-700); font-weight: 600; font-family: var(--mono); }
+.confirm-unit { color: var(--ink-500); font-size: 0.85rem; }
+.confirm-amt { color: var(--ink-900); font-variant-numeric: tabular-nums; flex-shrink: 0; font-family: var(--mono); }
+.confirm-total {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding-top: 12px; margin-top: 8px;
+  border-top: 1px solid var(--ink-300);
+}
+.confirm-total > span:first-child { font-weight: 600; }
+.confirm-total .mono {
+  font-family: var(--mono);
+  font-size: 1.4rem; font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Fulfillment block ─────────────────────────────────────── */
+.confirm-fulfill {
+  background: var(--leaf-50);
+  border: 1px solid var(--leaf-100);
+  border-radius: var(--r-md);
+  padding: 14px 16px;
+  margin-bottom: 14px;
+}
+.confirm-fulfill-row {
+  display: grid; grid-template-columns: 90px 1fr; gap: 14px;
+  align-items: start;
+}
+.confirm-fulfill-key {
+  font-size: 0.72rem; font-weight: 600; text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--leaf-700);
+  padding-top: 2px;
+}
+.confirm-fulfill-val { font-size: 0.95rem; color: var(--ink-900); font-weight: 600; }
+.confirm-fulfill-sub { font-size: 0.85rem; color: var(--ink-700); font-weight: 400; margin-top: 2px; }
+
+/* ── Mono utility ──────────────────────────────────────────── */
+.mono { font-family: var(--mono); }


### PR DESCRIPTION
## Summary

Establishes the Bay Branch Farm brand system and implements the first customer-facing UI. All future UI work has a design reference and a token foundation to build on.

## Files changed

- `.claude/agents/ui-reviewer.md` — customized for bushel: leaf/cream/ink tokens, customer vs admin surface rules, Playfair-only-on-hero guard, reconciliation row treatment
- `docs/BRAND.md` — fully populated: voice rules, color token table, type scale, spacing, status vocabulary, design reference index + Claude Designer URL
- `design/` — 20 Claude Designer prototype source files (tokens.css, 8 admin screens, 2 customer screens, frames); committed as permanent reference, not compiled
- `src/app/globals.css` — replace sailbook OKLCH placeholders with bushel hex tokens; add raw `--leaf-*` / `--ink-*` / `--cream` vars; map shadcn semantic tokens to bushel; admin sidebar → ink-900; light-mode only
- `src/app/layout.tsx` — Source Sans 3 + Playfair Display + JetBrains Mono via `next/font/google`
- `src/styles/customer.css` — plain CSS for customer pages: brand strip, status-shell, confirm-card, fulfill block, eyebrow, buttons, callout
- `src/components/customer/StatusShell.tsx` — Server Component: leaf SVG brand strip + shell + footer
- `src/app/c/[token]/page.tsx` — ClosedPage (TODO Phase 3: token lookup + open/invalid routing)
- `src/app/c/[token]/confirmed/page.tsx` — ConfirmedPage with placeholder order data (TODO Phase 4: real order lookup)
- `src/app/c/layout.tsx` — imports `customer.css` for all `/c/*` routes

## Code review

- **SVG raw hex** — inline SVG artwork uses `#3B6D11` etc. instead of `var(--leaf-600)`. CSS custom properties work in inline SVG — low priority, pre-Phase 4 fix.
- **`#5fa825` unlisted color** — one SVG fill in closed page is not a brand token (closest is `--leaf-500` `#4F8A1B`). Replace before launch.
- **Inline style in confirmed page** — `style={{ marginTop: 4, color: "var(--ink-700)" }}` should be a CSS class. Add `.callout-sub` to `customer.css`.
- **React key on product name** — fine for placeholder data; needs `item.id` when Phase 4 wires real orders. TODO comment added.
- **Playfair loaded but unused** — font is loaded on every page but `var(--display)` is never referenced in `customer.css`. Either apply it to the status-title or defer load until the order page ships.
- **Farm constants duplicated** — address + phone appear in 3 files; extract to `src/lib/farm.ts` before Phase 3.

## Test plan

- [ ] Navigate to `/c/any-token` — verify ClosedPage renders: leaf SVG illustration, "Ordering's closed for this week." heading, "Text Annabel" button, Bay Branch Farm brand strip, cream background
- [ ] Navigate to `/c/any-token/confirmed` — verify ConfirmedPage renders: sprout SVG, "Order received, Maya." heading, 4-line order summary card with totals, leaf-tinted delivery block, Wave invoice callout, "Text Annabel" button
- [ ] Verify both pages at 375px viewport — single column, no horizontal scroll, brand strip intact, touch targets ≥ 44px
- [ ] Verify Source Sans 3 loaded (no Nunito fallback) — check Network tab for fonts.gstatic.com requests
- [ ] Verify `bg-background` renders as cream `#FBFAF5` (not white) on the home/login page — confirms shadcn token remapping landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)