### PR TITLE
Phase 2.1 — Inventory editor (spreadsheet-style row form)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,21 @@
 # bushel — Claude Code Project Context
 
+## ⚠ READ FIRST — Design folder is authoritative for ALL UI work
+
+The `/design/` directory at the repo root contains hand-built JSX + CSS + HTML mockups for every page. Filenames match routes (`admin-inventory.jsx` ↔ `/admin/inventory`, `admin-customers.jsx` ↔ `/admin/customers`, `order-page.jsx` ↔ `/c/[token]`, etc.).
+
+**Before writing or modifying ANY file under `src/app/`, `src/components/admin/`, or `src/components/customer/`:**
+
+1. `ls design/` and identify the matching mockup
+2. Open the `.jsx` AND its companion `.css` if one exists
+3. Read both fully — the JSX defines structure + interaction, the CSS defines visual tokens
+4. Match the design's layout, controls, and dirty-state behavior — do not "simplify"
+5. If no design file exists for the page, **stop and ask** before inventing layout
+
+The mockups are the spec. Acceptance criteria in Issues + the design file together define done. Shipping a page that matches the AC but ignores the design is a rebuild, not a fix.
+
+This has been missed in prior sessions. Do not miss it again.
+
 ## What We're Building
 
 Bay Branch Farm Inventory & Order System (`order.baybranchfarm.com`). Replaces tend.com for ~7 B2B customers (2 farm stands, 1 grocery store, 3–4 restaurants) on a weekly Sun/Mon → Wed/Thu cadence.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
+import { config } from "dotenv";
+
+config({ path: ".env.local" });
 
 export default defineConfig({
   testDir: "./tests",

--- a/src/actions/update-product.ts
+++ b/src/actions/update-product.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 
 type UpdateProductInput = {
@@ -16,7 +17,7 @@ export async function updateProduct(input: UpdateProductInput): Promise<string |
 
   if (!name.trim()) return "Name is required.";
   if (!unit.trim()) return "Unit is required.";
-  if (!Number.isFinite(price_cents) || price_cents < 0) return "Price must be a positive number.";
+  if (!Number.isFinite(price_cents) || price_cents < 0) return "Price must be zero or greater.";
   if (!Number.isInteger(qty_available) || qty_available < 0) return "Qty must be a non-negative whole number.";
 
   const supabase = await createClient();
@@ -26,5 +27,6 @@ export async function updateProduct(input: UpdateProductInput): Promise<string |
     .eq("id", id);
 
   if (error) return error.message;
+  revalidatePath("/admin/inventory");
   return null;
 }

--- a/src/actions/update-product.ts
+++ b/src/actions/update-product.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+
+type UpdateProductInput = {
+  id: string;
+  name: string;
+  unit: string;
+  price_cents: number;
+  qty_available: number;
+  is_available: boolean;
+};
+
+export async function updateProduct(input: UpdateProductInput): Promise<string | null> {
+  const { id, name, unit, price_cents, qty_available, is_available } = input;
+
+  if (!name.trim()) return "Name is required.";
+  if (!unit.trim()) return "Unit is required.";
+  if (!Number.isFinite(price_cents) || price_cents < 0) return "Price must be a positive number.";
+  if (!Number.isInteger(qty_available) || qty_available < 0) return "Qty must be a non-negative whole number.";
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("products")
+    .update({ name: name.trim(), unit: unit.trim(), price_cents, qty_available, is_available, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) return error.message;
+  return null;
+}

--- a/src/app/(admin)/admin/inventory/page.tsx
+++ b/src/app/(admin)/admin/inventory/page.tsx
@@ -1,3 +1,82 @@
-export default function InventoryPage() {
-  return <main>Inventory — coming in Phase 2.1</main>;
+import { createClient } from "@/lib/supabase/server";
+import { InventoryRow } from "@/components/admin/inventory-row";
+
+const thStyle: React.CSSProperties = {
+  padding: "10px 12px",
+  textAlign: "left",
+  fontSize: "0.72rem",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.08em",
+  color: "var(--ink-500)",
+  borderBottom: "2px solid var(--ink-100)",
+  whiteSpace: "nowrap",
+};
+
+export default async function InventoryPage() {
+  const supabase = await createClient();
+  const { data: products, error } = await supabase
+    .from("products")
+    .select("*")
+    .order("sort_order", { ascending: true, nullsFirst: false })
+    .order("name");
+
+  return (
+    <main style={{ padding: "32px 40px", maxWidth: 960 }}>
+      <h1
+        style={{
+          fontFamily: "var(--font-display)",
+          fontSize: "1.5rem",
+          fontWeight: 600,
+          color: "var(--ink-900)",
+          marginBottom: 24,
+        }}
+      >
+        Inventory
+      </h1>
+
+      {error && (
+        <p style={{ color: "var(--destructive)", marginBottom: 16 }}>{error.message}</p>
+      )}
+
+      {!error && (!products || products.length === 0) && (
+        <p style={{ color: "var(--ink-500)" }}>No products yet.</p>
+      )}
+
+      {products && products.length > 0 && (
+        <div style={{ overflowX: "auto" }}>
+          <style>{`
+            .inv-input:hover { border-color: var(--ink-200) !important; }
+            .inv-input:focus { outline: none; border-color: var(--leaf-500) !important; background: var(--paper) !important; }
+          `}</style>
+          <table
+            style={{
+              width: "100%",
+              borderCollapse: "collapse",
+              background: "var(--paper)",
+              borderRadius: "var(--r-lg)",
+              boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
+              overflow: "hidden",
+            }}
+          >
+            <thead>
+              <tr style={{ background: "var(--ink-50)" }}>
+                <th style={thStyle}>Name</th>
+                <th style={thStyle}>Unit</th>
+                <th style={thStyle}>Price ($)</th>
+                <th style={thStyle}>Qty Avail</th>
+                <th style={{ ...thStyle, textAlign: "center" }}>Available</th>
+                <th style={thStyle}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {products.map((product) => (
+                <InventoryRow key={product.id} product={product} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </main>
+  );
 }

--- a/src/components/admin/inventory-row.tsx
+++ b/src/components/admin/inventory-row.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { updateProduct } from "@/actions/update-product";
+import type { Tables } from "@/lib/supabase/types";
+
+type Product = Tables<"products">;
+
+const cellStyle: React.CSSProperties = {
+  padding: "10px 12px",
+  borderBottom: "1px solid var(--ink-100)",
+  verticalAlign: "middle",
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  background: "transparent",
+  border: "1px solid transparent",
+  borderRadius: "var(--r-sm)",
+  padding: "4px 6px",
+  fontSize: "0.875rem",
+  color: "var(--ink-900)",
+  fontFamily: "var(--font-sans)",
+};
+
+const inputFocusClass = "inv-input";
+
+export function InventoryRow({ product }: { product: Product }) {
+  const [name, setName] = useState(product.name);
+  const [unit, setUnit] = useState(product.unit);
+  const [priceStr, setPriceStr] = useState((product.price_cents / 100).toFixed(2));
+  const [qtyStr, setQtyStr] = useState(String(product.qty_available));
+  const [isAvailable, setIsAvailable] = useState(product.is_available);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  function handleSave() {
+    setError(null);
+    setSaved(false);
+    const price_cents = Math.round(parseFloat(priceStr) * 100);
+    const qty_available = parseInt(qtyStr, 10);
+    startTransition(async () => {
+      const err = await updateProduct({
+        id: product.id,
+        name,
+        unit,
+        price_cents,
+        qty_available,
+        is_available: isAvailable,
+      });
+      if (err) setError(err);
+      else setSaved(true);
+    });
+  }
+
+  return (
+    <tr>
+      <td style={cellStyle}>
+        <input
+          className={inputFocusClass}
+          style={inputStyle}
+          value={name}
+          onChange={(e) => { setName(e.target.value); setSaved(false); }}
+          aria-label={`Name for ${product.name}`}
+        />
+      </td>
+      <td style={cellStyle}>
+        <input
+          className={inputFocusClass}
+          style={{ ...inputStyle, width: 80 }}
+          value={unit}
+          onChange={(e) => { setUnit(e.target.value); setSaved(false); }}
+          aria-label={`Unit for ${product.name}`}
+        />
+      </td>
+      <td style={cellStyle}>
+        <input
+          className={inputFocusClass}
+          style={{ ...inputStyle, width: 90 }}
+          type="number"
+          min="0"
+          step="0.01"
+          value={priceStr}
+          onChange={(e) => { setPriceStr(e.target.value); setSaved(false); }}
+          aria-label={`Price for ${product.name}`}
+        />
+      </td>
+      <td style={cellStyle}>
+        <input
+          className={inputFocusClass}
+          style={{ ...inputStyle, width: 80 }}
+          type="number"
+          min="0"
+          step="1"
+          value={qtyStr}
+          onChange={(e) => { setQtyStr(e.target.value); setSaved(false); }}
+          aria-label={`Qty available for ${product.name}`}
+        />
+      </td>
+      <td style={{ ...cellStyle, textAlign: "center" }}>
+        <input
+          type="checkbox"
+          checked={isAvailable}
+          onChange={(e) => { setIsAvailable(e.target.checked); setSaved(false); }}
+          aria-label={`Available for ${product.name}`}
+          style={{ width: 16, height: 16, cursor: "pointer", accentColor: "var(--leaf-600)" }}
+        />
+      </td>
+      <td style={{ ...cellStyle, whiteSpace: "nowrap" }}>
+        <button
+          onClick={handleSave}
+          disabled={pending}
+          style={{
+            padding: "4px 14px",
+            fontSize: "0.8rem",
+            fontWeight: 600,
+            background: "var(--leaf-600)",
+            color: "var(--paper)",
+            border: "none",
+            borderRadius: "var(--r-sm)",
+            cursor: pending ? "default" : "pointer",
+            opacity: pending ? 0.6 : 1,
+          }}
+        >
+          {pending ? "Saving…" : "Save"}
+        </button>
+        {saved && (
+          <span style={{ marginLeft: 8, fontSize: "0.78rem", color: "var(--leaf-700)" }}>
+            Saved
+          </span>
+        )}
+        {error && (
+          <span style={{ marginLeft: 8, fontSize: "0.78rem", color: "var(--destructive)" }}>
+            {error}
+          </span>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -4,3 +4,9 @@ insert into public.customers (name, token) values
   ('Test Farm Stand',  'testtoken-farmstand-0001'),
   ('Test Restaurant',  'testtoken-restaurant-0001')
 on conflict (token) do nothing;
+
+insert into public.products (id, name, unit, price_cents, qty_available, is_available, sort_order) values
+  ('cccccccc-0000-0000-0000-000000000001'::uuid, 'Kale',  'bunch',  300,  10, true, 1),
+  ('cccccccc-0000-0000-0000-000000000002'::uuid, 'Eggs',  'dozen',  600,   5, true, 2),
+  ('cccccccc-0000-0000-0000-000000000003'::uuid, 'Honey', 'jar',   1200,   8, true, 3)
+on conflict (id) do nothing;

--- a/tests/admin-inventory.spec.ts
+++ b/tests/admin-inventory.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+import { ADMIN_STORAGE_STATE, TEST_PRODUCTS } from "./helpers";
+
+test.describe("admin inventory", () => {
+  test.use({ storageState: ADMIN_STORAGE_STATE });
+
+  test("inventory page renders product table", async ({ page }) => {
+    await page.goto("/admin/inventory");
+    await expect(page.getByRole("heading", { name: /inventory/i })).toBeVisible();
+    await expect(page.getByRole("table")).toBeVisible();
+    await expect(page.getByRole("cell", { name: TEST_PRODUCTS.kale.name }).first()).toBeVisible();
+    await expect(page.getByRole("cell", { name: TEST_PRODUCTS.eggs.name }).first()).toBeVisible();
+    await expect(page.getByRole("cell", { name: TEST_PRODUCTS.honey.name }).first()).toBeVisible();
+  });
+
+  test("edit qty and price, save, verify persistence", async ({ page }) => {
+    await page.goto("/admin/inventory");
+
+    const qtyInput = page.getByRole("spinbutton", { name: `Qty available for ${TEST_PRODUCTS.kale.name}` });
+    const priceInput = page.getByRole("spinbutton", { name: `Price for ${TEST_PRODUCTS.kale.name}` });
+
+    await qtyInput.fill("42");
+    await priceInput.fill("3.50");
+
+    // Find the Save button in the Kale row by locating the row containing Kale's name input
+    const kaleNameInput = page.getByRole("textbox", { name: `Name for ${TEST_PRODUCTS.kale.name}` });
+    const kaleRow = kaleNameInput.locator("xpath=ancestor::tr");
+    await kaleRow.getByRole("button", { name: /save/i }).click();
+
+    await expect(kaleRow.getByText("Saved")).toBeVisible();
+
+    // Reload and verify persistence
+    await page.reload();
+    await expect(page.getByRole("spinbutton", { name: `Qty available for ${TEST_PRODUCTS.kale.name}` })).toHaveValue("42");
+    await expect(page.getByRole("spinbutton", { name: `Price for ${TEST_PRODUCTS.kale.name}` })).toHaveValue("3.50");
+  });
+
+  test("save resets qty back to original after second edit", async ({ page }) => {
+    await page.goto("/admin/inventory");
+
+    const qtyInput = page.getByRole("spinbutton", { name: `Qty available for ${TEST_PRODUCTS.kale.name}` });
+    // Reset Kale qty back to original value
+    await qtyInput.fill(String(TEST_PRODUCTS.kale.qty_available));
+
+    const kaleNameInput = page.getByRole("textbox", { name: `Name for ${TEST_PRODUCTS.kale.name}` });
+    const kaleRow = kaleNameInput.locator("xpath=ancestor::tr");
+    await kaleRow.getByRole("button", { name: /save/i }).click();
+
+    await expect(kaleRow.getByText("Saved")).toBeVisible();
+  });
+});

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -76,6 +76,18 @@ export default async function globalSetup() {
   if (upsertError)
     throw new Error(`public.users upsert failed: ${upsertError.message}`);
 
+  // Upsert test products so inventory tests are self-contained
+  const { error: productsError } = await adminClient.from("products").upsert(
+    [
+      { id: "cccccccc-0000-0000-0000-000000000001", name: "Kale",  unit: "bunch", price_cents: 300,  qty_available: 10, is_available: true,  sort_order: 1 },
+      { id: "cccccccc-0000-0000-0000-000000000002", name: "Eggs",  unit: "dozen", price_cents: 600,  qty_available: 5,  is_available: true,  sort_order: 2 },
+      { id: "cccccccc-0000-0000-0000-000000000003", name: "Honey", unit: "jar",   price_cents: 1200, qty_available: 8,  is_available: true,  sort_order: 3 },
+    ],
+    { onConflict: "id" },
+  );
+  if (productsError)
+    throw new Error(`products upsert failed: ${productsError.message}`);
+
   // Sign in to get a real, server-verified session
   const anonClient = createClient(supabaseUrl, anonKey, {
     auth: { autoRefreshToken: false, persistSession: false },

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -19,3 +19,9 @@ export const TEST_CUSTOMERS = {
     token: "testtoken-restaurant-0001",
   },
 } as const;
+
+export const TEST_PRODUCTS = {
+  kale:  { id: "cccccccc-0000-0000-0000-000000000001", name: "Kale",  unit: "bunch", price_cents: 300,  qty_available: 10 },
+  eggs:  { id: "cccccccc-0000-0000-0000-000000000002", name: "Eggs",  unit: "dozen", price_cents: 600,  qty_available: 5  },
+  honey: { id: "cccccccc-0000-0000-0000-000000000003", name: "Honey", unit: "jar",   price_cents: 1200, qty_available: 8  },
+} as const;


### PR DESCRIPTION
## Summary
Implements the admin inventory editor at `/admin/inventory`. Each product renders as a row with inline-editable name, unit, price, qty, and availability inputs and a per-row Save button. Saves go through a `updateProduct` Server Action with field validation and `revalidatePath` on success.

Closes #32.

> **Note:** PR #43 (task 2.2) is stacked on this branch. Merge this first.

## Files changed
- `playwright.config.ts` — load `.env.local` via dotenv so Playwright env doesn't require shell exports
- `src/actions/update-product.ts` (new) — validate + update via Supabase server client; `revalidatePath` after success
- `src/app/(admin)/admin/inventory/page.tsx` — Server Component fetches products, renders the table
- `src/components/admin/inventory-row.tsx` (new) — `'use client'` row; `useTransition` + direct server action call; inline saved/error feedback
- `supabase/seed.sql` — three test products (Kale, Eggs, Honey) with fixed UUIDs for dev convenience
- `tests/admin-inventory.spec.ts` (new) — 3 Playwright tests (render, edit-and-persist, reset)
- `tests/global-setup.ts` — upsert same three products with fixed UUIDs so Playwright is self-contained
- `tests/helpers.ts` — `TEST_PRODUCTS` constant

## Code review
@code-review (Sonnet) ran against the full diff. Two real findings, both addressed in `674d126`:

- *consistency* — `updateProduct` was missing `revalidatePath("/admin/inventory")` (sibling action `prepopulate-from-last-week.ts` has it). Without it, Server Component re-renders can show stale rows until the route cache expires. **Fixed.**
- *bug* — Price validation message said "Price must be a positive number" but the check allows `0`. **Fixed** to "Price must be zero or greater."

Non-blocking notes for the record:

- *security* (V2) — `admin_all_products` is `for all to authenticated using (true)`. Permissive but matches current auth model (admin-only authenticated users). Flag for @architect when customer auth lands.
- *nit* (V2) — `parseFloat("3.5abc")` returns `3.5` silently; price input could be tightened. Browsers typically scrub `type="number"`, so low-risk in practice.
- *nit* — Table action column header is unannounced to screen readers. Could add `<span class="sr-only">Actions</span>`.
- *cleanup* — `tests/admin-inventory.spec.ts` "reset" test name implies cross-test dependency; the test is actually independent (sets value explicitly). Naming-only.

## Test plan
- [ ] Run `npx playwright test tests/admin-inventory.spec.ts --project=desktop`; confirm 3 tests pass
- [ ] Run `supabase test db`; confirm 43 pgTAP tests pass (no RLS changes here but smoke it)
- [ ] Run `supabase db reset` (locally) — confirm `supabase/seed.sql` adds the three test products without error
- [ ] Manual smoke (on preview URL):
  1. Sign in as admin → navigate to `/admin/inventory`
  2. Verify the table renders with all products, sorted by `sort_order` then `name`
  3. Change Kale's qty to a new value (e.g. 25), click **Save**
  4. Verify a green **Saved** indicator appears
  5. Hard-refresh the page → verify the new qty persists
  6. Try setting a negative price → verify "Price must be zero or greater." error inline
  7. Try clearing the name field → verify "Name is required." error inline
  8. Toggle the **Available** checkbox off for one product → Save → as anon, verify that product no longer appears (DEC-031 / RLS `is_available = true` filter)