### PR TITLE
auto-sync downstream — 2026-05-10

### DIFF
--- a/.claude/agents/sync-config.md
+++ b/.claude/agents/sync-config.md
@@ -41,6 +41,8 @@ If `mode` is missing, default to `interactive`. If `mode: auto` is requested but
 - `<seeds>/dev/` — template for dev projects (Next.js + Supabase shape)
 - `<seeds>/domain/` — template for non-dev domains (bread, tomatoes, ops, etc.)
 - `<seeds>/seeds-version` — the latest published schema version (the calling skill should have already gated on compatibility before invoking you, but verify)
+- `<seeds>/.claude/type-manifest.yaml` — project-type gating manifest (DEC-011). Lists the small set of `dev/claude/` files that only apply to certain project types (e.g. `agents/ui-reviewer.md` only applies to `webapp`-type projects)
+- The active project's `.claude/project-type` — single-line file naming the project's type (`webapp` or `tool`). Optional; if absent, no type-gating is applied
 - The active project's `.claude/agents/`, `.claude/skills/`, `CLAUDE.md`, and `docs/` — the live versions
 - `<seeds>/dev/claude/skills/push-seeds/SKILL.md` and `<seeds>/dev/claude/skills/pull-seeds/SKILL.md` — the invocation wrappers that call you
 
@@ -55,7 +57,17 @@ If `mode` is missing, default to `interactive`. If `mode: auto` is requested but
 
 ### Step 1 — Diff
 
-For each relevant file pair, diff project-live against seeds-template:
+**Project-type gating (DEC-011).** Before scoping the diff, read `<project>/.claude/project-type` (single-line file: `webapp`, `tool`, or other supported tokens). Then read `<seeds>/.claude/type-manifest.yaml` for the gating rules. For every file pair below, check whether the template-side path appears in the manifest. If it does and the project's type is not in the manifest's allowed list for that path, **drop the pair from the diff scope** and record one entry for the Step 6 report:
+
+> `<file>` skipped — project type `<type>`, file applies to `[<allowed types>]` (manifest-gated)
+
+If `.claude/project-type` is absent or holds an unrecognized token, treat the project as **ungated** — diff every pair as before, no gating applied. Add a single one-liner to the Step 6 report so the reviewer knows the gate didn't fire:
+
+> Project-type gating skipped — `.claude/project-type` is `<missing | unknown:"<token>">`. All template files diffed without filtering.
+
+Type-gating is a **scoping decision**, not a hunk-level one. It removes file pairs from the diff scope before any classification happens. Hunks within an ungated file are still classified normally per Step 2.
+
+For each pair that survived the gate, diff project-live against seeds-template:
 
 - Skills: `.claude/skills/<name>/SKILL.md` vs `<seeds>/dev/claude/skills/<name>/SKILL.md`
 - Agents: `.claude/agents/<name>.md` vs `<seeds>/dev/claude/agents/<name>.md`
@@ -64,7 +76,7 @@ For each relevant file pair, diff project-live against seeds-template:
 
 The diff itself is direction-symmetric — same hunks, same classification rubric. Direction only matters at apply time (Step 4).
 
-**Never blanket-skip a file** that has a corresponding template, even if the project's copy is heavily customized. Hunk-classify the diff. Files like `docs/BRAND.md`, `docs/PROJECT_PLAN.md`, `docs/RETROSPECTIVES.md`, and `CLAUDE.md` carry both project substitutions AND structural template content; treating them as 100%-project-specific blanks out the structural channel and was the failure mode of the 2026-05-08 first run.
+**Never blanket-skip a file** that has a corresponding template, even if the project's copy is heavily customized. Hunk-classify the diff. Files like `docs/BRAND.md`, `docs/PROJECT_PLAN.md`, `docs/RETROSPECTIVES.md`, and `CLAUDE.md` carry both project substitutions AND structural template content; treating them as 100%-project-specific blanks out the structural channel and was the failure mode of the 2026-05-08 first run. The only gate that drops a whole file is the project-type manifest above — and that gate is explicit.
 
 ### Step 2 — Classify each diff hunk
 
@@ -108,7 +120,15 @@ Output a table:
 | File | Hunk | Provenance | Classification | Action |
 |------|------|------------|----------------|--------|
 
-`Hunk` is a one-line summary of the changed content (e.g. `"## Voice" body diverged`, `new "## Color tokens" section`, `[placeholder] filled with "We write in second person..."`). `Provenance` is one of `Project-only` / `Template-only` / `Both-modified`. `Classification` is `Skip` / `Backport` / `Flag`. `Action` is what you actually did/will do (`Skipped`, `Forward-ported`, `Backported`, `Flagged in PR body`).
+`Hunk` is a one-line summary of the changed content (e.g. `"## Voice" body diverged`, `new "## Color tokens" section`, `[placeholder] filled with "We write in second person..."`). `Provenance` is one of `Project-only` / `Template-only` / `Both-modified` / `Type-gated`. `Classification` is `Skip` / `Backport` / `Flag`. `Action` is what you actually did/will do (`Skipped`, `Forward-ported`, `Backported`, `Flagged in PR body`).
+
+For files dropped from scope by the Step 1 type gate, emit one row per gated file:
+
+| File | Hunk | Provenance | Classification | Action |
+|------|------|------------|----------------|--------|
+| `agents/ui-reviewer.md` | (file) | Type-gated | Skip | Skipped — project type `tool`, file applies to `[webapp]` |
+
+Type-gated rows always carry `Hunk: (file)` (it's a whole-file gate, not a hunk classification) and `Action` includes both the project's type and the manifest's allowed list so the reviewer can verify the gate fired correctly.
 
 In `mode: interactive`:
 - For each **backport** (push) / **forward-port** (pull), show the diff hunk and ask: "Apply? (y/n)"

--- a/.claude/agents/tape-reader.md
+++ b/.claude/agents/tape-reader.md
@@ -1,6 +1,6 @@
 ---
 name: tape-reader
-description: Analyzes session JSONL transcripts for workflow anti-patterns and proposes targeted improvements to skill and agent files. Invoked by /read-the-tape. Covers known patterns P1–P10 and surfaces new candidates to grow its own checklist.
+description: Analyzes session JSONL transcripts for workflow anti-patterns and proposes targeted improvements to skill and agent files. Invoked by /read-the-tape. Covers known patterns P1–P11 and surfaces new candidates to grow its own checklist.
 tools: Read, Edit, Write, Bash, Glob, Grep
 ---
 
@@ -131,7 +131,7 @@ For each pattern, note: **occurred / not found / inconclusive**.
 
 ## Step 3 — Look for new patterns
 
-Beyond P1–P10, scan for friction signals not yet on the list:
+Beyond P1–P11, scan for friction signals not yet on the list:
 
 - Any tool call that failed and was retried 2+ times
 - The same file being read multiple times in the same session
@@ -194,7 +194,7 @@ If nothing was approved, skip the PR entirely. Report findings only.
 If Step 3 found new patterns, list them clearly:
 
 > **Candidate patterns for @tape-reader:**
-> - CX: [description] — suggest adding as P11
+> - CX: [description] — suggest adding as P12
 >
 > To add: edit `.claude/agents/tape-reader.md` and add to the known-patterns section. Then `/push-seeds` to backport.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ Roles:
 | `docs/VELOCITY_AND_POKER_GUIDE.md` | Estimation methodology |
 | `docs/CHEATSHEET.md` | One-page printable skill reference |
 | `sessions/*.md` | Per-session files — `YYYY-MM-DD-HHMM-<dev>-<slug>.md` |
+| `.claude/seeds-version` | Schema version this project was last installed at. Used by `/pull-seeds` to gate template syncs. |
+| `.claude/project-type` | Project type — `webapp` or `tool`. Used by `@sync-config` to gate template files that don't apply to this project's type (DEC-011). Optional. |
 
 ## Core Data Model (target — see Phase 1.1)
 


### PR DESCRIPTION
## Summary

Nightly downstream sync from `mobiustripper42/seeds` — 2026-05-10. Seeds version: 3. All applicable files forward-ported from `seeds/dev/claude/`.

## Files changed

- `.claude/agents/sync-config.md` — forward-ported DEC-011 project-type gating: Step 1 now reads `.claude/project-type` and `<seeds>/.claude/type-manifest.yaml`, drops manifest-gated file pairs from diff scope before classification, and emits Type-gated rows in the Step 3 findings table. Context section updated to list the type-manifest and project-type inputs.
- `.claude/agents/tape-reader.md` — forward-ported P11 official promotion: description updated to "P1–P11", Step 3 header updated to "Beyond P1–P11", Step 7 candidate label updated to "P12". (Note: P11 body content was already present in bushel's file — only the counter references in description/Step 3/Step 7 were stale.)
- `CLAUDE.md` — added `.claude/seeds-version` and `.claude/project-type` rows to Key Docs table. (`## Verbosity` and `## Cost and Waste` were already present — not duplicated.)

## Sync classification table

| File | Hunk | Provenance | Classification | Action |
|------|------|------------|----------------|--------|
| `agents/sync-config.md` | DEC-011 project-type gating (Step 1, Context, Step 3) | Template-only | Backport | Forward-ported |
| `agents/tape-reader.md` | Description/Step 3/Step 7 counter updates (P10→P11, P11→P12) | Template-only | Backport | Forward-ported |
| `CLAUDE.md` | `.claude/seeds-version` + `.claude/project-type` Key Docs rows | Template-only | Backport | Forward-ported |
| `skills/kill-this/SKILL.md` | Step 3 generator command example | Both-modified | Skip | Skipped — bushel has Supabase-specific "supabase migration new" example; template has generic "a generator command". Project customization preserved. |
| `agents/ui-reviewer.md` | (file) | Both-modified | Skip | Skipped — bushel's file is fully customized with Bay Branch Farm brand tokens; template "Active Theme" section is Both-modified throughout. |

## Skipped

- No upstream changes backported — no structural improvements found in bushel to propagate to seeds.
- `skills/kill-this/SKILL.md` Step 3 example — Both-modified; bushel-specific Supabase example preserved.
- `agents/ui-reviewer.md` — Both-modified throughout; bushel's brand-specific customization preserved.

## Pattern flags

None.

## Seeds version

Source: `seeds-version: 3`. No version gate failures — bushel is at version 3.

---
*Generated by nightly sync Routine — 2026-05-10*

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQkPTwwW7XaNmJYPJvV9r1)_