### PR TITLE
auto-sync downstream — 2026-05-13

### DIFF
--- a/.claude/skills/its-alive/SKILL.md
+++ b/.claude/skills/its-alive/SKILL.md
@@ -31,6 +31,37 @@ Run `git fetch origin` to refresh remote state. Capture `BRANCH=$(git branch --s
 - `main`: `git pull --ff-only origin main`. On divergence, show `git log --oneline origin/main..HEAD` and `git log --oneline HEAD..origin/main`, then ask: **"(a) rebase, (b) reset to origin/main, (c) abort?"** Wait for the choice.
 - Anything else (manual non-standard branch): if `git status --porcelain` is dirty, stop and ask the user to commit/stash. If clean, ask the user **"Stay on `$BRANCH` or switch to `main`?"** Wait for the choice — don't auto-switch.
 
+### Step 0.5 — Orphan branch + unmerged PR scan
+
+Before stamping time, check for leftover work from prior sessions. The CC platform creates a new `claude/*` branch per session, so previous sessions' branches and PRs stay alive on the remote until explicitly merged or deleted. This is the single biggest source of "I thought that was closed" surprises.
+
+**Resolve `WORKING_BRANCH`** (same logic as `/its-dead` Step 5):
+```
+git show-ref --verify --quiet refs/remotes/origin/staging && WORKING_BRANCH=staging || WORKING_BRANCH=main
+```
+
+**Scan A — remote `claude/*` branches with commits not on `$WORKING_BRANCH`:**
+```
+git for-each-ref refs/remotes/origin/claude/ --format='%(refname:short)'
+```
+For each `origin/claude/<slug>` (other than the current branch): `git log --oneline origin/$WORKING_BRANCH..<ref>`. If non-empty, it's a candidate.
+
+**Scan B — open PRs from prior sessions:**
+- `gh pr list --state open --base "$WORKING_BRANCH" --json number,title,headRefName,createdAt,updatedAt --limit 20` — or MCP `mcp__github__list_pull_requests` if `gh` is unavailable.
+
+**Cross-reference** the two scans. Three categories surface:
+| Category | Definition | Action |
+|----------|------------|--------|
+| Open-with-PR | Branch has unmerged commits AND an open PR | Tell the user; don't touch. They're "in flight." |
+| Orphan-without-PR | Branch has unmerged commits AND no open PR | **Real problem** — work would silently disappear. Surface with prompt: "(a) open a PR now, (b) cherry-pick onto current branch, (c) delete (commits will be lost)?" Wait. |
+| Stale-no-commits | Branch exists on remote but no commits ahead of `$WORKING_BRANCH` | Quietly suggest `git push origin --delete <ref>` if more than one such ref exists. |
+
+Also surface any open PR whose `createdAt` is more than 24h old — likely forgotten merges. List with: "⚠ PR #N (`<title>`) has been open since `<createdAt>`. Merge with `gh pr merge N --merge --delete-branch` or close if abandoned."
+
+This step is **advisory only** for in-flight work and **gating** for orphans-without-PR. Don't proceed past it without the user's explicit choice when an orphan is found.
+
+If `gh` and MCP are both unavailable, skip this step silently — log a note in Context. The user can run `/restart-this` or rerun `/its-alive` once those tools come back.
+
 ## Step 1 — Stamp the time
 
 ```
@@ -109,9 +140,15 @@ slug: <SLUG>
 branch: <BRANCH>
 started: <START_UTC>
 ended:
+wall_clock:
+dev_time:
+review_time:
 duration:
 points:
 status: open
+pr_number:
+pr_url:
+pr_opened_at:
 transcript: <TRANSCRIPT>
 ---
 

--- a/.claude/skills/its-dead/SKILL.md
+++ b/.claude/skills/its-dead/SKILL.md
@@ -24,15 +24,78 @@ If found: LEGACY MODE. Note this and proceed; all writes go to `session-log.md` 
 
 If neither: stop and ask the user how to proceed.
 
-## Step 1 — Calculate duration
+## Step 1 — Calculate time fields
 
-**End time:** `END_UTC=$(git log -1 --format="%cI")` (most recent commit ISO 8601 timestamp).
+Three numbers go into the session frontmatter, all in hours, rounded to nearest 5 minutes (0.083 hr). The session splits in two at `pr_opened_at`: everything before is dev work, everything after is review/close-out work.
 
-**Start time:**
+| Field | Window | Definition |
+|-------|--------|------------|
+| `wall_clock` | `started` → `ended` | Raw end−start. Includes idle. |
+| `dev_time` | `started` → `pr_opened_at` | Active dev time. Wall portion minus inferred breaks within that window. |
+| `review_time` | `pr_opened_at` → `ended` | Review + close-out time (addressing code-review findings, drafting log, running `/its-dead`). Wall portion minus inferred breaks within that window. |
+
+Merge happens AFTER `/its-dead` under DEC-012, so it's outside the session — not counted in any of these.
+
+`duration:` remains in the frontmatter as a synonym for `dev_time:` for legacy velocity-table readers — write both to the same value.
+
+### Step 1.0 — End time
+
+```
+END_UTC=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+```
+(Not `git log -1 --format="%cI"` — that's the last commit's time, which can be hours earlier than session close if the user reviewed the /kill-this draft for a while. Wall clock means right now.)
+
+### Step 1.1 — Start time
+
 - NEW MODE: parse `started:` from the session file's YAML frontmatter.
 - LEGACY MODE: parse the timestamp from the `## Session N — YYYY-MM-DD HH:MM [open]` heading.
 
-Compute `END_UTC - START_UTC` in hours, rounded to nearest 5 minutes (0.083 hr). Apply any time adjustment from skill args (e.g. "subtract 30 minutes" → reduce by 0.5 hr). If you cannot confidently determine duration, ask the user.
+### Step 1.2 — wall_clock
+
+`WALL_CLOCK = (END_UTC − START_UTC) in hours`. Round to nearest 0.083 hr.
+
+### Step 1.3 — Break inference (per window)
+
+A "break" is any gap between consecutive transcript JSONL entries longer than the **15-minute threshold**.
+
+**How to compute:**
+1. Read `transcript:` path from the session frontmatter.
+2. If the file exists: extract each line's `timestamp` field, sort, and walk pairwise. For each gap > 15 min, classify it by the gap-start timestamp:
+   - Gap-start ≤ `pr_opened_at` → dev-window break.
+   - Gap-start > `pr_opened_at` → review-window break.
+3. If the file is missing or unreadable: skip inference (both window breaks = 0) and note `inference: unavailable` in the Context section.
+
+Multiple JSONL files may exist if the session was compacted — Glob all `*.jsonl` in the transcript directory whose first timestamp is ≥ `started`, concatenate timestamps, sort.
+
+**Manual adjustment from skill args:** if the user passed adjustments (e.g. `/its-dead subtract 30 minutes for time away from desk`), apply on top of inference. Ask which window the adjustment belongs to if not obvious from the user's phrasing; default to dev-window if ambiguous.
+
+### Step 1.4 — dev_time
+
+If `pr_opened_at` is **set** in the frontmatter (normal case — /kill-this ran):
+```
+dev_window = pr_opened_at − started
+dev_time = max(0, dev_window − dev_window_breaks − dev_window_adjustment)
+```
+
+If `pr_opened_at` is **blank** (STATE=NO_PR — /kill-this didn't open a PR):
+```
+dev_time = wall_clock − all_breaks − adjustments
+review_time = 0
+```
+The whole session was effectively dev work — no review phase. Skip Step 1.5.
+
+### Step 1.5 — review_time
+
+```
+review_window = ended − pr_opened_at
+review_time = max(0, review_window − review_window_breaks − review_window_adjustment)
+```
+
+`review_time` captures work done after the PR was opened: addressing `@code-review` findings, drafting the session entry, running `/its-dead`. The user-merge that happens AFTER `/its-dead` is outside this window — DEC-012 puts the merge outside the session entirely.
+
+If `wall_clock < 0.25h`, skip both window inferences — there's not enough span. Set `dev_time = wall_clock - any adjustments`, `review_time = 0`.
+
+If you cannot confidently determine any of these, ask the user. Never guess.
 
 ## Step 2 — Tally points
 
@@ -54,7 +117,10 @@ Use whichever produced a number. If both are empty, mark `points: 0` with a note
 **NEW MODE:** edit the session file:
 1. Update frontmatter:
    - `ended: <END_UTC>`
-   - `duration: <hours>` (e.g. `2.5`)
+   - `wall_clock: <WALL_CLOCK>` (e.g. `4.5`)
+   - `dev_time: <DEV_TIME>` (e.g. `2.5`)
+   - `review_time: <REVIEW_TIME>` (blank if not yet known — next /its-alive backfills)
+   - `duration: <DEV_TIME>` (synonym for dev_time, kept for legacy readers)
    - `points: <sum>`
    - `status: closed`
 2. Replace the body sections with the approved /kill-this draft (Task, Completed, In Progress, Blocked, Next Steps, Context, Code Review).
@@ -145,7 +211,33 @@ Done.
   If `git branch -d` fails: tell the user, provide `git branch -D` to run manually.
   Then continue to Step 5.3 for the post-merge version bump.
 - **STATE=CLOSED:** STOP. Ask: "PR was closed without merging — discard this branch or keep?" Wait.
-- **STATE=NO_PR:** legacy DEC-005 cleanup (orphan auto-branches like `claude/<slug>`):
+- **STATE=NO_PR:** legacy DEC-005 cleanup (orphan auto-branches like `claude/<slug>`) — but **first detect protected `$WORKING_BRANCH`** (DEC-012). If `$WORKING_BRANCH` rejects direct push, drop into the PR-creation fallback rather than failing:
+
+  **Protection probe (do this before the cleanup attempt):**
+  ```
+  PROTECTED=0
+  if gh api "repos/{owner}/{repo}/branches/$WORKING_BRANCH/protection" --silent 2>/dev/null; then PROTECTED=1; fi
+  ```
+  (If `gh` is unavailable, also try MCP `mcp__github__pull_request_read`-adjacent endpoints; if both unavailable, attempt the push and catch a 403 as `PROTECTED=1`.)
+
+  **If `PROTECTED=1` (protected-main fallback):**
+  Treat this as if the session ran without a PR by accident. Open one now:
+  a. `git add $FILES && git commit -m "Update session log for session $N"` on the current branch.
+  b. `git push origin $BRANCH`.
+  c. Compose a minimal PR body:
+     ```
+     ## Summary
+     Session $N close-out — PR opened by /its-dead because direct push to `$WORKING_BRANCH` is protected and no PR existed from /kill-this.
+
+     ## Files changed
+     <list from git diff --name-only origin/$WORKING_BRANCH..HEAD>
+     ```
+  d. Try `gh pr create --base "$WORKING_BRANCH" --head "$BRANCH" --title "Session $N close-out" --body "..."`. On non-zero exit, fall back to `mcp__github__create_pull_request`. On both failing, STOP and ask user to open manually.
+  e. Capture the resulting PR URL. **Set `STATE=OPEN`** (the protected-main fallback effectively turns this into an OPEN-state close) and continue to Step 6, which will surface the merge instruction.
+  f. Do NOT delete the branch — the PR is the merge gate now.
+  No version bump on this path — the post-merge bump waits for the next session's /its-alive (which detects the merge during orphan-branch scan and triggers Step 5.3 retroactively) or for `/its-dead` of the merging session.
+
+  **If `PROTECTED=0` (unprotected main — original DEC-005 path):**
   a. `git add $FILES && git commit -m "..."` on the current branch.
   b. `git checkout $WORKING_BRANCH` (or `git checkout -b $WORKING_BRANCH origin/$WORKING_BRANCH` if no local copy yet). `git pull --ff-only origin $WORKING_BRANCH`.
   c. `git merge --ff-only $BRANCH`. If can't FF, surface and ask.
@@ -153,7 +245,7 @@ Done.
   e. `git push origin --delete $BRANCH`. Capture success/failure.
   f. If remote delete failed: append `**Orphan branch:** \`$BRANCH\` could not be deleted on origin (best-effort failure). Manual cleanup via GitHub UI required.` to the session file's Context section. Amend the commit.
   g. `git push origin $WORKING_BRANCH`.
-  No version bump for NO_PR — it's a legacy cleanup path, not a real merge event. (If a project on this path adopts semver, it should also adopt PR flow.)
+  No version bump for NO_PR — it's a legacy cleanup path, not a real merge event.
 
 ### Step 5.3 — Version bump (dev projects only, post-merge)
 
@@ -203,9 +295,29 @@ f. **Echo:** `Version bumped: v<previous> → v<NEW_VERSION>` (and `tag: v<NEW_V
 
 ## Step 6 — Closing summary
 
-Print a one-line summary:
+The summary must be **conditional on the resolved `STATE`** — never report a flat "Session N closed" when there's still an action waiting. The user reads this line and walks away; if a PR is open they'll forget it sat there.
+
+**STATE=OPEN (most common on protected-main PR-flow projects):**
 ```
-Session <N> closed. Duration: <hours>h. Points: <N>. File: <path>.
+Session <N> closed. Wall: <wall_clock>h | Dev: <dev_time>h | Pts: <N>.
+⚠ PR #<X> is OPEN — merge to ship:
+    gh pr merge <X> --merge --delete-branch
+or via GitHub UI. Branch `$BRANCH` lives until merged. Review time fills in next /its-alive.
 ```
 
-If on a PR-flow project and the phase rituals are in use, also say: "Phase progress: see `gh issue list --label phase:current --state open` — close out remaining issues, then `/retro` at phase boundary."
+**STATE=MERGED:**
+```
+Session <N> closed. Wall: <wall_clock>h | Dev: <dev_time>h | Review: <review_time>h | Pts: <N>.
+PR #<X> merged. Branch cleaned. Version bumped: v<previous> → v<NEW_VERSION>.
+```
+Drop the version-bump line if Step 5.3 skipped (non-dev project, etc.).
+
+**STATE=NO_PR (legacy DEC-005 direct-push to unprotected main):**
+```
+Session <N> closed. Wall: <wall_clock>h | Dev: <dev_time>h | Pts: <N>.
+Cleaned up `$BRANCH`.
+```
+
+**STATE=CLOSED:** the skill already STOPped in Step 5.2 awaiting user direction; no closing summary fires from that path.
+
+If on a PR-flow project and the phase rituals are in use, append: "Phase progress: see `gh issue list --label phase:current --state open` — close out remaining issues, then `/retro` at phase boundary."

--- a/.claude/skills/kill-this/SKILL.md
+++ b/.claude/skills/kill-this/SKILL.md
@@ -117,6 +117,24 @@ On success (exit 0, URL printed): capture URL. Done.
 
 Capture the returned PR URL. Surface it in your response and note it in the draft session log entry's `Context` section.
 
+### Step 4.3 — Record PR anchors in session frontmatter
+
+Write three fields to the open session file's YAML frontmatter so `/its-dead` Step 1.4 and the next `/its-alive` review_time backfill can find them:
+
+```
+pr_number: <PR_NUMBER>
+pr_url: <PR_URL>
+pr_opened_at: <ISO 8601 timestamp of this PR creation>
+```
+
+For Method 1 (`gh pr create`): capture the URL from stdout; the `pr_opened_at` is "right now" — use `date -u +%Y-%m-%dT%H:%M:%SZ`.
+For Method 2 (MCP): the response body contains `created_at` — use that for `pr_opened_at`.
+For Method 3 (manual fallback): leave the three fields blank; the user will fill in or let backfill skip.
+
+If `EXISTING_PR_STATE=OPEN` and Step 4.2 was skipped: still write these fields, capturing them from the existing PR's data (Method 1: `gh pr view "$BRANCH" --json number,url,createdAt`; Method 2: the MCP `list_pull_requests` response already includes `created_at` and `html_url`).
+
+If `EXISTING_PR_STATE=MERGED`: write `pr_number`, `pr_url`, `pr_opened_at`, AND `pr_merged_at` from the PR's `merged_at`. /its-dead Step 1.4 will compute `review_time` directly without backfill.
+
 ## Step 5 — Draft session log entry
 
 Find the open session — try new format first:


### PR DESCRIPTION
## Summary

Forward-port 3 skill improvements from seeds to bushel: Step 0.5 (orphan branch scan) + expanded session frontmatter in `its-alive`; multi-field time tracking (wall\_clock / dev\_time / review\_time) in `its-dead`; and Step 4.3 (PR anchor recording) in `kill-this`.

Base: main

## Classification table

| File | Hunk | Provenance | Classification | Action |
|------|------|------------|----------------|--------|
| `skills/its-alive/SKILL.md` | Step 0.5 — Orphan branch + unmerged PR scan (new step before Step 1; scans remote claude/* branches and open PRs for leftover work) | Template-only | Forward-port | Forward-ported |
| `skills/its-alive/SKILL.md` | Session frontmatter expanded: `wall_clock`, `dev_time`, `review_time`, `pr_number`, `pr_url`, `pr_opened_at` fields added | Template-only | Forward-port | Forward-ported |
| `skills/its-dead/SKILL.md` | Multi-field time model: three-field split at `pr_opened_at` (wall\_clock / dev\_time / review\_time); per-window break inference; conditional closing summary by STATE | Template-only | Forward-port | Forward-ported |
| `skills/its-dead/SKILL.md` | Protected-main fallback (DEC-012): NO\_PR path now probes branch protection and opens a PR instead of attempting direct push | Template-only | Forward-port | Forward-ported |
| `skills/kill-this/SKILL.md` | Step 4.3 — Record PR anchors in session frontmatter (`pr_number`, `pr_url`, `pr_opened_at`) after PR creation | Template-only | Forward-port | Forward-ported |
| `skills/kill-this/SKILL.md` | Step 3 example text: `supabase migration new` (bushel project-specific wording) | Project-only | Skip | Skipped — bushel project-specific text preserved |

## Files changed

- `.claude/skills/its-alive/SKILL.md`
- `.claude/skills/its-dead/SKILL.md`
- `.claude/skills/kill-this/SKILL.md`

## Pattern flags

None.

## Skipped hunks

- `skills/kill-this/SKILL.md` Step 3 example: bushel uses `` `supabase migration new` creates the migration file empty `` (project-specific); seeds template uses generic `a generator command creates the file initially empty`. Bushel's concrete text preserved.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186KB62jUTy9VpW6ZesQ7JY)_