### PR TITLE
Phase 2.2 — Pre-populate from last week (orders-derived restore)

### DIFF
--- a/src/actions/prepopulate-from-last-week.ts
+++ b/src/actions/prepopulate-from-last-week.ts
@@ -1,0 +1,14 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+
+export async function prepopulateFromLastWeek(): Promise<{ error: string | null; restoredCount: number }> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.rpc("prepopulate_inventory_from_last_week");
+
+  if (error) return { error: error.message, restoredCount: 0 };
+
+  revalidatePath("/admin/inventory");
+  return { error: null, restoredCount: data?.length ?? 0 };
+}

--- a/src/app/(admin)/admin/inventory/page.tsx
+++ b/src/app/(admin)/admin/inventory/page.tsx
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { InventoryRow } from "@/components/admin/inventory-row";
+import { PrepopulateButton } from "@/components/admin/prepopulate-button";
 
 const thStyle: React.CSSProperties = {
   padding: "10px 12px",
@@ -42,6 +43,8 @@ export default async function InventoryPage() {
       {!error && (!products || products.length === 0) && (
         <p style={{ color: "var(--ink-500)" }}>No products yet.</p>
       )}
+
+      {!error && products && products.length > 0 && <PrepopulateButton />}
 
       {products && products.length > 0 && (
         <div style={{ overflowX: "auto" }}>

--- a/src/components/admin/prepopulate-button.tsx
+++ b/src/components/admin/prepopulate-button.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { prepopulateFromLastWeek } from "@/actions/prepopulate-from-last-week";
+
+export function PrepopulateButton() {
+  const [pending, startTransition] = useTransition();
+  const [message, setMessage] = useState<{ kind: "success" | "error"; text: string } | null>(null);
+
+  function handleClick() {
+    if (!window.confirm("Restore last week's starting inventory? This adds last week's ordered quantities back to current values.")) return;
+    setMessage(null);
+    startTransition(async () => {
+      const result = await prepopulateFromLastWeek();
+      if (result.error) {
+        setMessage({ kind: "error", text: result.error });
+      } else if (result.restoredCount === 0) {
+        setMessage({ kind: "success", text: "No prior-week orders to restore from." });
+      } else {
+        setMessage({ kind: "success", text: `Restored qty on ${result.restoredCount} product${result.restoredCount === 1 ? "" : "s"}.` });
+      }
+    });
+  }
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 20 }}>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={pending}
+        style={{
+          padding: "8px 16px",
+          fontSize: "0.85rem",
+          fontWeight: 600,
+          background: "var(--paper)",
+          color: "var(--ink-900)",
+          border: "1px solid var(--ink-200)",
+          borderRadius: "var(--r-sm)",
+          cursor: pending ? "default" : "pointer",
+          opacity: pending ? 0.6 : 1,
+        }}
+      >
+        {pending ? "Restoring…" : "Pre-populate from last week"}
+      </button>
+      {message && (
+        <span
+          style={{
+            fontSize: "0.82rem",
+            color: message.kind === "error" ? "var(--destructive)" : "var(--leaf-700)",
+          }}
+        >
+          {message.text}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -296,7 +296,13 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      prepopulate_inventory_from_last_week: {
+        Args: never
+        Returns: {
+          added_qty: number
+          product_id: string
+        }[]
+      }
     }
     Enums: {
       [_ in never]: never

--- a/supabase/migrations/20260511171821_prepopulate_from_last_week_function.sql
+++ b/supabase/migrations/20260511171821_prepopulate_from_last_week_function.sql
@@ -1,0 +1,39 @@
+-- Restore qty_available on every product by adding back what was ordered in
+-- the most recent prior week. With DEC-012's optimistic decrement model,
+-- this reverses last week's customer demand and yields the starting
+-- inventory level Annabel had set at the top of last week.
+--
+-- security invoker: runs as the calling role (authenticated admin).
+-- The admin_all_products and authenticated-reads-orders policies cover it.
+
+create or replace function public.prepopulate_inventory_from_last_week()
+returns table(product_id uuid, added_qty integer)
+language sql
+security invoker
+set search_path = public
+as $$
+  with last_week as (
+    select max(week_of) as week_of
+    from public.orders
+    where week_of < current_date
+  ),
+  totals as (
+    select oi.product_id, sum(oi.qty)::int as ordered_qty
+    from public.order_items oi
+    join public.orders o on o.id = oi.order_id
+    cross join last_week lw
+    where lw.week_of is not null and o.week_of = lw.week_of
+    group by oi.product_id
+  ),
+  updated as (
+    update public.products p
+    set qty_available = p.qty_available + t.ordered_qty,
+        updated_at = now()
+    from totals t
+    where t.product_id = p.id
+    returning p.id, t.ordered_qty
+  )
+  select id, ordered_qty from updated;
+$$;
+
+grant execute on function public.prepopulate_inventory_from_last_week() to authenticated;

--- a/supabase/migrations/20260511171821_prepopulate_from_last_week_function.sql
+++ b/supabase/migrations/20260511171821_prepopulate_from_last_week_function.sql
@@ -4,7 +4,8 @@
 -- inventory level Annabel had set at the top of last week.
 --
 -- security invoker: runs as the calling role (authenticated admin).
--- The admin_all_products and authenticated-reads-orders policies cover it.
+-- The admin_all_products / admin_all_orders / admin_all_order_items
+-- policies (each FOR ALL TO authenticated) cover the reads and update.
 
 create or replace function public.prepopulate_inventory_from_last_week()
 returns table(product_id uuid, added_qty integer)

--- a/tests/admin-prepopulate.spec.ts
+++ b/tests/admin-prepopulate.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+import { ADMIN_STORAGE_STATE, TEST_CUSTOMERS, TEST_PRODUCTS } from "./helpers";
+
+// Fixed UUIDs so the seed is idempotent across re-runs.
+const LAST_WEEK_ORDER_ID = "eeeeeeee-0000-0000-0000-000000000001";
+const LAST_WEEK_ORDER_ITEM_ID = "ffffffff-0000-0000-0000-000000000001";
+const LAST_WEEK_QTY = 3;
+
+function adminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+}
+
+function lastWeekDate(): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - 7);
+  return d.toISOString().slice(0, 10);
+}
+
+test.describe("admin inventory — pre-populate from last week", () => {
+  test.use({ storageState: ADMIN_STORAGE_STATE });
+
+  test.beforeEach(async () => {
+    const supabase = adminClient();
+
+    // Resolve the test farm-stand customer id (seed.sql doesn't fix the UUID)
+    const { data: customer, error: customerError } = await supabase
+      .from("customers")
+      .select("id")
+      .eq("token", TEST_CUSTOMERS.farmStand.token)
+      .single();
+    if (customerError || !customer) throw new Error(`Test customer lookup failed: ${customerError?.message ?? "not found"}`);
+
+    // Reset Kale to a clean 0 starting state so the assertion is unambiguous
+    const { error: resetError } = await supabase
+      .from("products")
+      .update({ qty_available: 0 })
+      .eq("id", TEST_PRODUCTS.kale.id);
+    if (resetError) throw new Error(`Kale reset failed: ${resetError.message}`);
+
+    // Clear any prior last-week test fixture (cascades order_items)
+    await supabase.from("orders").delete().eq("id", LAST_WEEK_ORDER_ID);
+
+    // Seed one order from last week against Kale, qty=3
+    const { error: orderError } = await supabase.from("orders").insert({
+      id: LAST_WEEK_ORDER_ID,
+      customer_id: customer.id,
+      week_of: lastWeekDate(),
+      fulfillment_type: "delivery",
+      status: "new",
+    });
+    if (orderError) throw new Error(`Last-week order insert failed: ${orderError.message}`);
+
+    const { error: itemError } = await supabase.from("order_items").insert({
+      id: LAST_WEEK_ORDER_ITEM_ID,
+      order_id: LAST_WEEK_ORDER_ID,
+      product_id: TEST_PRODUCTS.kale.id,
+      qty: LAST_WEEK_QTY,
+      unit_price_cents: TEST_PRODUCTS.kale.price_cents,
+    });
+    if (itemError) throw new Error(`Last-week order_item insert failed: ${itemError.message}`);
+  });
+
+  test.afterEach(async () => {
+    const supabase = adminClient();
+    await supabase.from("orders").delete().eq("id", LAST_WEEK_ORDER_ID);
+    // Reset Kale qty back to the canonical seed value
+    await supabase
+      .from("products")
+      .update({ qty_available: TEST_PRODUCTS.kale.qty_available })
+      .eq("id", TEST_PRODUCTS.kale.id);
+  });
+
+  test("button restores last week's ordered qty onto current inventory", async ({ page }) => {
+    await page.goto("/admin/inventory");
+
+    const kaleQty = page.getByRole("spinbutton", { name: `Qty available for ${TEST_PRODUCTS.kale.name}` });
+    await expect(kaleQty).toHaveValue("0");
+
+    page.once("dialog", (d) => d.accept());
+    await page.getByRole("button", { name: /pre-populate from last week/i }).click();
+
+    await expect(page.getByText(/restored qty on/i)).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByRole("spinbutton", { name: `Qty available for ${TEST_PRODUCTS.kale.name}` }))
+      .toHaveValue(String(LAST_WEEK_QTY));
+  });
+
+  test("cancelling the confirm dialog is a no-op", async ({ page }) => {
+    await page.goto("/admin/inventory");
+    page.once("dialog", (d) => d.dismiss());
+    await page.getByRole("button", { name: /pre-populate from last week/i }).click();
+    await expect(page.getByRole("spinbutton", { name: `Qty available for ${TEST_PRODUCTS.kale.name}` })).toHaveValue("0");
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on #task/2.1. Adds a one-click "Pre-populate from last week" button to `/admin/inventory` that restores `qty_available` to the prior week's starting level by adding SUM(last week's `order_items.qty`) back onto each product. Per DEC-012, orders decrement qty; this reverses that for one week. No snapshot tables — purely derived from existing order history.

Closes #33.

> ⚠ **Stacked PR:** Base is `task/2.1-inventory-editor`. Merge #(2.1) first; this PR's diff will then resolve cleanly against `main`.

## Files changed
- `src/actions/prepopulate-from-last-week.ts` (new)
- `src/app/(admin)/admin/inventory/page.tsx`
- `src/components/admin/prepopulate-button.tsx` (new)
- `src/lib/supabase/types.ts` (regenerated)
- `supabase/migrations/20260511171821_prepopulate_from_last_week_function.sql` (new)
- `tests/admin-prepopulate.spec.ts` (new)

## Code review
@code-review (Sonnet) ran against `HEAD`. Findings, all non-blocking:

- *commentary* — Function shape: `security invoker` + `set search_path = public` + `grant execute … to authenticated` is the right RLS shape. `admin_all_products / orders / order_items` policies cover the reads and update.
- *nit* — Double-click idempotency: if Annabel clicks twice in the same week, qty is restored twice. Confirm dialog is the V1 guard; tighter idempotency (e.g. a "last restored at" marker) is V2 territory.
- *nit* — Return shape `{ error, restoredCount }` deviates from CLAUDE.md's `{ error: string | null }` for button actions. Extra field drives the success message; cleanup-tier divergence.
- *commentary* — `window.confirm` rather than a shadcn modal: acceptable V1, matches admin minimalism.
- *commentary* — Fixed-UUID seed + `beforeEach/afterEach` cleanup gives clean test isolation. Would collide under parallel workers, but `workers=1` per config.

Doc nit in the migration's comment block was caught and fixed in a follow-up commit (`a2e2f4d`).

## Test plan
- [ ] Run `supabase db push` against staging; confirm `prepopulate_inventory_from_last_week()` function created without error
- [ ] Run `supabase test db`; confirm all 43 pgTAP tests pass
- [ ] Run `npx playwright test tests/admin-prepopulate.spec.ts --project=desktop`; confirm 2 tests pass
- [ ] Manual smoke (on preview URL):
  1. Navigate to `/admin/inventory`
  2. Pick a product (e.g. Kale) and note its current qty
  3. As a customer (or via SQL), create an order for "last week" with that product, qty 5
  4. Back on `/admin/inventory`, click **Pre-populate from last week**, accept the confirm dialog
  5. Verify a "Restored qty on N products" message appears
  6. Verify Kale's qty now shows previous-value + 5
- [ ] Manual no-op smoke: with no prior-week orders in the DB, click the button → verify "No prior-week orders to restore from." message
- [ ] Cancel-path: click the button, dismiss the confirm dialog → verify nothing changes