### PR TITLE
read-the-tape session 9: workflow improvements

### DIFF
--- a/.claude/agents/tape-reader.md
+++ b/.claude/agents/tape-reader.md
@@ -121,6 +121,14 @@ For each pattern, note: **occurred / not found / inconclusive**.
 
 ---
 
+### P11 — Multi-hypothesis debugging without step-gating
+**Signal:** User message corrects or redirects Claude after Claude proposed 2+ simultaneous fixes during a manual testing sequence; or user explicitly asks for "one step at a time"
+**Why it hurts:** User runs the wrong step, gets a different error, and both parties lose track of which variable changed; prolongs debugging significantly
+**Fix:** When user reports a runtime error during manual testing, propose exactly one diagnostic check or one code change, then stop and wait for the result before the next step
+**Files:** `CLAUDE.md` (Workflow Notes section) — not a skill file
+
+---
+
 ## Step 3 — Look for new patterns
 
 Beyond P1–P10, scan for friction signals not yet on the list:

--- a/.claude/skills/kill-this/SKILL.md
+++ b/.claude/skills/kill-this/SKILL.md
@@ -40,6 +40,8 @@ Push the branch: `git push -u origin $BRANCH`. Do not open a PR yet — code rev
 
 Run the @code-review agent against HEAD (`git diff HEAD~1`). Wait for it to complete. Capture the findings — you'll need them for the PR body and the session log draft.
 
+When addressing code review findings before the PR: Read every file you plan to edit before editing it — including files created by shell commands during the task (e.g. `supabase migration new` creates the migration file empty; Read it before Writing to it). Parallel writes fail silently without a prior Read.
+
 ## Step 4 — Open PR (feature branches only)
 
 **Resolve PR base:** projects using staging-flow (DEC-008) PR into `staging`, not `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,10 @@ npx supabase gen types typescript --local > src/lib/supabase/types.ts
 - Strict mode. No `any`.
 - Generated Supabase types from `lib/supabase/types.ts`. Regenerate after every schema change.
 
+### Next.js 16 routing
+- `src/proxy.ts` is the middleware entry point — export name is `proxy`, not `middleware`. Do NOT create `src/middleware.ts`; Next.js 16 will reject both existing simultaneously.
+- Check `src/` structure before writing new auth/routing files.
+
 ### Components
 - Server Components by default. `'use client'` only when needed.
 - shadcn/ui in `components/ui/` — don't edit directly.
@@ -231,6 +235,7 @@ npx supabase gen types typescript --local > src/lib/supabase/types.ts
 - `/kill-this` opens PR. Self-merge after review unless stakeholder review needed.
 - Keep ≤3 open PRs. Prefer 1.
 - Never two open PRs with migrations on the same table — merge one first.
+- **Stacking PRs is preferred** when tasks depend on each other. Branch the next task off the previous task branch (`git checkout -b task/X.Y-next task/X.Y-prev`), not off main. Only wait for the previous PR to merge when there's a migration conflict on the same table.
 
 ### Staging vs no-staging (DEC-008)
 


### PR DESCRIPTION
## Patterns found and fixed

- **P3/P10** — Write-before-read during code-review fixup: kill-this Step 3 now instructs reading all files (including shell-created ones like `supabase migration new` output) before editing
- **CX1** — Next.js 16 `proxy.ts` vs `middleware.ts` confusion: added note to CLAUDE.md Conventions; `src/middleware.ts` and `src/proxy.ts` cannot coexist
- **CX2 (modified)** — Sequential task branch tangle: CLAUDE.md PR Workflow now documents stacking PRs off the previous task branch as the preferred approach; only block on migration conflicts
- **CX3 → P11** — Multi-hypothesis debugging: added P11 to tape-reader agent — one diagnostic step at a time during manual testing sequences

## Patterns found but skipped
None — all approved by user.

## Candidate patterns discovered
CX3 was promoted to P11 directly.

Note: Run /push-seeds after merge to backport to seeds.