### PR TITLE
auto-sync downstream — 2026-05-09

### DIFF
--- a/.claude/agents/sync-config.md
+++ b/.claude/agents/sync-config.md
@@ -60,18 +60,29 @@ For each relevant file pair, diff project-live against seeds-template:
 - Skills: `.claude/skills/<name>/SKILL.md` vs `<seeds>/dev/claude/skills/<name>/SKILL.md`
 - Agents: `.claude/agents/<name>.md` vs `<seeds>/dev/claude/agents/<name>.md`
 - Project docs: `docs/<name>.md` vs `<seeds>/dev/claude/docs/<name>.md` (or `domain/` for non-dev projects)
+- Project root `CLAUDE.md` vs `<seeds>/dev/claude/CLAUDE.md` — the project's own file is heavily customized (stack, role descriptions, project-specific commands), but the template has structural sections (`§Migration Protocol`, `§Versioning`, `§PR Workflow`, `§Tone`, `§Verbosity`, `§Cost and Waste`, etc.) that propagate as new headers or amended subsections. Diff and hunk-classify per the rubric below; never blanket-skip this pair.
 
 The diff itself is direction-symmetric — same hunks, same classification rubric. Direction only matters at apply time (Step 4).
 
+**Never blanket-skip a file** that has a corresponding template, even if the project's copy is heavily customized. Hunk-classify the diff. Files like `docs/BRAND.md`, `docs/PROJECT_PLAN.md`, `docs/RETROSPECTIVES.md`, and `CLAUDE.md` carry both project substitutions AND structural template content; treating them as 100%-project-specific blanks out the structural channel and was the failure mode of the 2026-05-08 first run.
+
 ### Step 2 — Classify each diff hunk
 
-For every changed hunk, classify:
+For every changed hunk, first label its **provenance** by where the content lives:
+
+- **Project-only** — the hunk's content is in the project file but absent from the template. The project either filled in a `[placeholder]` slot (concrete project text where the template has a blank) OR added structure the template doesn't have.
+- **Template-only** — the hunk's content is in the template but absent from the project file. The template added something the project hasn't received yet — typically a structural improvement.
+- **Both-modified** — both sides have non-matching content for the same logical hunk. Project customized AND template diverged at the same place.
+
+Then classify each hunk into one of three actions:
 
 **Skip — project-specific substitution:**
 - Project name token replacement (e.g., "SailBook" → "[Project]")
 - Hardcoded deadlines, season references, client names
 - Project-specific file paths or schema references
 - Stack choices specific to this project's domain
+- Concrete content filling in a `[placeholder]` slot
+- **Default action for `Project-only` hunks in PULL direction** (and for `Both-modified` in `mode: auto` — see below)
 
 **Backport — structural improvement:**
 - New step added to a skill
@@ -80,18 +91,24 @@ For every changed hunk, classify:
 - Additions to session log format, commit message format, etc.
 - New branching or conditional behavior
 - Improvements to agent prompts or review checklists
+- New section header / subsection that isn't `[placeholder]` content
+- **Default action for `Template-only` hunks in PULL direction** (and `Project-only` hunks in PUSH direction, after generification)
 
 **Flag — pattern emerging:**
 - A change that looks useful in BOTH `dev/` and `domain/` contexts
 - Content that could sensibly live in a future `shared/` location
 - Do NOT extract shared content automatically. Flag it and describe the pattern.
 
+The provenance + action together resolve most hunks unambiguously. For genuinely uncertain hunks (e.g. a `Both-modified` where it's unclear whether the project intentionally diverged from a structural template change or accidentally drifted), classify as **Flag** in `mode: interactive` (ask the user) or **Skip** in `mode: auto` (the PR is the safety net — over-skipping is recoverable next run, over-applying pollutes).
+
 ### Step 3 — Present findings
 
 Output a table:
 
-| File | Change summary | Classification | Action |
-|------|----------------|----------------|--------|
+| File | Hunk | Provenance | Classification | Action |
+|------|------|------------|----------------|--------|
+
+`Hunk` is a one-line summary of the changed content (e.g. `"## Voice" body diverged`, `new "## Color tokens" section`, `[placeholder] filled with "We write in second person..."`). `Provenance` is one of `Project-only` / `Template-only` / `Both-modified`. `Classification` is `Skip` / `Backport` / `Flag`. `Action` is what you actually did/will do (`Skipped`, `Forward-ported`, `Backported`, `Flagged in PR body`).
 
 In `mode: interactive`:
 - For each **backport** (push) / **forward-port** (pull), show the diff hunk and ask: "Apply? (y/n)"


### PR DESCRIPTION
Nightly sync Routine — downstream pass — 2026-05-09. Source: `mobiustripper42/seeds` template (`dev/claude/`).

**Base:** main (no `staging` branch detected in bushel)

## Classification table

| File | Hunk | Provenance | Classification | Action |
|------|------|------------|----------------|--------|
| `.claude/agents/sync-config.md` | Entire agent replaced: added provenance layer (Project-only/Template-only/Both-modified), updated Step 2 rubric with per-direction default-action notes, added CLAUDE.md diffing to Step 1, added "Never blanket-skip" warning, updated Step 3 table to include Provenance + Action columns, expanded Step 4 apply instructions | Template-only | Forward-port | Forward-ported — replaced bushel's 10011-byte v1 with current 12799-byte template |
| `.claude/agents/architect.md`, `code-review.md`, `pm.md` | SHA matches template exactly (these are the template) | — | No diff | Nothing to do |
| `.claude/agents/tape-reader.md` | Bushel has newer version with P11 — template is behind | Project-only | Skip | Skipped — bushel leads; P11 backport handled in upstream PR on seeds |
| `.claude/agents/ui-reviewer.md` | Entirely project-specific (Bay Branch Farm brand) | Both-modified | Skip | Skipped — project-specific design system |
| `.claude/settings.json` | Project-specific permissions | Both-modified | Skip | Skipped — project-specific toolchain |
| `.claude/skills/*` | All skill SHAs match template except kill-this | — | — | |
| `.claude/skills/kill-this/SKILL.md` | Bushel has newer version with read-before-edit instruction — template is behind | Project-only | Skip | Skipped — bushel leads; kill-this backport handled in upstream PR on seeds |

## Files changed

- `.claude/agents/sync-config.md` — replaced with current template version

## Pattern flags

None.

## Skipped hunks

- **`tape-reader.md`** — bushel is ahead (P11 added); handled as upstream backport to seeds.
- **`kill-this/SKILL.md`** — bushel is ahead (read-before-edit instruction); handled as upstream backport to seeds.
- **`ui-reviewer.md`** — project-specific; no template content to forward-port.
- **`settings.json`** — project-specific permissions; no template content to forward-port.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqaXcn2mc7Cr8iqFQBixMY)_