### PR TITLE
Glob-tool fix for /its-alive Step 5 + /read-the-tape Step 1

### DIFF
--- a/.claude/skills/its-alive/SKILL.md
+++ b/.claude/skills/its-alive/SKILL.md
@@ -75,16 +75,23 @@ If `sessions/` does not exist: this is the first session under the new format. C
 
 ## Step 5 — Capture the transcript path
 
+Compute the project's JSONL directory path via Bash:
+
 ```
-PROJECT_SLUG=$(pwd | tr '/' '-')
-JSONL_DIR="$HOME/.claude/projects/$PROJECT_SLUG"
-TRANSCRIPT=$(cd "$JSONL_DIR" 2>/dev/null && ls -t *.jsonl 2>/dev/null | head -1)
-[ -n "$TRANSCRIPT" ] && TRANSCRIPT="$JSONL_DIR/$TRANSCRIPT"
+echo "$HOME/.claude/projects/$(pwd | tr '/' '-')"
 ```
 
-The `cd`-and-relative-glob form is deliberate. Tree-sitter-bash (used by Claude Code's static command validator) parses `"$VAR"/*.glob` as a string-concatenated-with-glob node it can't classify, so the harness drops to "needs confirmation" on every session start. Doing the lookup from inside the dir sidesteps the pattern entirely. Don't revert to `ls -t "$JSONL_DIR"/*.jsonl`.
+Capture stdout as `JSONL_DIR`. The command is structurally simple — variable expansion + a single pipe + echo — and passes the harness validator without prompting (no globs, no `cd`, no output redirection).
 
-If no JSONL is found, leave `transcript:` empty in the frontmatter. /read-the-tape will fall back to "latest JSONL" matching at audit time.
+Then use the **Glob** tool to find the latest JSONL:
+- `path: <JSONL_DIR>`
+- `pattern: *.jsonl`
+
+Glob returns absolute paths sorted by modification time, newest first. `TRANSCRIPT = result[0]`.
+
+If the Glob result is empty (no JSONL files in the dir, or the dir doesn't exist), leave `transcript:` empty in the frontmatter — `/read-the-tape` will fall back to "latest JSONL" matching at audit time.
+
+**Why the Glob tool, not Bash:** earlier versions used `ls *.jsonl` directly. Two harness validator rules have flagged that path: tree-sitter-bash can't classify `"$VAR"/*.glob` (drops to confirmation), and a newer rule flags `cd "$VAR" && ls 2>/dev/null` (compound `cd` + output redirection). Each shape was a workaround for the other. Switching to the Glob tool sidesteps every Bash validator entirely — Glob runs through the harness's tool layer, not the shell. The lone Bash call above is small enough that no validator pattern triggers.
 
 ## Step 6 — Compose the session filename and write the open entry
 

--- a/.claude/skills/read-the-tape/SKILL.md
+++ b/.claude/skills/read-the-tape/SKILL.md
@@ -15,17 +15,22 @@ Read its YAML frontmatter and pull `transcript:`. Use that path directly. If the
 Use it directly.
 
 **No arg — heuristic:**
+
+Compute the project's JSONL directory path via Bash:
+
 ```
-PROJECT_SLUG=$(pwd | tr '/' '-')
-JSONL_DIR="$HOME/.claude/projects/$PROJECT_SLUG"
-(cd "$JSONL_DIR" 2>/dev/null && ls -lt *.jsonl)
+echo "$HOME/.claude/projects/$(pwd | tr '/' '-')"
 ```
 
-The `cd`-and-relative-glob form is deliberate — tree-sitter-bash chokes on `"$VAR"/*.glob`, dropping every invocation into a permission prompt. See its-alive Step 5 for the longer note.
+Capture stdout as `JSONL_DIR`. Then use the **Glob** tool to list the JSONLs:
+- `path: <JSONL_DIR>`
+- `pattern: *.jsonl`
 
-The listing shows **basenames only** (because the `ls` ran from inside `$JSONL_DIR`). Re-prefix `$JSONL_DIR/` onto the chosen filename before passing to Step 2 — the @tape-reader agent expects a full absolute path.
+Glob returns absolute paths sorted by modification time, newest first. No basename re-prefixing needed — the result is already absolute.
 
-Default to the **second most recently modified JSONL** — the current session's JSONL is always the newest (being written live); the one to audit is the previous one. If only one JSONL exists, use it.
+Default to the **second-newest** JSONL (`result[1]`) — the current session's JSONL is always the newest (being written live); the one to audit is the previous one. If only one JSONL exists, use `result[0]`.
+
+The Glob tool is used in place of `ls *.jsonl` because the Bash form trips two harness validator rules (tree-sitter-bash on `"$VAR"/*.glob`, and a newer rule on `cd "$VAR" && ls 2>/dev/null`). See its-alive Step 5 for the full note.
 
 ## Step 2 — Invoke @tape-reader
 


### PR DESCRIPTION
## Summary

Forward-ports the seeds-side Glob-tool fix into bushel's installed skill copies (`.claude/skills/its-alive/SKILL.md` and `.claude/skills/read-the-tape/SKILL.md`). Same byte-identical SKILL.md content as the seeds template post-fix.

Replaces the bash-glob JSONL discovery in /its-alive Step 5 and /read-the-tape Step 1 with the **Glob** tool, sidestepping two harness validator rules:
- Tree-sitter-bash can't classify `"$VAR"/*.glob` (drops to confirmation).
- A newer rule flags compound `cd "$VAR" && ls 2>/dev/null` (compound `cd` + output redirection).

Surfaced by /read-the-tape in bushel today — both prompt patterns ("Find transcript dir", "Get latest transcript") consistently flagged across runs. The Glob tool runs through the harness's tool layer (not the shell), so neither validator pattern triggers.

Seeds-side companion PR: [seeds#20](https://github.com/mobiustripper42/seeds/pull/20).

## Files changed

- `.claude/skills/its-alive/SKILL.md` — Step 5 rewritten to use Glob tool.
- `.claude/skills/read-the-tape/SKILL.md` — Step 1 no-arg heuristic rewritten to use Glob tool.

## Test plan

- [ ] After merge, start a fresh session in bushel and run `/its-alive`. Step 5 should produce a transcript path with **no permission prompts** for the JSONL discovery (was 2 prompts per session before).
- [ ] After a second session, run `/read-the-tape` (no args). Step 1's heuristic should resolve to the previous session's JSONL silently.
- [ ] Mirror parity check: `diff <bushel>/.claude/skills/its-alive/SKILL.md <seeds>/dev/claude/skills/its-alive/SKILL.md` returns empty (bushel matches the seeds template post-fix). Same for read-the-tape.

## Out of scope

- helm + captains-log will receive this via tonight's nightly Routine downstream pass (non-UI files, apply to both project types — no `Type-gated` skip).
- The two-prompt set this fixes is one of the patterns @tape-reader surfaced earlier in the bushel session — but the per-pattern allowlist entries (e.g. `Bash(node -e:*)`, `Bash(eval $(supabase status:*)`) are separate; those land via /fewer-permission-prompts in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014c9qsW612nGoTXJSfB2hzf)_