### PR TITLE
Phase 2/3 — capture DEC-029…032; simplify fulfillment + sold-out spec; scope V1.5 multi-unit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,10 @@ Roles:
 
 ```
 products → order_items
-customers (token, contact, notification_preference) → orders → order_items
+customers (token, contact, send_weekly_link) → orders → order_items
 orders.needs_reconciliation (oversold flag)
-pickup_windows, ordering_schedule
+orders.pickup_note, orders.delivery_preference (DEC-029: free-text fulfillment, no structured pickup windows in V1)
+ordering_schedule (is_open default true per DEC-030)
 ```
 
 Schema details land in Phase 1.1 (sketched in plan; finalize at execution).

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -94,6 +94,8 @@ Locked during planning + poker. New decisions append. Superseded notes stay.
 
 **Decision:** 4 fixed windows per week, configurable but set-once. Customer chooses one at checkout when picking up.
 
+**Superseded by DEC-029.**
+
 ---
 
 ## DEC-014 — Reminders
@@ -275,7 +277,99 @@ PWA push notification is a stretch upgrade: if reliable on Android (the operator
 
 ---
 
+## DEC-029 — Fulfillment is free-text per order; no structured pickup windows
+
+**Decision:** Drop the `pickup_windows` table and the structured-window picker. The customer order form has two free-text fields, one per fulfillment type:
+
+- **Pickup:** `orders.pickup_note text NULL` — labeled "When are you picking up?", starts empty every week.
+- **Delivery:** `orders.delivery_preference text NULL` — labeled "Delivery preference", **prefilled with the value from this customer's most recent prior `delivery` order** (so customers who switch pickup → delivery don't get stale pickup-time prefills).
+
+Address pre-fill is unchanged (snapshot from `customers.delivery_address` per DEC-008). `orders.fulfillment_type` remains.
+
+**Why:**
+- At 7 customers, structured pickup-window scaffolding is overhead disproportionate to value. Annabel can read prose ("Wednesday afternoon, ~3 if that works") and plan her day.
+- The pickup-window picker was a meaningful chunk of task 3.4 UI; removing it drops 3.4 from 8 pts to 5 pts.
+- Delivery preferences are sticky-but-tweakable info ("leave at back door, gate code 4321"). Prefill-from-prior-order lets a customer keep using the same line week after week without forcing Annabel to maintain a customer-level field.
+
+**Trade-offs accepted:**
+- Operator loses the sortable "3 customers in the Wed 2–4 window" view that structured pickup windows enabled. Mental aggregation across prose is fine at 7 customers; would re-earn its keep around 25+.
+- Free-text is unconstrained — a customer could type "midnight Tuesday" and it would land. Annabel reads and reacts; same as today's SMS workflow.
+
+**Trigger to revisit:** customer count crosses ~25, or operator asks for grouped pickup-day planning. Migration back to structured windows is straightforward (text fields stay as a fallback "other").
+
+**Supersedes:** DEC-013.
+
+---
+
+## DEC-030 — Default mode: always open, manually closed; scheduled close opt-in
+
+**Decision:** Amends DEC-011. `ordering_schedule.is_open` default flips `false` → `true`. The default seeded row has `is_open = true` and all schedule columns (`weekly_open_day`, `weekly_open_time`, `weekly_close_day`, `weekly_close_time`, `override_closes_at`) NULL. The Phase 3.6 cron treats NULL schedule columns as "no schedule configured" and leaves `is_open` alone; it only acts when schedule columns are populated.
+
+**Why:**
+- The practical traffic gate for customer orders is the weekly SMS link, not the open/closed toggle. Customers don't browse `/c/[token]` on their own — they tap the link from Annabel's text. "Always open" doesn't mean 24/7 traffic; it means "when a customer does tap their link, the form works."
+- The closed state is reserved for explicit refuse-new-orders moments (vacation, bad week, broken equipment, end-of-season wind-down). Those are rare and deliberate — making them manual matches their nature.
+- The cron infrastructure from DEC-011 / Phase 3.6 still ships, just as opt-in. Annabel can configure a weekly auto-close later if she finds she wants one.
+
+**Trade-offs accepted:**
+- Customers can theoretically order at any hour if Annabel never closes the store. Acceptable per DEC-012 — vegetables to friends, not heart medicine.
+- Forgotten "close before vacation" is on Annabel. Mitigated by the SMS-as-traffic-gate insight: no new weekly link = effectively no new orders.
+
+**Supersedes/amends:** DEC-011 (the "single open/close toggle + configurable weekly schedule" part stands; the implicit "closed-by-default" assumption is inverted).
+
+**Resolves:** PROJECT_PLAN.md open question "No open/close time? — drop entirely?" Answer: no, keep, but invert default.
+
+---
+
+## DEC-031 — Sold-out display: per-item disabled at qty=0; page-level empty state when all visible items are sold out
+
+**Decision:** The customer inventory page renders four distinct states, depending on the combination of `ordering_schedule.is_open` and `products.qty_available`:
+
+| Store toggle | Inventory | Customer sees |
+|---|---|---|
+| Closed (manual) | any | "Orders are closed this week" message; no form |
+| Open | all visible items qty > 0 | Normal order form |
+| Open | some items qty = 0 (or qty < smallest active unit's `conversion_to_base` once DEC-032 lands) | Form renders; those rows greyed out with "Sold out" in place of the qty stepper |
+| Open | no visible item is orderable | "Everything sold out — check back next week" empty state; no form |
+
+**Why:**
+- Disabled-not-hidden gives customers visibility into what *was* on offer this week, which informs their ordering rhythm ("kale moves fast — I'll order Monday next time").
+- If Annabel restocks mid-week, the same row re-enables — no row-add/row-remove churn.
+- `is_available = false` rows stay filtered out entirely. "Not on the menu this week" is a separate concept from "ran out." Both the per-item disable and the all-sold-out empty state ignore `is_available = false` rows.
+
+**Interaction with DEC-012 (optimistic placement):** The disable is a soft UI hint, not enforcement. A customer who loaded the page when qty=1 and submits after someone else bought the last one still has their order accepted; `needs_reconciliation` fires and Annabel texts to resolve. This is intentional and unchanged. Realtime inventory subscription (Phase 3.8, dark-flagged) would tighten this further if shipped.
+
+---
+
+## DEC-032 — Multi-unit products in V1.5 (per-unit pricing; inventory in base units)
+
+**Decision:** Multi-unit products are not in V1. V1 ships with one unit per product. **V1.5** is a focused follow-up phase (Phase 6.5 in PROJECT_PLAN.md) that adds multi-unit support. Reverses neither DEC-007 (per-customer pricing stays deferred to V2) nor any other prior decision.
+
+**Model when V1.5 ships:**
+
+- Each product has a `base_unit` (e.g. "lb") and `qty_available numeric(10,2)` tracked in base units.
+- New table `product_units (id, product_id, unit text, conversion_to_base numeric(10,4), price_cents integer, sort_order integer, is_active boolean)`. Each product has at least one row (the base unit, conversion=1.0). Cherry tomatoes might have three: lb (1.0), pint (0.83), flat (10.0).
+- `order_items` gains `product_unit_id` FK. `unit_price_cents` continues to snapshot, now from the chosen unit's price.
+- Decrement at order time: `products.qty_available -= order_items.qty * product_units.conversion_to_base`. No rounding — fractional decrements are honest and `numeric(10,2)` handles them cleanly.
+- Per-unit pricing is **independent**, not auto-computed from the conversion factor. Annabel sets pint=$5.00, lb=$4.50, flat=$40.00 directly. Conversion factors govern inventory math only.
+- Per-unit sold-out check: a unit's radio is greyed out when `qty_available < conversion_to_base`. Whole-product sold-out when no active unit is orderable.
+- Customer-side UI: radio-button picker when a product has 2+ active units, no picker when only 1. Switching the radio resets qty to 0 (carrying "6 pints" across to "6 flats" is a recipe for accidental $240 orders).
+
+**Explicit non-coupling to DEC-007:** Per-unit pricing is *not* per-customer pricing. All customers see the same pint price, the same lb price, the same flat price.
+
+**Why V1.5 and not V1:**
+- V1 ships sooner. Real customer usage informs whether multi-unit needs to land in week 2 or month 2 after launch.
+- Multi-unit roughly doubles Phase 2 scope and adds meaningful surface to Phase 3 (admin inventory editor, customer form, sold-out logic, pre-fill behavior). Slotting it as its own phase keeps the V1 plan coherent.
+
+**Why not V2:**
+- Selling the same physical product in different denominations is core wholesale produce behavior, not a "nice to have." Deferring to V2 means an indeterminate slip; V1.5 is a committed follow-up with a sized scope.
+
+**Known V1 kludge:** for products that genuinely need multiple units in V1 (Annabel will identify these), create them as separate products: "Cherry tomatoes (lb)" and "Cherry tomatoes (pint)" with separately-managed `qty_available`. Annabel reconciles harvest-to-inventory split mentally. Tolerable for ~3 products for ~weeks. If the count is higher, this DEC's V1/V1.5 split should be revisited and multi-unit pulled forward into V1.
+
+**Trigger to validate now:** Annabel-facing question — *"How many of the products you sell need to be sold in different units to different customers?"* If answer is 2–3, V1.5 framing holds. If "most of them," pull forward into V1.
+
+---
+
 ## Open / Pending Product Owner Discussion
 
 - **Minimum delivery amount (in dollars).** Threshold below which delivery is unavailable, or above which delivery is free. Phase 7+ candidate.
-- **No open/close time?** Possibility of dropping the open/close toggle entirely (always open). Major scope reduction (eliminates 3.6 + race specs in 3.7). Needs deeper discussion before committing.
+- **Multi-unit product count (DEC-032).** Confirm with Annabel how many V1 products need multi-unit. If small (~3), V1.5 framing holds; if large, pull DEC-032 forward into V1.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -78,7 +78,7 @@ Locked during planning + poker. New decisions append. Superseded notes stay.
 
 **Decision:** Single open/close toggle (source of truth) + configurable weekly schedule + manual "open for N hours" override that auto-closes.
 
-**Note:** product owner discussion is open about whether to drop the open/close concept entirely. See Open Questions.
+**Amended by DEC-030** — default mode is now always-open, manually closed; scheduled close is opt-in.
 
 ---
 

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -191,7 +191,6 @@ Contingent on Annabel confirming the V1 multi-unit product count is small (~3); 
 - **Minimum delivery amount (dollars):** threshold for delivery, or free-delivery cutoff? Phase 7+ candidate.
 - **Multi-unit product count (DEC-032):** confirm with Annabel how many V1 products genuinely need multi-unit. If small (~3), V1.5 framing in Phase 6.5 holds; if large, pull DEC-032 forward into V1.
 - Specific Sun/Mon send time → Annabel fills in once cadence stabilizes
-- Specific four pickup window times → Annabel fills in
 - Final SMS copy → drafted in Phase 4 with feedback in preview UI
 - sailbook's exact CSS approach → confirm at start of Phase 0 (DEC-021)
 - GitHub Actions CI scope → revisit in Phase 6

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -32,12 +32,16 @@ Fibonacci scale: 2, 3, 5, 8. No 1s. Avoid 13s (break down).
 
 ## v1 Total
 
-- **108 pts all-in** (with realtime live)
-- **103 pts** with 3.8 (realtime) shipped behind a dark flag
+- **106 pts all-in** (with realtime live)
+- **101 pts** with 3.8 (realtime) shipped behind a dark flag
 
 **Time projection:**
-- Best case (0.15 hrs/pt): **~16.2 hrs** all-in / **~15.5 hrs** dark realtime
-- Conservative (0.35 hrs/pt): **~37.8 hrs** all-in / **~36 hrs** dark realtime
+- Best case (0.15 hrs/pt): **~15.9 hrs** all-in / **~15.2 hrs** dark realtime
+- Conservative (0.35 hrs/pt): **~37.1 hrs** all-in / **~35.4 hrs** dark realtime
+
+**V1.5 (Phase 6.5):** **15 pts** for multi-unit products (DEC-032). Sized as a focused follow-up phase; not counted in V1 totals.
+
+**Re-baselined 2026-05-10:** Phase 2 +1 pt (2.0b migration to drop pickup_windows + flip is_open default per DEC-029/DEC-030). Phase 3.4 8→5 pts (DEC-029 simplification of order form: free-text fulfillment replaces pickup-window picker). Net: −2 pts in V1; +15 pts in new V1.5 phase. See DEC-029, DEC-030, DEC-031, DEC-032.
 
 **Re-baselined 2026-05-08:** SMS pivot (DEC-026/027) reshaped the old Phase 5 (Notifications, 12 pt Twilio integration) into the new Phase 4 (Notifications, 11 pt deep-link + email), removing the multi-week carrier-approval risk from the critical path. The old Phase 3 (customers + tokens) and Phase 4 (public ordering) were combined into a single customer-side Phase 3, with a new 3.0 priority-column migration. Old Phases 6 and 7 renumbered to 5 and 6. Net: +1 pt, materially less schedule risk.
 
@@ -71,17 +75,18 @@ Goal: deployable empty Next.js app at `order.baybranchfarm.com` with Supabase, P
 
 ---
 
-## Phase 2 — Inventory editing (9 pts → ~1.35–3.15 hrs)
+## Phase 2 — Inventory editing (10 pts → ~1.5–3.5 hrs)
 
 | # | Task | Pts | Status |
 |---|---|---|---|
 | 2.0a | UX screen vs schema + decision audit: close gaps found (products.category, notification_preference cleanup, delivery window decision) | 2 | [#35](https://github.com/mobiustripper42/bushel/issues/35) |
+| 2.0b | Schema migration: drop `pickup_windows` table + `orders.pickup_window_id`; add `orders.pickup_note`, `orders.delivery_preference`; flip `ordering_schedule.is_open` default to `true`; regenerate types (DEC-029, DEC-030) | 1 | TBD |
 | 2.1 | Inventory editor (spreadsheet-style row form); Playwright spec rolled in | 5 | [#32](https://github.com/mobiustripper42/bushel/issues/32) |
 | 2.2 | "Pre-populate from last week" action (simple reset, no snapshots in v1) | 2 | [#33](https://github.com/mobiustripper42/bushel/issues/33) |
 
 ---
 
-## Phase 3 — Customer side (37 pts all-in / 32 pts with 3.8 dark → ~5.55–12.95 hrs)
+## Phase 3 — Customer side (34 pts all-in / 29 pts with 3.8 dark → ~5.1–11.9 hrs)
 
 Customer management, tokenized URL access, and the public ordering experience. Combined from the prior Phase 3 (customers + tokens, 11 pts) and Phase 4 (public ordering, 24 pts), plus a new 3.0 priority-column migration. Both prior phases were small and coherent as one customer-side surface.
 
@@ -91,10 +96,10 @@ Customer management, tokenized URL access, and the public ordering experience. C
 | 3.1 | Manual customer CRUD UI (admin); priority field; email/phone OR validation | 3 | TBD |
 | 3.2 | Token generation, durable per-customer URL, regenerate button + thorough testing | 5 | TBD |
 | 3.3 | `/c/[token]` route validates token, sets cookie, identifies customer; thorough session testing | 3 | TBD |
-| 3.4 | Customer inventory page; order form (running total, qty steppers, delivery/pickup toggle, address pre-fill, pickup window picker) | 8 | TBD |
+| 3.4 | Customer inventory page; order form (running total, qty steppers, delivery/pickup toggle, address pre-fill, free-text pickup-note OR delivery-preference per DEC-029, optional customer-notes textarea) | 5 | TBD |
 | 3.5 | Optimistic order placement: insert + decrement (allow negative), set `needs_reconciliation` flag if oversold | 3 | TBD |
-| 3.6 | Open/close toggle + scheduled cutoff + "open for N hours" override; Vercel Cron + TZ math | 5 | TBD (pending PO discussion) |
-| 3.7 | Closed/sold-out states; Playwright specs (golden, closed-mid-order race, oversold-flags-for-admin) | 3 | TBD |
+| 3.6 | Manual open/close toggle (default open per DEC-030); optional scheduled cutoff + "open for N hours" override; Vercel Cron + TZ math kicks in only when schedule columns are set | 5 | TBD |
+| 3.7 | Closed state + per-item sold-out (disabled row at qty=0) + all-sold-out empty state (DEC-031); Playwright specs (golden, closed-mid-order race, oversold-flags-for-admin) | 3 | TBD |
 | 3.8 | Realtime inventory subscription, behind `NEXT_PUBLIC_REALTIME_INVENTORY` flag, ship-or-skip at end of Phase 3 | 5 | TBD |
 
 ---
@@ -132,6 +137,25 @@ Operator-sent SMS via native deep links (DEC-026); admin order-arrival alert via
 | 6.2 | Production env: Vercel env vars, transactional email service configured (provider, API key, single-recipient deny-list test), DNS for `order` confirmed, secrets | 2 | TBD |
 | 6.3 | UAT with Annabel; final fixes; structural issues defer to Phase 7+ | 3 | TBD |
 
+V1 ships at end of Phase 6.
+
+---
+
+## Phase 6.5 — V1.5: Multi-unit products (15 pts → ~2.25–5.25 hrs)
+
+Adds multi-unit denomination per product (DEC-032). Inventory in base units; customer picks unit at order; conversion happens at decrement. Pricing is independent per unit (does NOT revive per-customer pricing — DEC-007 still defers that to V2).
+
+Contingent on Annabel confirming the V1 multi-unit product count is small (~3); if "most products," pull DEC-032 forward into V1.
+
+| # | Task | Pts | Status |
+|---|---|---|---|
+| 6.5a | Migration: add `product_units` table; move `products.unit`/`price_cents` semantics into rows there; convert `products.qty_available` to `numeric(10,2)`; add `order_items.product_unit_id` FK; backfill existing single-unit products as one `product_units` row each; backfill existing `order_items.product_unit_id` to the corresponding new row | 3 | TBD |
+| 6.5b | Inventory editor: per-product "Units" sub-sheet (add/remove/edit unit rows with label, conversion-to-base, price, active flag); base-unit row protected | 5 | TBD |
+| 6.5c | Customer order form: radio-button unit picker (2+ active units only); qty resets on radio change; sold-out per-unit (disable radio when `qty_available < conversion_to_base`) | 2 | TBD |
+| 6.5d | Order placement: fractional decrement (`qty * conversion_to_base`), per-unit `unit_price_cents` snapshot, whole-product-sold-out logic ignoring `is_available=false` rows | 2 | TBD |
+| 6.5e | Pre-fill from last week: pre-fills the unit set per product, not just qty | 1 | TBD |
+| 6.5f | Playwright + pgTAP: conversion math, per-unit sold-out, oversell-by-unit reconciliation, order-detail display strings | 2 | TBD |
+
 ---
 
 ## Phase 7+ (deferred / optional)
@@ -165,7 +189,7 @@ Operator-sent SMS via native deep links (DEC-026); admin order-arrival alert via
 ## Open Questions (pending product-owner discussion)
 
 - **Minimum delivery amount (dollars):** threshold for delivery, or free-delivery cutoff? Phase 7+ candidate.
-- **No open/close time?** Drop the toggle entirely (always open)? Major scope reduction — eliminates 3.6 (~5 pts) and most of 3.7. Needs deeper discussion before committing.
+- **Multi-unit product count (DEC-032):** confirm with Annabel how many V1 products genuinely need multi-unit. If small (~3), V1.5 framing in Phase 6.5 holds; if large, pull DEC-032 forward into V1.
 - Specific Sun/Mon send time → Annabel fills in once cadence stabilizes
 - Specific four pickup window times → Annabel fills in
 - Final SMS copy → drafted in Phase 4 with feedback in preview UI

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -90,22 +90,9 @@ Indexes:
 
 ---
 
-### `pickup_windows`
+### `pickup_windows` — REMOVED (DEC-029)
 
-Four fixed windows per week, configurable but set-once in practice (DEC-013).
-
-| Column | Type | Nullable | Default | Notes |
-|--------|------|----------|---------|-------|
-| id | uuid | NOT NULL | gen_random_uuid() | PK |
-| label | text | NOT NULL | | e.g. "Wednesday 2–4 PM" |
-| day_of_week | smallint | NOT NULL | | 0 = Sun … 6 = Sat |
-| start_time | time | NOT NULL | | |
-| end_time | time | NOT NULL | | |
-| is_active | boolean | NOT NULL | true | Hide without deleting |
-| sort_order | integer | NULL | | |
-| created_at | timestamptz | NOT NULL | now() | |
-
-Indexes: none beyond PK.
+Originally specified by DEC-013 (4 fixed windows per week). Removed by DEC-029: fulfillment is free-text per order. Replacement: `orders.pickup_note` and `orders.delivery_preference` (see `orders` section below). Migration drops the table.
 
 ---
 
@@ -116,7 +103,7 @@ Singleton config row (expect exactly 1). Controls live open/close state and week
 | Column | Type | Nullable | Default | Notes |
 |--------|------|----------|---------|-------|
 | id | uuid | NOT NULL | gen_random_uuid() | PK |
-| is_open | boolean | NOT NULL | false | Authoritative live toggle |
+| is_open | boolean | NOT NULL | true | Authoritative live toggle. Default `true` per DEC-030 — store is open until manually closed. |
 | weekly_open_day | smallint | NULL | | 0 = Sun … 6 = Sat |
 | weekly_open_time | time | NULL | | Phase 3.6 cron flips `is_open` on schedule |
 | weekly_close_day | smallint | NULL | | |
@@ -139,11 +126,12 @@ One order per customer per week.
 | customer_id | uuid | NOT NULL | | FK → customers(id) |
 | week_of | date | NOT NULL | | Monday of the ISO week (`date_trunc('week', now())`) |
 | fulfillment_type | text | NOT NULL | 'delivery' | codes(type='fulfillment_type'); app-enforced |
-| pickup_window_id | uuid | NULL | | FK → pickup_windows(id); required when fulfillment_type = 'pickup', enforced app-side in V1 |
+| pickup_note | text | NULL | | Free-text "When are you picking up?"; populated when fulfillment_type='pickup' (DEC-029). No prefill — starts empty every week. |
+| delivery_preference | text | NULL | | Free-text "Delivery preference"; populated when fulfillment_type='delivery' (DEC-029). Customer order form pre-fills from this customer's most recent prior `delivery` order. |
 | delivery_address | text | NULL | | Snapshot of customer address at order time |
 | status | text | NOT NULL | 'new' | codes(type='order_status'); app-enforced |
 | needs_reconciliation | boolean | NOT NULL | false | True if any item went oversold (DEC-012) |
-| notes | text | NULL | | Customer notes to farm |
+| notes | text | NULL | | Customer notes to farm — optional textarea on order form |
 | created_at | timestamptz | NOT NULL | now() | |
 | updated_at | timestamptz | NOT NULL | now() | |
 
@@ -178,8 +166,9 @@ Indexes:
 
 ## Trade-offs
 
-- **`qty` integer on order_items** — whole-unit ordering only. Works if Bay Branch sells in pre-packed denominations ("1 lb bag" × N). If fractional weight ordering is ever needed, migrate to `numeric(10,2)`.
-- **Pickup constraint app-side** — `pickup_window_id` required when `fulfillment_type = 'pickup'` is enforced in application code in V1, not a DB CHECK. Simple enough at this scale.
+- **`qty` integer on order_items** — whole-unit ordering only. Works if Bay Branch sells in pre-packed denominations ("1 lb bag" × N). V1.5 (DEC-032) moves `products.qty_available` to `numeric(10,2)` for multi-unit support; `order_items.qty` stays integer (whole pints, whole flats).
+- **No structured pickup windows** — DEC-029 removed `pickup_windows`. Fulfillment is free-text on the order: `pickup_note` (no prefill) and `delivery_preference` (prefilled from prior delivery order). Migration back to structured windows is reversible if customer count grows.
 - **`notification_preference` text + CHECK** — retained flexible for a v2 customer email channel (placeholder; DEC-020 superseded by DEC-026/027 — v1 customer outbound is operator-sent SMS only). Could move into `codes` when email customer-side lands; CHECK constraint is sufficient for now.
 - **`codes` table, no DB FK** — `orders.fulfillment_type` and `orders.status` reference `codes` by convention, app-enforced. Avoids composite FK ugliness on `orders`.
-- **`ordering_schedule` is inert until Phase 3.6** — table shape is defined here; cron logic and open/close wiring land in Phase 3.6.
+- **`ordering_schedule` is inert until Phase 3.6** — table shape is defined here; cron logic and open/close wiring land in Phase 3.6. Default `is_open = true` per DEC-030.
+- **Multi-unit deferred to V1.5 (DEC-032)** — `products.unit` and `products.price_cents` remain in V1; V1.5 migration moves them into a child `product_units` table and converts `qty_available` to `numeric(10,2)`.

--- a/sessions/2026-05-10-2031-eric-phase-2-updates.md
+++ b/sessions/2026-05-10-2031-eric-phase-2-updates.md
@@ -13,16 +13,34 @@ transcript: /c/Users/eric/.claude/projects/C--Users-eric-OneDrive-Documents-GitH
 
 # Session 12 — phase-2-updates
 
-**Task:** Planning session — Phase 2 updates (in plan mode, no code)
+**Task:** Planning session — review Phase 2/3 spec with PO feedback; capture decisions and update plan
 
 **Completed:**
+- DEC-029: free-text fulfillment per order; supersedes DEC-013 (structured pickup windows dropped)
+- DEC-030: ordering window defaults to "always open, manually closed"; amends DEC-011
+- DEC-031: sold-out display — per-item disabled at qty=0; page-level empty state when all visible items sold out
+- DEC-032: multi-unit products moved to a new V1.5 phase (Phase 6.5, ~15 pts); per-unit pricing independent (NOT per-customer pricing — DEC-007 still defers that to V2)
+- SCHEMA.md: removed `pickup_windows` table section; added `orders.pickup_note` + `orders.delivery_preference`; flipped `ordering_schedule.is_open` default; updated Trade-offs
+- PROJECT_PLAN.md: new task 2.0b (1 pt) for migration; task 3.4 8→5 pts; task 3.6 description tweak (manual default); task 3.7 description expansion; new Phase 6.5 with 6 tasks; v1 totals recomputed 108→106 (all-in) / 103→101 (3.8 dark); resolved "drop open/close entirely?" open question
+- CLAUDE.md: Core Data Model updated to reflect free-text fulfillment + send_weekly_link
 
-**In Progress:**
+**Decisions confirmed (no doc change needed):**
+- Customer order confirmation flow (on-screen + Annabel SMS via Phase 4.2) is correct as speced
+- Customer comments textarea: add to task 3.4 (now folded into the 5-pt re-estimate)
+- Per-customer pricing stays deferred to V2
 
-**Blocked:**
+**Open question added:**
+- Multi-unit product count — confirm with Annabel how many V1 products genuinely need multi-unit. If small (~3), V1.5 framing holds; if large, pull DEC-032 forward into V1.
 
-**Next Steps:**
+**In Progress:** nothing
+
+**Blocked:** nothing
+
+**Next Steps:** PR this branch into main (planning-only — no code, doc updates plus session log). Resume task 2.1 (inventory editor) once merged. Confirm DEC-032 multi-unit count with Annabel before Phase 6.5 starts.
 
 **Context:**
+- This was a pure planning session — no production code touched. Only docs.
+- The "weekly SMS link is the practical traffic gate, not the open/closed toggle" insight is captured in DEC-030 — worth remembering when reasoning about ordering-window behavior.
+- DEC-032's V1/V1.5 split was a deliberate choice to ship V1 sooner; can be reversed if Annabel confirms many products need multi-unit.
 
-**Code Review:**
+**Code Review:** N/A — docs-only branch

--- a/sessions/2026-05-10-2031-eric-phase-2-updates.md
+++ b/sessions/2026-05-10-2031-eric-phase-2-updates.md
@@ -1,0 +1,28 @@
+---
+session: 12
+dev: eric
+slug: phase-2-updates
+branch: plan/phase-2-updates
+started: 2026-05-10T20:31:33Z
+ended:
+duration:
+points:
+status: open
+transcript: /c/Users/eric/.claude/projects/C--Users-eric-OneDrive-Documents-GitHub-bushel/3acccb73-4f06-4444-bfaf-629ab073d880.jsonl
+---
+
+# Session 12 — phase-2-updates
+
+**Task:** Planning session — Phase 2 updates (in plan mode, no code)
+
+**Completed:**
+
+**In Progress:**
+
+**Blocked:**
+
+**Next Steps:**
+
+**Context:**
+
+**Code Review:**


### PR DESCRIPTION
## Summary

Planning-session output capturing 4 new architectural decisions surfaced in a product-owner review of the Phase 2/3 spec. **Docs-only** — no production code. Simplifies V1 fulfillment, inverts the open/close default, formalizes sold-out states, and carves out a V1.5 phase for multi-unit products.

## Files changed
- `CLAUDE.md` — Core Data Model block refreshed
- `docs/DECISIONS.md` — DEC-029, 030, 031, 032 added; DEC-011 amendment marker; DEC-013 superseded marker
- `docs/PROJECT_PLAN.md` — task 3.4 8→5 pts; new 2.0b migration task; new Phase 6.5 (V1.5 multi-unit, 15 pts); v1 totals recomputed; open questions cleaned
- `docs/SCHEMA.md` — `pickup_windows` removed; `orders.pickup_note` + `orders.delivery_preference` added; `ordering_schedule.is_open` default flipped
- `sessions/2026-05-10-2031-eric-phase-2-updates.md` — session 12 log

## Code review

@code-review pass on `git diff HEAD~1`:
- ✅ Internal cross-refs between DECs, SCHEMA.md, and PROJECT_PLAN.md line up.
- 🟡 Two consistency cleanups addressed in follow-up commit: DEC-011 needed an "Amended by DEC-030" marker; PROJECT_PLAN.md still had a "Specific four pickup window times" open question that DEC-029 obsoleted.
- 🟡 Pre-existing drift flagged (not blocking, not addressed in this PR): v1 sub-task point sums total 108/103 vs the stated 106/101 — inherited 2-pt arithmetic drift from an earlier baseline. Audit at next retro.
- 🟡 Pre-existing drift flagged (not addressed): `docs/SCHEMA.md` still lists `customers.notification_preference` instead of `send_weekly_link` (DEC-028). Belongs in a separate doc-sync.

## Test plan

- [ ] Open `docs/DECISIONS.md` → confirm DEC-029 through DEC-032 are present, DEC-013 shows "Superseded by DEC-029", DEC-011 shows "Amended by DEC-030".
- [ ] Open `docs/SCHEMA.md` → confirm `pickup_windows` section is the REMOVED stub, the `orders` table lists `pickup_note` and `delivery_preference` columns (no `pickup_window_id`), and `ordering_schedule.is_open` default is `true`.
- [ ] Open `docs/PROJECT_PLAN.md` → confirm: v1 total reads 106/101, task 2.0b is listed under Phase 2, task 3.4 is 5 pts, Phase 6.5 exists with 6 sub-tasks summing to 15 pts, Open Questions has multi-unit count question and no "four pickup window times" line.
- [ ] Open `CLAUDE.md` → confirm Core Data Model block mentions `send_weekly_link`, `pickup_note`, `delivery_preference`, and the `is_open default true` note.
- [ ] Verify no broken cross-references by spot-checking the DEC-029 → SCHEMA.md links and DEC-032 → Phase 6.5 link.