### PR TITLE
Phase 3.1 — Admin customer CRUD UI with priority + email/phone OR validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .envrc
+.claude/scheduled_tasks.lock

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
+import { config } from "dotenv";
+
+config({ path: ".env.local" });
 
 export default defineConfig({
   testDir: "./tests",

--- a/src/actions/customers.ts
+++ b/src/actions/customers.ts
@@ -1,0 +1,87 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+
+export type CustomerInput = {
+  name: string;
+  business_name: string;
+  email: string;
+  phone: string;
+  delivery_address: string;
+  priority: number;
+  send_weekly_link: boolean;
+  is_active: boolean;
+};
+
+function validate(input: CustomerInput): string | null {
+  if (!input.name.trim()) return "Name is required.";
+  const hasEmail = input.email.trim().length > 0;
+  const hasPhone = input.phone.trim().length > 0;
+  if (!hasEmail && !hasPhone) return "At least one of email or phone is required.";
+  if (hasEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input.email.trim())) {
+    return "Email looks malformed.";
+  }
+  if (!Number.isInteger(input.priority) || input.priority < 0) {
+    return "Priority must be a whole number, zero or greater.";
+  }
+  return null;
+}
+
+function normalize(input: CustomerInput) {
+  return {
+    name: input.name.trim(),
+    business_name: input.business_name.trim() || null,
+    email: input.email.trim() || null,
+    phone: input.phone.trim() || null,
+    delivery_address: input.delivery_address.trim() || null,
+    priority: input.priority,
+    send_weekly_link: input.send_weekly_link,
+    is_active: input.is_active,
+  };
+}
+
+export async function createCustomer(input: CustomerInput): Promise<{ error: string | null; id: string | null }> {
+  const validationError = validate(input);
+  if (validationError) return { error: validationError, id: null };
+
+  const supabase = await createClient();
+  const placeholderToken = `placeholder-${crypto.randomUUID()}`;
+  const { data, error } = await supabase
+    .from("customers")
+    .insert({ ...normalize(input), token: placeholderToken })
+    .select("id")
+    .single();
+
+  if (error) return { error: error.message, id: null };
+  revalidatePath("/admin/customers");
+  return { error: null, id: data.id };
+}
+
+export async function updateCustomer(id: string, input: CustomerInput): Promise<string | null> {
+  const validationError = validate(input);
+  if (validationError) return validationError;
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("customers")
+    .update({ ...normalize(input), updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) return error.message;
+  revalidatePath("/admin/customers");
+  revalidatePath(`/admin/customers/${id}`);
+  return null;
+}
+
+export async function toggleCustomerActive(id: string, is_active: boolean): Promise<{ error: string | null }> {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("customers")
+    .update({ is_active, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) return { error: error.message };
+  revalidatePath("/admin/customers");
+  return { error: null };
+}

--- a/src/app/(admin)/admin/customers/[id]/page.tsx
+++ b/src/app/(admin)/admin/customers/[id]/page.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { CustomerForm } from "@/components/admin/customer-form";
+
+export default async function EditCustomerPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const { data: customer, error } = await supabase
+    .from("customers")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (error || !customer) notFound();
+
+  return (
+    <main style={{ padding: "32px 40px", maxWidth: 900 }}>
+      <div style={{ marginBottom: 8 }}>
+        <Link href="/admin/customers" style={{ fontSize: "0.82rem", color: "var(--ink-500)", textDecoration: "none" }}>
+          ← Customers
+        </Link>
+      </div>
+      <h1
+        style={{
+          fontFamily: "var(--font-display)",
+          fontSize: "1.5rem",
+          fontWeight: 600,
+          color: "var(--ink-900)",
+          marginBottom: 4,
+        }}
+      >
+        {customer.name}
+      </h1>
+      <p style={{ fontSize: "0.82rem", color: "var(--ink-500)", marginBottom: 24 }}>
+        Token: <code style={{ fontFamily: "var(--font-mono)" }}>{customer.token}</code>
+      </p>
+      <CustomerForm customer={customer} />
+    </main>
+  );
+}

--- a/src/app/(admin)/admin/customers/new/page.tsx
+++ b/src/app/(admin)/admin/customers/new/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { CustomerForm } from "@/components/admin/customer-form";
+
+export default function NewCustomerPage() {
+  return (
+    <main style={{ padding: "32px 40px", maxWidth: 900 }}>
+      <div style={{ marginBottom: 8 }}>
+        <Link href="/admin/customers" style={{ fontSize: "0.82rem", color: "var(--ink-500)", textDecoration: "none" }}>
+          ← Customers
+        </Link>
+      </div>
+      <h1
+        style={{
+          fontFamily: "var(--font-display)",
+          fontSize: "1.5rem",
+          fontWeight: 600,
+          color: "var(--ink-900)",
+          marginBottom: 24,
+        }}
+      >
+        New customer
+      </h1>
+      <CustomerForm />
+    </main>
+  );
+}

--- a/src/app/(admin)/admin/customers/page.tsx
+++ b/src/app/(admin)/admin/customers/page.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { CustomerActiveToggle } from "@/components/admin/customer-active-toggle";
+
+const thStyle: React.CSSProperties = {
+  padding: "10px 12px",
+  textAlign: "left",
+  fontSize: "0.72rem",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.08em",
+  color: "var(--ink-500)",
+  borderBottom: "2px solid var(--ink-100)",
+  whiteSpace: "nowrap",
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: "10px 12px",
+  borderBottom: "1px solid var(--ink-100)",
+  fontSize: "0.9rem",
+  color: "var(--ink-900)",
+};
+
+export default async function CustomersPage() {
+  const supabase = await createClient();
+  const { data: customers, error } = await supabase
+    .from("customers")
+    .select("*")
+    .order("priority", { ascending: true })
+    .order("name");
+
+  return (
+    <main style={{ padding: "32px 40px", maxWidth: 1100 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 24 }}>
+        <h1
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: "1.5rem",
+            fontWeight: 600,
+            color: "var(--ink-900)",
+            margin: 0,
+          }}
+        >
+          Customers
+        </h1>
+        <Link
+          href="/admin/customers/new"
+          style={{
+            padding: "8px 16px",
+            fontSize: "0.85rem",
+            fontWeight: 600,
+            background: "var(--leaf-600)",
+            color: "var(--paper)",
+            borderRadius: "var(--r-sm)",
+            textDecoration: "none",
+          }}
+        >
+          + New customer
+        </Link>
+      </div>
+
+      {error && <p style={{ color: "var(--destructive)", marginBottom: 16 }}>{error.message}</p>}
+
+      {!error && (!customers || customers.length === 0) && (
+        <p style={{ color: "var(--ink-500)" }}>No customers yet.</p>
+      )}
+
+      {customers && customers.length > 0 && (
+        <div style={{ overflowX: "auto" }}>
+          <table
+            style={{
+              width: "100%",
+              borderCollapse: "collapse",
+              background: "var(--paper)",
+              borderRadius: "var(--r-lg)",
+              boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
+              overflow: "hidden",
+            }}
+          >
+            <thead>
+              <tr style={{ background: "var(--ink-50)" }}>
+                <th style={thStyle}>Name</th>
+                <th style={thStyle}>Business</th>
+                <th style={thStyle}>Email</th>
+                <th style={thStyle}>Phone</th>
+                <th style={thStyle}>Priority</th>
+                <th style={thStyle}>Send link</th>
+                <th style={thStyle}>Status</th>
+                <th style={thStyle}><span style={{ position: "absolute", left: -9999 }}>Actions</span></th>
+              </tr>
+            </thead>
+            <tbody>
+              {customers.map((c) => (
+                <tr key={c.id} style={{ opacity: c.is_active ? 1 : 0.55 }}>
+                  <td style={tdStyle}>
+                    <Link href={`/admin/customers/${c.id}`} style={{ color: "var(--ink-900)", fontWeight: 500 }}>
+                      {c.name}
+                    </Link>
+                  </td>
+                  <td style={tdStyle}>{c.business_name ?? ""}</td>
+                  <td style={tdStyle}>{c.email ?? ""}</td>
+                  <td style={tdStyle}>{c.phone ?? ""}</td>
+                  <td style={tdStyle}>{c.priority}</td>
+                  <td style={tdStyle}>{c.send_weekly_link ? "Yes" : "No"}</td>
+                  <td style={tdStyle}>{c.is_active ? "Active" : "Inactive"}</td>
+                  <td style={{ ...tdStyle, textAlign: "right", whiteSpace: "nowrap" }}>
+                    <CustomerActiveToggle id={c.id} isActive={c.is_active} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/src/components/admin/customer-active-toggle.tsx
+++ b/src/components/admin/customer-active-toggle.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useTransition } from "react";
+import { toggleCustomerActive } from "@/actions/customers";
+
+export function CustomerActiveToggle({ id, isActive }: { id: string; isActive: boolean }) {
+  const [pending, startTransition] = useTransition();
+
+  function handleClick() {
+    startTransition(async () => {
+      await toggleCustomerActive(id, !isActive);
+    });
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={pending}
+      aria-label={isActive ? "Deactivate customer" : "Activate customer"}
+      style={{
+        padding: "4px 10px",
+        fontSize: "0.78rem",
+        fontWeight: 600,
+        background: isActive ? "var(--paper)" : "var(--leaf-600)",
+        color: isActive ? "var(--ink-700)" : "var(--paper)",
+        border: `1px solid ${isActive ? "var(--ink-200)" : "var(--leaf-600)"}`,
+        borderRadius: "var(--r-sm)",
+        cursor: pending ? "default" : "pointer",
+        opacity: pending ? 0.6 : 1,
+      }}
+    >
+      {pending ? "…" : isActive ? "Deactivate" : "Activate"}
+    </button>
+  );
+}

--- a/src/components/admin/customer-form.tsx
+++ b/src/components/admin/customer-form.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { Tables } from "@/lib/supabase/types";
+import { createCustomer, updateCustomer, type CustomerInput } from "@/actions/customers";
+
+type Customer = Tables<"customers">;
+
+const fieldStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 6,
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: "0.78rem",
+  fontWeight: 600,
+  color: "var(--ink-700)",
+};
+
+const inputStyle: React.CSSProperties = {
+  padding: "8px 10px",
+  fontSize: "0.9rem",
+  background: "var(--paper)",
+  border: "1px solid var(--ink-200)",
+  borderRadius: "var(--r-sm)",
+  color: "var(--ink-900)",
+  fontFamily: "var(--font-sans)",
+};
+
+export function CustomerForm({ customer }: { customer?: Customer }) {
+  const router = useRouter();
+  const [name, setName] = useState(customer?.name ?? "");
+  const [businessName, setBusinessName] = useState(customer?.business_name ?? "");
+  const [email, setEmail] = useState(customer?.email ?? "");
+  const [phone, setPhone] = useState(customer?.phone ?? "");
+  const [deliveryAddress, setDeliveryAddress] = useState(customer?.delivery_address ?? "");
+  const [priority, setPriority] = useState(String(customer?.priority ?? 100));
+  const [sendWeeklyLink, setSendWeeklyLink] = useState(customer?.send_weekly_link ?? true);
+  const [isActive, setIsActive] = useState(customer?.is_active ?? true);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSaved(false);
+    const input: CustomerInput = {
+      name,
+      business_name: businessName,
+      email,
+      phone,
+      delivery_address: deliveryAddress,
+      priority: parseInt(priority, 10),
+      send_weekly_link: sendWeeklyLink,
+      is_active: isActive,
+    };
+    startTransition(async () => {
+      if (customer) {
+        const err = await updateCustomer(customer.id, input);
+        if (err) setError(err);
+        else setSaved(true);
+      } else {
+        const result = await createCustomer(input);
+        if (result.error) setError(result.error);
+        else router.push("/admin/customers");
+      }
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1fr 1fr",
+        gap: 18,
+        maxWidth: 720,
+        background: "var(--paper)",
+        padding: 24,
+        borderRadius: "var(--r-lg)",
+        boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
+      }}
+    >
+      <label style={fieldStyle}>
+        <span style={labelStyle}>Name *</span>
+        <input style={inputStyle} value={name} onChange={(e) => setName(e.target.value)} required aria-label="Name" />
+      </label>
+
+      <label style={fieldStyle}>
+        <span style={labelStyle}>Business name</span>
+        <input style={inputStyle} value={businessName} onChange={(e) => setBusinessName(e.target.value)} aria-label="Business name" />
+      </label>
+
+      <label style={fieldStyle}>
+        <span style={labelStyle}>Email</span>
+        <input style={inputStyle} type="email" value={email} onChange={(e) => setEmail(e.target.value)} aria-label="Email" />
+      </label>
+
+      <label style={fieldStyle}>
+        <span style={labelStyle}>Phone</span>
+        <input style={inputStyle} type="tel" value={phone} onChange={(e) => setPhone(e.target.value)} aria-label="Phone" />
+      </label>
+
+      <label style={{ ...fieldStyle, gridColumn: "1 / -1" }}>
+        <span style={labelStyle}>Delivery address</span>
+        <input style={inputStyle} value={deliveryAddress} onChange={(e) => setDeliveryAddress(e.target.value)} aria-label="Delivery address" />
+      </label>
+
+      <label style={fieldStyle}>
+        <span style={labelStyle}>Priority (lower = sends earlier)</span>
+        <input
+          style={inputStyle}
+          type="number"
+          min="0"
+          step="1"
+          value={priority}
+          onChange={(e) => setPriority(e.target.value)}
+          aria-label="Priority"
+        />
+      </label>
+
+      <div style={{ ...fieldStyle, justifyContent: "flex-end" }}>
+        <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: "0.9rem" }}>
+          <input
+            type="checkbox"
+            checked={sendWeeklyLink}
+            onChange={(e) => setSendWeeklyLink(e.target.checked)}
+            aria-label="Send weekly link"
+            style={{ width: 16, height: 16, accentColor: "var(--leaf-600)" }}
+          />
+          <span>Send weekly link</span>
+        </label>
+        <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: "0.9rem" }}>
+          <input
+            type="checkbox"
+            checked={isActive}
+            onChange={(e) => setIsActive(e.target.checked)}
+            aria-label="Active"
+            style={{ width: 16, height: 16, accentColor: "var(--leaf-600)" }}
+          />
+          <span>Active</span>
+        </label>
+      </div>
+
+      <div style={{ gridColumn: "1 / -1", display: "flex", alignItems: "center", gap: 16, marginTop: 4 }}>
+        <button
+          type="submit"
+          disabled={pending}
+          style={{
+            padding: "8px 18px",
+            fontSize: "0.9rem",
+            fontWeight: 600,
+            background: "var(--leaf-600)",
+            color: "var(--paper)",
+            border: "none",
+            borderRadius: "var(--r-sm)",
+            cursor: pending ? "default" : "pointer",
+            opacity: pending ? 0.6 : 1,
+          }}
+        >
+          {pending ? "Saving…" : customer ? "Save changes" : "Create customer"}
+        </button>
+        {saved && <span style={{ fontSize: "0.85rem", color: "var(--leaf-700)" }}>Saved</span>}
+        {error && <span role="alert" style={{ fontSize: "0.85rem", color: "var(--destructive)" }}>{error}</span>}
+      </div>
+    </form>
+  );
+}

--- a/tests/admin-customers.spec.ts
+++ b/tests/admin-customers.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+import { ADMIN_STORAGE_STATE, TEST_CUSTOMERS } from "./helpers";
+
+function adminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+}
+
+// Each test uses a unique name + token so concurrent re-runs don't collide,
+// and afterEach scrubs anything inserted during the test.
+function uniqueName(base: string) {
+  return `${base} ${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+}
+
+test.describe("admin customers", () => {
+  test.use({ storageState: ADMIN_STORAGE_STATE });
+
+  const createdIds: string[] = [];
+  const renamedIds: { id: string; original: string }[] = [];
+  const emailedIds: string[] = [];
+
+  test.afterEach(async () => {
+    const supabase = adminClient();
+    if (createdIds.length) {
+      await supabase.from("customers").delete().in("id", createdIds);
+      createdIds.length = 0;
+    }
+    for (const { id, original } of renamedIds) {
+      await supabase.from("customers").update({ name: original }).eq("id", id);
+    }
+    renamedIds.length = 0;
+    if (emailedIds.length) {
+      await supabase.from("customers").update({ email: null }).in("id", emailedIds);
+      emailedIds.length = 0;
+    }
+  });
+
+  test("list renders existing customers", async ({ page }) => {
+    await page.goto("/admin/customers");
+    await expect(page.getByRole("heading", { name: /customers/i })).toBeVisible();
+    await expect(page.getByRole("cell", { name: TEST_CUSTOMERS.farmStand.name }).first()).toBeVisible();
+    await expect(page.getByRole("cell", { name: TEST_CUSTOMERS.restaurant.name }).first()).toBeVisible();
+  });
+
+  test("create flow: new customer appears in list", async ({ page }) => {
+    const name = uniqueName("Test Bakery");
+
+    await page.goto("/admin/customers");
+    await page.getByRole("link", { name: /new customer/i }).click();
+    await expect(page).toHaveURL(/\/admin\/customers\/new/);
+
+    await page.getByRole("textbox", { name: "Name", exact: true }).fill(name);
+    await page.getByRole("textbox", { name: "Email", exact: true }).fill("bakery@example.com");
+    await page.getByRole("spinbutton", { name: "Priority" }).fill("50");
+    await page.getByRole("button", { name: /create customer/i }).click();
+
+    await expect(page).toHaveURL(/\/admin\/customers$/);
+    await expect(page.getByRole("cell", { name })).toBeVisible();
+
+    // Track the created row for cleanup
+    const supabase = adminClient();
+    const { data } = await supabase.from("customers").select("id").eq("name", name).single();
+    if (data) createdIds.push(data.id);
+  });
+
+  test("create flow: rejects when both email and phone are empty", async ({ page }) => {
+    await page.goto("/admin/customers/new");
+    await page.getByRole("textbox", { name: "Name", exact: true }).fill(uniqueName("No Contact"));
+    await page.getByRole("button", { name: /create customer/i }).click();
+    await expect(page.getByText(/at least one of email or phone is required/i)).toBeVisible();
+    await expect(page).toHaveURL(/\/admin\/customers\/new/);
+  });
+
+  test("edit flow: updating name persists", async ({ page }) => {
+    const supabase = adminClient();
+    const { data: original, error } = await supabase
+      .from("customers")
+      .select("id, name")
+      .eq("token", TEST_CUSTOMERS.farmStand.token)
+      .single();
+    if (error || !original) throw new Error(`Could not find farm stand customer: ${error?.message}`);
+
+    const newName = uniqueName("Farm Stand Edited");
+    renamedIds.push({ id: original.id, original: original.name });
+    emailedIds.push(original.id);
+
+    await page.goto(`/admin/customers/${original.id}`);
+    await page.getByRole("textbox", { name: "Name", exact: true }).fill(newName);
+    // Seed customer has no email/phone; the OR-validation requires at least one
+    await page.getByRole("textbox", { name: "Email", exact: true }).fill("farmstand@example.com");
+    await page.getByRole("button", { name: /save changes/i }).click();
+
+    // Wait for the save round-trip: button re-enables (label flips back from "Saving…")
+    await expect(page.getByRole("button", { name: /save changes/i })).toBeEnabled();
+
+    // Verify persistence at the DB layer first (canonical truth)
+    const { data: updated } = await supabase.from("customers").select("name").eq("id", original.id).single();
+    expect(updated?.name).toBe(newName);
+
+    // Then verify the list view reflects it
+    await page.goto("/admin/customers");
+    await expect(page.getByRole("cell", { name: newName })).toBeVisible();
+  });
+
+  test("deactivate toggle flips status", async ({ page }) => {
+    // Seed an isolated customer for this test so the toggle doesn't affect others
+    const supabase = adminClient();
+    const name = uniqueName("Toggle Test");
+    const { data, error } = await supabase
+      .from("customers")
+      .insert({ name, token: `tgl-${Date.now()}`, email: "toggle@example.com", is_active: true })
+      .select("id")
+      .single();
+    if (error || !data) throw new Error(`Seed insert failed: ${error?.message}`);
+    createdIds.push(data.id);
+
+    await page.goto("/admin/customers");
+    const row = page.getByRole("cell", { name }).locator("xpath=ancestor::tr");
+    await row.getByRole("button", { name: /deactivate customer/i }).click();
+    await expect(row.getByRole("button", { name: /activate customer/i })).toBeVisible();
+    await expect(row).toContainText(/inactive/i);
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on PR #54 (task 3.0). Adds the admin customer management surface at `/admin/customers`:
- Server Component list (sorted by `priority ASC, name ASC`)
- `/admin/customers/new` and `/admin/customers/[id]` form routes sharing a `CustomerForm` Client Component
- Server Actions for create / update / toggle-active
- Validation: name required, at least one of email or phone (OR rule), email format if provided, priority integer ≥ 0
- Token auto-generated as `\`placeholder-\${crypto.randomUUID()}\`` — task 3.2 will replace with proper crypto generation and a regenerate button

Closes #46.

> ⚠ **Stacked PR.** Base is `task/3.0-customer-priority-column`. Merge #54 first; this PR will then resolve cleanly against `main`.

## Files changed
- `playwright.config.ts` — load `.env.local` via dotenv (same fix as PR #44, needed independently here off-main)
- `src/actions/customers.ts` (new) — createCustomer / updateCustomer / toggleCustomerActive
- `src/app/(admin)/admin/customers/page.tsx` (new) — list view
- `src/app/(admin)/admin/customers/new/page.tsx` (new) — create form route
- `src/app/(admin)/admin/customers/[id]/page.tsx` (new) — edit form route
- `src/components/admin/customer-form.tsx` (new) — shared form Client Component
- `src/components/admin/customer-active-toggle.tsx` (new) — list-row toggle button
- `tests/admin-customers.spec.ts` (new) — 5 Playwright tests
- `.gitignore` — exclude `.claude/scheduled_tasks.lock`

## Code review
@code-review (Sonnet) ran against the diff. All commentary / nits, no blockers:

- *commentary* — `placeholder-${randomUUID()}` token is ~122 bits of entropy, unguessable. **Carry-forward for 3.2:** make regenerate-token mandatory before `send_weekly_link` can fire, otherwise the `placeholder-` prefix would leak into customer URLs.
- *commentary* — Email regex + `type="email"` + server-side validate is correct defense-in-depth. Don't tighten the regex; RFC-correct ones are a tarpit.
- *commentary* — `onSubmit` + `e.preventDefault()` + direct server action via `useTransition` is the right idiom; the `action={fn}` form can't return values without `useActionState`.
- *commentary* — `priority ASC, name ASC` tie-breaker is the obvious second sort key. No @architect escalation needed.
- *commentary* — `toBeEnabled()` as save-completion signal is a legitimate pattern (`useTransition`'s pending settles only after the action resolves). Reliable, documented inline.
- *nit* — `parseInt("")` → `NaN` → slightly misleading "Priority must be…" error. Low priority since `<input type="number" min="0">` makes empty hard to reach.
- *nit* — `customer-form.tsx` at 171 lines (near 200-line soft ceiling). Fine for now; if 3.2 adds a regenerate-token block, extract field groups.

## Test plan
- [ ] Run `npx playwright test tests/admin-customers.spec.ts --project=desktop`; confirm 5 tests pass
- [ ] Run `supabase test db`; confirm 46 pgTAP tests pass (no schema changes here, smoke only)
- [ ] Manual smoke (on preview URL):
  1. Sign in as admin → navigate to `/admin/customers`
  2. Verify list shows all customers, sorted by priority then name; status column shows Active/Inactive; deactivated rows are faded
  3. Click **+ New customer** → verify URL is `/admin/customers/new` and form is empty
  4. Fill name only → click **Create customer** → verify "At least one of email or phone is required." error inline
  5. Add an email → click create → verify redirected to list view with the new customer visible
  6. Click the new customer's name → verify edit form pre-fills correctly; check the token displays with `placeholder-` prefix
  7. Change name + priority → click **Save changes** → verify button label flips back to "Save changes" (save round-trip complete) → reload → verify changes persist
  8. Return to list → click **Deactivate** on a row → verify status flips to Inactive immediately and row fades; click **Activate** → verify it flips back
- [ ] Sanity check the placeholder token reality: `select id, name, token from customers where token like 'placeholder-%';` → confirm 3.1-created rows are flagged for 3.2's regenerate step