### PR TITLE
Phase 3.0 — Add customers.priority column for SMS send-queue ordering

### DIFF
--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -65,6 +65,7 @@ export type Database = {
           is_active: boolean
           name: string
           phone: string | null
+          priority: number
           send_weekly_link: boolean
           token: string
           updated_at: string
@@ -78,6 +79,7 @@ export type Database = {
           is_active?: boolean
           name: string
           phone?: string | null
+          priority?: number
           send_weekly_link?: boolean
           token: string
           updated_at?: string
@@ -91,6 +93,7 @@ export type Database = {
           is_active?: boolean
           name?: string
           phone?: string | null
+          priority?: number
           send_weekly_link?: boolean
           token?: string
           updated_at?: string

--- a/supabase/migrations/20260511190838_add_customer_priority.sql
+++ b/supabase/migrations/20260511190838_add_customer_priority.sql
@@ -1,0 +1,11 @@
+-- customers.priority — send-queue ordering for the weekly SMS link (DEC-026/027).
+-- Lower number sends earlier; 100 is a neutral default so existing rows
+-- and new customers without a strong preference all sit at the same rank.
+-- Not-null + default means the send-queue ORDER BY priority never needs
+-- to think about NULLs.
+
+alter table public.customers
+  add column priority integer not null default 100;
+
+comment on column public.customers.priority is
+  'Send-queue ordering (DEC-026/027). Lower = earlier in the cycle. Default 100.';

--- a/supabase/migrations/20260511190838_add_customer_priority.sql
+++ b/supabase/migrations/20260511190838_add_customer_priority.sql
@@ -5,7 +5,8 @@
 -- to think about NULLs.
 
 alter table public.customers
-  add column priority integer not null default 100;
+  add column priority integer not null default 100
+  check (priority >= 0);
 
 comment on column public.customers.priority is
   'Send-queue ordering (DEC-026/027). Lower = earlier in the cycle. Default 100.';

--- a/supabase/tests/rls_tables.sql
+++ b/supabase/tests/rls_tables.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(33);
+select plan(36);
 
 -- ============================================================
 -- Schema sanity: RLS enabled on all tables
@@ -36,6 +36,13 @@ select col_not_null('public', 'products', 'category', 'products.category is not 
 select col_has_default('public', 'products', 'category', 'products.category has a default');
 select col_not_null('public', 'customers', 'send_weekly_link', 'customers.send_weekly_link is not null');
 select col_has_default('public', 'customers', 'send_weekly_link', 'customers.send_weekly_link has a default');
+
+-- ============================================================
+-- Schema sanity: Phase 3.0 columns
+-- ============================================================
+select has_column('public', 'customers', 'priority', 'customers.priority column exists');
+select col_not_null('public', 'customers', 'priority', 'customers.priority is not null');
+select col_default_is('public', 'customers', 'priority', '100', 'customers.priority defaults to 100');
 
 -- ============================================================
 -- Seed test data (postgres role bypasses RLS)


### PR DESCRIPTION
## Summary
Adds `customers.priority integer not null default 100 check (priority >= 0)` to support the SMS send-queue ordering per DEC-026/027. Lower number sends earlier; 100 is a neutral default so existing rows and new customers without a strong preference all sit at the same rank. No UI in this task — 3.1 surfaces the field.

Closes #45.

## Files changed
- `supabase/migrations/20260511190838_add_customer_priority.sql` (new)
- `supabase/tests/rls_tables.sql` (plan 33 → 36; 3 schema assertions)
- `src/lib/supabase/types.ts` (regenerated)

## Code review
@code-review (Sonnet) ran against the two-commit diff. One actionable finding, addressed:

- *cleanup* — Bare `integer` allows negatives/zero/2.1B. **Fixed** in `35431ea` — added `check (priority >= 0)`.

Non-actionable notes for the record:
- *cleanup* (V2) — `integer` vs `smallint`: 4 bytes for 1–3 digit values across ~7 customers; matches existing migration style, not load-bearing at this scale.
- *cleanup* — Backfill assertion in pgTAP would be belt-and-suspenders (Postgres's `default` guarantees it). Skipped.
- *@architect note* — Tie-breaker rule for equal-priority rows (name? created_at? random?) is a 3.1 decision, not 3.0. Worth deciding before 3.1's ORDER BY clause is written.

## Test plan
- [ ] Run `supabase db push` against staging; confirm migration applied without error
- [ ] Run `supabase test db`; confirm all 46 pgTAP tests pass (was 43)
- [ ] Sanity check via `psql` / Supabase dashboard:
  1. Connect to the DB after migration
  2. `select id, name, priority from customers limit 5;` → verify existing rows show `priority = 100`
  3. `insert into customers (name, token, priority) values ('Test', 'tok-x', -1);` → verify constraint rejects with `23514` (check_violation)
  4. `insert into customers (name, token, priority) values ('Test', 'tok-y', 1);` → verify accepted
- [ ] Confirm `src/lib/supabase/types.ts` shows `priority: number` on the customers Row/Insert/Update types