### PR TITLE
Phase 2.0a — UX/schema audit: add products.category, replace notification_preference with send_weekly_link

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -263,6 +263,18 @@ PWA push notification is a stretch upgrade: if reliable on Android (the operator
 
 ---
 
+## DEC-028 — Customer send opt-in: send_weekly_link boolean (replaces notification_preference)
+
+**Decision:** Replace `customers.notification_preference text CHECK ('sms','email','none')` with `customers.send_weekly_link boolean NOT NULL DEFAULT true`.
+
+**Why:** `notification_preference` was scoped for a multi-channel world (SMS, email, both) that DEC-026 eliminated. With operator-sent SMS deep links as the only customer channel, the meaningful choice collapses to one bit: does this customer receive the weekly order link? A boolean named `send_weekly_link` is unambiguous and requires no enum gymnastics. `false` replaces `'none'`; `true` replaces `'sms'`. The `'email'` and `'both'` values are dropped with no v1 replacement.
+
+**Trade-offs accepted:** If a v2 email channel is added (Phase 7+), a new column will be needed rather than reusing this one. That's the right trade — v2 scope shouldn't constrain the v1 schema.
+
+**Migration:** `20260510050945_replace_notification_preference.sql`. Existing `'none'` rows → `false`; all others → `true`. Safe on an empty table at this stage of development.
+
+---
+
 ## Open / Pending Product Owner Discussion
 
 - **Minimum delivery amount (in dollars).** Threshold below which delivery is unavailable, or above which delivery is free. Phase 7+ candidate.

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -64,8 +64,8 @@ export type Database = {
           id: string
           is_active: boolean
           name: string
-          notification_preference: string
           phone: string | null
+          send_weekly_link: boolean
           token: string
           updated_at: string
         }
@@ -77,8 +77,8 @@ export type Database = {
           id?: string
           is_active?: boolean
           name: string
-          notification_preference?: string
           phone?: string | null
+          send_weekly_link?: boolean
           token: string
           updated_at?: string
         }
@@ -90,8 +90,8 @@ export type Database = {
           id?: string
           is_active?: boolean
           name?: string
-          notification_preference?: string
           phone?: string | null
+          send_weekly_link?: boolean
           token?: string
           updated_at?: string
         }
@@ -270,6 +270,7 @@ export type Database = {
       }
       products: {
         Row: {
+          category: string
           created_at: string
           description: string | null
           id: string
@@ -282,6 +283,7 @@ export type Database = {
           updated_at: string
         }
         Insert: {
+          category?: string
           created_at?: string
           description?: string | null
           id?: string
@@ -294,6 +296,7 @@ export type Database = {
           updated_at?: string
         }
         Update: {
+          category?: string
           created_at?: string
           description?: string | null
           id?: string

--- a/supabase/migrations/20260510050944_add_product_category.sql
+++ b/supabase/migrations/20260510050944_add_product_category.sql
@@ -1,0 +1,6 @@
+-- Phase 2.0a: add category to products to match the inventory editor UX.
+-- Values mirror the design mockup: Vegetables, Fruit, Herbs, Flowers, Other.
+
+alter table public.products
+  add column category text not null default 'Other'
+    check (category in ('Vegetables', 'Fruit', 'Herbs', 'Flowers', 'Other'));

--- a/supabase/migrations/20260510050945_replace_notification_preference.sql
+++ b/supabase/migrations/20260510050945_replace_notification_preference.sql
@@ -1,0 +1,18 @@
+-- Phase 2.0a: replace notification_preference with send_weekly_link.
+--
+-- notification_preference ('sms'/'email'/'none') is vestigial from before
+-- DEC-026 (operator-sent SMS deep links; no platform-sent email to customers).
+-- In V1 all customer outbound is SMS-only, so the channel choice collapses to
+-- a single boolean: does this customer receive the weekly order link?
+--
+-- Migration is safe on an empty table (dev/CI only at this stage).
+-- Preserve intent: 'none' → false, anything else → true.
+
+alter table public.customers
+  add column send_weekly_link boolean not null default true;
+
+update public.customers
+  set send_weekly_link = (notification_preference <> 'none');
+
+alter table public.customers
+  drop column notification_preference;

--- a/supabase/tests/rls_tables.sql
+++ b/supabase/tests/rls_tables.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(33);
+select plan(37);
 
 -- ============================================================
 -- Schema sanity: RLS enabled on all tables
@@ -32,6 +32,14 @@ select is(
   (select relrowsecurity from pg_class where oid = 'public.order_items'::regclass),
   true, 'RLS enabled on order_items'
 );
+
+-- ============================================================
+-- Schema sanity: Phase 2.0a columns
+-- ============================================================
+select col_not_null('public', 'products', 'category', 'products.category is not null');
+select col_has_default('public', 'products', 'category', 'products.category has a default');
+select col_not_null('public', 'customers', 'send_weekly_link', 'customers.send_weekly_link is not null');
+select col_has_default('public', 'customers', 'send_weekly_link', 'customers.send_weekly_link has a default');
 
 -- ============================================================
 -- Seed test data (postgres role bypasses RLS)

--- a/supabase/tests/rls_tables.sql
+++ b/supabase/tests/rls_tables.sql
@@ -120,8 +120,6 @@ select is_empty(
 );
 reset role;
 
-reset role;
-
 set local role authenticated;
 select isnt_empty($$ select * from public.pickup_windows $$, 'authenticated can read all pickup windows');
 reset role;


### PR DESCRIPTION
## Summary

Pre-2.1 audit comparing design mockups (`design/`) against the Phase 1 schema. Found two actionable gaps; fixed both with migrations and updated types + decisions doc. Closes #35.

## Files changed

- `supabase/migrations/20260510050944_add_product_category.sql` — adds `products.category text NOT NULL DEFAULT 'Other' CHECK (...)` with values matching the inventory editor mockup
- `supabase/migrations/20260510050945_replace_notification_preference.sql` — drops `notification_preference` text enum, adds `send_weekly_link boolean NOT NULL DEFAULT true` (DEC-028)
- `src/lib/supabase/types.ts` — regenerated; `category` and `send_weekly_link` present, `notification_preference` gone
- `docs/DECISIONS.md` — added DEC-028 documenting the `send_weekly_link` decision
- `supabase/tests/rls_tables.sql` — bumped plan from 33→37; added `col_not_null` / `col_has_default` assertions for both new columns; removed pre-existing duplicate `reset role`

## Code review

Clean bill of health on new code. Pre-existing duplicate `reset role` in pickup_windows block was the only finding — removed in final commit.

## Test plan

- [ ] Run `supabase db reset` — confirm both migrations apply without error
- [ ] Run `supabase test db` — confirm all 47 tests pass
- [ ] Run `npm run build` — confirm TypeScript strict passes with regenerated types
- [ ] Confirm `src/lib/supabase/types.ts` has `category: string` on products row, `send_weekly_link: boolean` on customers row, and no `notification_preference` field