### PR TITLE
auto-sync downstream — 2026-05-12

### DIFF
--- a/.claude/agents/sync-config.md
+++ b/.claude/agents/sync-config.md
@@ -31,7 +31,7 @@ The invoking caller passes `mode: interactive` (default) or `mode: auto`.
   - Stage commits with one of these literal message formats (no placeholders — substitute the actual values):
     - **PUSH:** `sync-config: push backport from <repo>` (e.g. `sync-config: push backport from bushel`)
     - **PULL:** `sync-config: pull propagate from seeds` (no `<repo>` — pull always sources from seeds)
-  One commit per source repo per direction. No empty commits.
+    One commit per source repo per direction. No empty commits.
   - Do NOT push, do NOT open a PR. The calling Routine handles git operations.
 
 If `mode` is missing, default to `interactive`. If `mode: auto` is requested but `direction` is also missing or ambiguous, STOP — auto mode requires both parameters resolved upfront.
@@ -61,9 +61,10 @@ If `mode` is missing, default to `interactive`. If `mode: auto` is requested but
 
 > `<file>` skipped — project type `<type>`, file applies to `[<allowed types>]` (manifest-gated)
 
-If `.claude/project-type` is absent or holds an unrecognized token, treat the project as **ungated** — diff every pair as before, no gating applied. Add a single one-liner to the Step 6 report so the reviewer knows the gate didn't fire:
+If `.claude/project-type` is absent or holds an unrecognized token, treat the project as **ungated** — diff every pair as before, no gating applied. Add a single one-liner to the Step 6 report so the reviewer knows the gate didn't fire. Use one of these two literal forms (substitute the actual token):
 
-> Project-type gating skipped — `.claude/project-type` is `<missing | unknown:"<token>">`. All template files diffed without filtering.
+- File missing: `Project-type gating skipped — .claude/project-type is missing. All template files diffed without filtering.`
+- Unknown token: `Project-type gating skipped — .claude/project-type is "<token>" (unrecognized; supported: webapp, tool). All template files diffed without filtering.`
 
 Type-gating is a **scoping decision**, not a hunk-level one. It removes file pairs from the diff scope before any classification happens. Hunks within an ungated file are still classified normally per Step 2.
 


### PR DESCRIPTION
## auto-sync downstream — 2026-05-12

Nightly sync routine (DEC-010), direction: **downstream** (seeds → bushel). Mode: `auto`. Nothing merges automatically — this PR is the human review checkpoint.

---

### Classification table

| File | Hunk | Provenance | Classification | Action |
|------|------|------------|----------------|--------|
| `agents/sync-config.md` | Ungated one-liner: two-form split (missing / unknown token) replacing single combined `<missing \| unknown:"<token>">` form | Template-only | Forward-port | Applied |
| `agents/ui-reviewer.md` | Bay Branch Farm customizations throughout (leaf-600 palette, customer vs admin surfaces, Source Sans 3 typography) | Both-modified | Skip | Skipped |
| `skills/kill-this/SKILL.md` | Step 3: supabase-specific `supabase migration new` example vs template's generic "a generator command" | Both-modified | Skip | Skipped |
| `CLAUDE.md` | "Stacking PRs" guidance with migration-specific language | Project-only | Flag | Flagged — see below |

---

### Files changed (1)

- `.claude/agents/sync-config.md` — ungated warning now uses explicit two-form: one literal for missing `.claude/project-type`, one for unrecognized token. Replaces the old combined `<missing | unknown:"<token>">` placeholder form.

---

### Pattern flags

**`CLAUDE.md` — Stacking PRs guidance (Project-only, flagged — not applied):**

> *"Stacking PRs is preferred when tasks depend on each other. Branch the next task off the previous task branch (`git checkout -b task/X.Y-next task/X.Y-prev`), not off main. Only wait for the previous PR to merge when there's a migration conflict on the same table."*

This pattern could generalize to the template's `§PR Workflow` section, but the sentence "Only wait for the previous PR to merge when there's a migration conflict on the same table" is migration-specific and would need pruning before landing in seeds. Not applied — flagged for your review.

---

### Skipped hunks

- **`agents/ui-reviewer.md`** — Both-modified throughout. Every section has been substantially customized for Bay Branch Farm (brand voice, color tokens, customer vs admin UI surfaces, typography). No hunk is cleanly structural — skipped in `mode: auto`. If you've made structural improvements (new review steps, new heuristics) that should flow back to seeds, run `/push-seeds` manually.
- **`skills/kill-this/SKILL.md`** — Both-modified. The supabase-specific example in Step 3 is a project substitution. Template now uses generic language ("a generator command"); your version names `supabase migration new` explicitly. This is correct project-specific content — not overwritten.

---

### Base

All changes sourced from seeds at `502f593` (seeds-version: 3). No upstream (bushel → seeds) backports warranted this run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6uv4ELE8GyxsGUEtf5hPQ)_