### PR TITLE
Phase 1.3 — Admin route group, proxy auth guard, is_admin escalation fix

### DIFF
--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,0 +1,7 @@
+export default function AdminPage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center p-6">
+      <p className="text-muted-foreground">Admin shell coming in 1.4.</p>
+    </main>
+  );
+}

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -16,11 +16,16 @@ export default async function AdminLayout({
     redirect("/login");
   }
 
-  const { data: profile } = await supabase
+  // Proxy already called getUser() for session refresh — this is the second call per request.
+  const { data: profile, error } = await supabase
     .from("users")
     .select("is_admin")
     .eq("id", user.id)
     .single();
+
+  if (error) {
+    redirect("/login?error=auth_error");
+  }
 
   if (!profile?.is_admin) {
     redirect("/");

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,0 +1,30 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { data: profile } = await supabase
+    .from("users")
+    .select("is_admin")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile?.is_admin) {
+    redirect("/");
+  }
+
+  return <>{children}</>;
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -24,8 +24,9 @@ export async function updateSession(request: NextRequest) {
     },
   );
 
-  // Touch auth.getUser() to refresh the session cookie if needed.
-  await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  return supabaseResponse;
+  return { response: supabaseResponse, user };
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,42 +1,19 @@
-import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
-import type { Database } from "@/lib/supabase/types";
+import { updateSession } from "@/lib/supabase/middleware";
 
 export async function proxy(request: NextRequest) {
-  let supabaseResponse = NextResponse.next({ request });
-
-  const supabase = createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return request.cookies.getAll();
-        },
-        setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value }) =>
-            request.cookies.set(name, value),
-          );
-          supabaseResponse = NextResponse.next({ request });
-          cookiesToSet.forEach(({ name, value, options }) =>
-            supabaseResponse.cookies.set(name, value, options),
-          );
-        },
-      },
-    },
-  );
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { response, user } = await updateSession(request);
 
   if (request.nextUrl.pathname.startsWith("/admin") && !user) {
     const loginUrl = new URL("/login", request.url);
-    loginUrl.searchParams.set("next", request.nextUrl.pathname);
+    loginUrl.searchParams.set(
+      "next",
+      request.nextUrl.pathname + request.nextUrl.search,
+    );
     return NextResponse.redirect(loginUrl);
   }
 
-  return supabaseResponse;
+  return response;
 }
 
 export const config = {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,8 +1,42 @@
-import { type NextRequest } from "next/server";
-import { updateSession } from "@/lib/supabase/middleware";
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+import type { Database } from "@/lib/supabase/types";
 
 export async function proxy(request: NextRequest) {
-  return await updateSession(request);
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value),
+          );
+          supabaseResponse = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (request.nextUrl.pathname.startsWith("/admin") && !user) {
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("next", request.nextUrl.pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return supabaseResponse;
 }
 
 export const config = {

--- a/supabase/migrations/20260508190557_restrict_user_update_no_escalation.sql
+++ b/supabase/migrations/20260508190557_restrict_user_update_no_escalation.sql
@@ -1,0 +1,17 @@
+-- Phase 1.3: prevent authenticated users from self-escalating is_admin.
+-- The original user_update_own policy allowed unrestricted column updates,
+-- which meant any authenticated user could flip their own is_admin to true.
+-- This was deferred from Phase 1.2 and is resolved here.
+--
+-- New check: is_admin must remain unchanged (current value must equal new value).
+-- Profile fields (display_name, etc.) are still freely updatable by the owner.
+
+drop policy if exists "user_update_own" on public.users;
+
+create policy "user_update_own" on public.users
+  for update to authenticated
+  using (auth.uid() = id)
+  with check (
+    auth.uid() = id
+    and is_admin = (select is_admin from public.users where id = auth.uid())
+  );

--- a/tests/admin-auth.spec.ts
+++ b/tests/admin-auth.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("admin route guard", () => {
+  test("unauthenticated /admin redirects to /login", async ({ page }) => {
+    await page.goto("/admin");
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("redirect preserves ?next param", async ({ page }) => {
+    await page.goto("/admin");
+    await expect(page).toHaveURL(/[?&]next=%2Fadmin/);
+  });
+
+  test("login page is reachable", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.getByRole("button", { name: /sign in/i })).toBeVisible();
+  });
+});

--- a/tests/admin-auth.spec.ts
+++ b/tests/admin-auth.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "@playwright/test";
 
+// Authenticated-but-not-admin and admin-access paths are not tested here —
+// Google OAuth has no headless path. Those paths are covered by the pgTAP
+// RLS tests for is_admin and will be revisited once a test-mode session
+// injection mechanism lands (tracked in helpers.ts loginAsAdmin stub).
+
 test.describe("admin route guard", () => {
   test("unauthenticated /admin redirects to /login", async ({ page }) => {
     await page.goto("/admin");


### PR DESCRIPTION
## Summary

Adds the `/admin` route group with a two-layer auth guard: the proxy blocks unauthenticated requests at the edge, and the admin layout verifies `is_admin` in the database. Also patches a privilege-escalation gap deferred from Phase 1.2.

closes #19

## Files changed

- `src/proxy.ts` — delegates session refresh to `updateSession()`, adds unauthenticated `/admin` redirect with query-string preservation
- `src/lib/supabase/middleware.ts` — `updateSession` now returns `{ response, user }` so proxy.ts avoids a second `getUser()` call
- `src/app/(admin)/layout.tsx` — new admin route group layout: checks `is_admin`, handles query error, redirects non-admins to `/`
- `src/app/(admin)/admin/page.tsx` — stub admin page (placeholder for 1.4)
- `supabase/migrations/20260508190557_restrict_user_update_no_escalation.sql` — drops and recreates `user_update_own` policy with `is_admin` immutability check
- `tests/admin-auth.spec.ts` — Playwright tests for unauthenticated redirect + `?next` preservation

## Code review

6 findings from @code-review, all addressed:

- **Security** — `is_admin` self-escalation via `user_update_own` → new migration adds immutability check in `WITH CHECK`
- **Bug** — Admin layout had no `.error` check; query failure would silently redirect the real admin → now redirects to `/login?error=auth_error`
- **Consistency** — `proxy.ts` duplicated `updateSession` cookie plumbing → refactored; `updateSession` returns `user` alongside `response`
- **Consistency** — Double `getUser()` per request is unavoidable with this pattern → comment added in layout
- **Cleanup** — `?next` param didn't preserve query string → fixed with `pathname + search`
- **Cleanup** — Test file didn't explain why authenticated paths are untested → gap comment added

## Test plan

- [ ] `supabase db reset` locally — confirm all 3 migrations apply without error
- [ ] `supabase test db` — confirm 43 pgTAP tests pass (includes cross-customer isolation and existing RLS policies)
- [ ] Start dev server (`npm run dev`), navigate to `/admin` while logged out → verify redirect to `/login?next=%2Fadmin`
- [ ] Navigate to `/admin?tab=orders` while logged out → verify `?next=%2Fadmin%3Ftab%3Dorders` preserved
- [ ] `npx playwright test tests/admin-auth.spec.ts --project=desktop` — confirm 3 tests pass
- [ ] After merge: `supabase db push` to apply migration to remote