### PR TITLE
Revert settings.local.json allowlist noise from task branch

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,8 +2,7 @@
   "permissions": {
     "allow": [
       "Bash(cat ~/.claude/devname 2>/dev/null && echo \"FOUND\" || echo \"MISSING\")",
-      "Bash(git config *)",
-      "Bash(awk '/^select \\(is\\\\b|isnt_empty|is_empty|throws_ok|lives_ok|col_not_null|col_has_default|isnt\\\\b\\)/' /home/eric/bushel/supabase/tests/rls_tables.sql)"
+      "Bash(git config *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(cat ~/.claude/devname 2>/dev/null && echo \"FOUND\" || echo \"MISSING\")",
-      "Bash(git config *)"
+      "Bash(git config *)",
+      "Bash(awk '/^select \\(is\\\\b|isnt_empty|is_empty|throws_ok|lives_ok|col_not_null|col_has_default|isnt\\\\b\\)/' /home/eric/bushel/supabase/tests/rls_tables.sql)"
     ]
   }
 }

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -183,11 +183,12 @@ export type Database = {
           created_at: string
           customer_id: string
           delivery_address: string | null
+          delivery_preference: string | null
           fulfillment_type: string
           id: string
           needs_reconciliation: boolean
           notes: string | null
-          pickup_window_id: string | null
+          pickup_note: string | null
           status: string
           updated_at: string
           week_of: string
@@ -196,11 +197,12 @@ export type Database = {
           created_at?: string
           customer_id: string
           delivery_address?: string | null
+          delivery_preference?: string | null
           fulfillment_type?: string
           id?: string
           needs_reconciliation?: boolean
           notes?: string | null
-          pickup_window_id?: string | null
+          pickup_note?: string | null
           status?: string
           updated_at?: string
           week_of: string
@@ -209,11 +211,12 @@ export type Database = {
           created_at?: string
           customer_id?: string
           delivery_address?: string | null
+          delivery_preference?: string | null
           fulfillment_type?: string
           id?: string
           needs_reconciliation?: boolean
           notes?: string | null
-          pickup_window_id?: string | null
+          pickup_note?: string | null
           status?: string
           updated_at?: string
           week_of?: string
@@ -226,47 +229,7 @@ export type Database = {
             referencedRelation: "customers"
             referencedColumns: ["id"]
           },
-          {
-            foreignKeyName: "orders_pickup_window_id_fkey"
-            columns: ["pickup_window_id"]
-            isOneToOne: false
-            referencedRelation: "pickup_windows"
-            referencedColumns: ["id"]
-          },
         ]
-      }
-      pickup_windows: {
-        Row: {
-          created_at: string
-          day_of_week: number
-          end_time: string
-          id: string
-          is_active: boolean
-          label: string
-          sort_order: number | null
-          start_time: string
-        }
-        Insert: {
-          created_at?: string
-          day_of_week: number
-          end_time: string
-          id?: string
-          is_active?: boolean
-          label: string
-          sort_order?: number | null
-          start_time: string
-        }
-        Update: {
-          created_at?: string
-          day_of_week?: number
-          end_time?: string
-          id?: string
-          is_active?: boolean
-          label?: string
-          sort_order?: number | null
-          start_time?: string
-        }
-        Relationships: []
       }
       products: {
         Row: {

--- a/supabase/migrations/20260511121208_fulfillment_schema_drop_pickup_windows.sql
+++ b/supabase/migrations/20260511121208_fulfillment_schema_drop_pickup_windows.sql
@@ -1,0 +1,18 @@
+-- DEC-029: replace structured pickup windows with free-text fulfillment fields
+-- DEC-030: ordering window defaults open (was closed)
+
+-- Drop FK before dropping the table
+alter table public.orders drop column if exists pickup_window_id;
+
+drop table if exists public.pickup_windows;
+
+-- Free-text fulfillment fields (DEC-029)
+alter table public.orders
+  add column pickup_note        text,
+  add column delivery_preference text;
+
+-- Default ordering schedule to open (DEC-030)
+alter table public.ordering_schedule
+  alter column is_open set default true;
+
+update public.ordering_schedule set is_open = true;

--- a/supabase/migrations/20260511121208_fulfillment_schema_drop_pickup_windows.sql
+++ b/supabase/migrations/20260511121208_fulfillment_schema_drop_pickup_windows.sql
@@ -4,6 +4,7 @@
 -- Drop FK before dropping the table
 alter table public.orders drop column if exists pickup_window_id;
 
+-- RLS policies on this table (from 20260508014838) are dropped automatically with the table.
 drop table if exists public.pickup_windows;
 
 -- Free-text fulfillment fields (DEC-029)

--- a/supabase/tests/rls_tables.sql
+++ b/supabase/tests/rls_tables.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(37);
+select plan(33);
 
 -- ============================================================
 -- Schema sanity: RLS enabled on all tables
@@ -15,10 +15,6 @@ select is(
 select is(
   (select relrowsecurity from pg_class where oid = 'public.products'::regclass),
   true, 'RLS enabled on products'
-);
-select is(
-  (select relrowsecurity from pg_class where oid = 'public.pickup_windows'::regclass),
-  true, 'RLS enabled on pickup_windows'
 );
 select is(
   (select relrowsecurity from pg_class where oid = 'public.ordering_schedule'::regclass),
@@ -52,9 +48,6 @@ insert into public.products (id, name, unit, price_cents, qty_available, is_avai
   ('bbbbbbbb-0000-0000-0000-000000000001'::uuid, 'Kale', 'bunch', 300, 10, true),
   ('bbbbbbbb-0000-0000-0000-000000000002'::uuid, 'Hidden Item', 'each', 500, 5, false);
 
-insert into public.pickup_windows (id, label, day_of_week, start_time, end_time, is_active) values
-  ('cccccccc-0000-0000-0000-000000000001'::uuid, 'Wed 2–4 PM', 3, '14:00', '16:00', true),
-  ('cccccccc-0000-0000-0000-000000000002'::uuid, 'Inactive Window', 4, '10:00', '12:00', false);
 
 insert into public.orders (id, customer_id, week_of, fulfillment_type, status) values
   ('dddddddd-0000-0000-0000-000000000001'::uuid,
@@ -107,33 +100,15 @@ select lives_ok(
 reset role;
 
 -- ============================================================
--- pickup_windows
--- ============================================================
-set local role anon;
-select isnt_empty(
-  $$ select * from public.pickup_windows where is_active = true $$,
-  'anon can read active pickup windows'
-);
-select is_empty(
-  $$ select * from public.pickup_windows where is_active = false $$,
-  'anon cannot read inactive pickup windows'
-);
-reset role;
-
-set local role authenticated;
-select isnt_empty($$ select * from public.pickup_windows $$, 'authenticated can read all pickup windows');
-reset role;
-
--- ============================================================
 -- ordering_schedule
 -- ============================================================
 set local role anon;
 select isnt_empty($$ select * from public.ordering_schedule $$, 'anon can read ordering_schedule');
 -- UPDATE with no matching policy silently affects 0 rows; verify value is unchanged
-update public.ordering_schedule set is_open = true;
+update public.ordering_schedule set is_open = false;
 select is(
   (select is_open from public.ordering_schedule),
-  false,
+  true,
   'anon cannot update ordering_schedule (value unchanged after attempt)'
 );
 reset role;


### PR DESCRIPTION
## Summary

Drop the `pickup_windows` table and replace structured pickup-window FK on `orders` with two free-text fulfillment columns (`pickup_note`, `delivery_preference`). Flip `ordering_schedule.is_open` default to `true` and update the singleton row. Regenerate TypeScript types. Fixes broken pgTAP tests that still referenced the dropped table.

closes #41

## Files changed

- `supabase/migrations/20260511121208_fulfillment_schema_drop_pickup_windows.sql` — new migration
- `src/lib/supabase/types.ts` — regenerated
- `supabase/tests/rls_tables.sql` — remove pickup_windows seed + 4 dead tests; fix ordering_schedule assertion for new default

## Code review

Two bugs caught and fixed before PR:
- `rls_tables.sql` still seeded and tested `pickup_windows` (relation-does-not-exist at test time) — removed
- `ordering_schedule` anon-update test asserted `is_open = false` but default is now `true` — corrected; UPDATE attempt now tries `false` to demonstrate the block

Inline comment added to migration noting RLS policies cascade with `DROP TABLE`.

## Test plan

- [ ] `supabase db push` — confirm migration applies without error
- [ ] `supabase test db` — confirm all 43 tests pass (was 47 before fix)
- [ ] Verify `orders` table has `pickup_note` and `delivery_preference` columns and no `pickup_window_id`
- [ ] Verify `ordering_schedule` singleton row has `is_open = true`
- [ ] Verify `pickup_windows` table no longer exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)