### PR TITLE
Infra — Stable preview.baybranchfarm.com URL + OAuth callback bugfix

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,12 @@
       "Bash(cat ~/.claude/devname 2>/dev/null && echo \"FOUND\" || echo \"MISSING\")",
       "Bash(git config *)",
       "Bash(xargs -n1 git branch -d)",
-      "Bash(awk -F= '{print $1}')"
+      "Bash(awk -F= '{print $1}')",
+      "Bash(vercel --version)",
+      "Bash(vercel whoami *)",
+      "Bash(dig +short preview.baybranchfarm.com CNAME)",
+      "Bash(dig +short preview.baybranchfarm.com)",
+      "Skill(kill-this)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,7 +319,7 @@ To keep the preview URL bookmarkable on a phone, a fixed subdomain points at whi
 - Supabase Dashboard → Authentication → URL Configuration → Redirect URLs → add `https://preview.baybranchfarm.com/**`.
 - **Double-star, not single-star.** `/*` matches one path segment only (so `/auth/callback` fails to match); `/**` matches any path. A single-star slip costs an hour of "auth almost works" debugging — Supabase silently falls back to Site URL on a non-match, and the user lands on `/?code=...` with the callback route never running. Session 19 (2026-05-14) burned this exact hour.
 
-If the subdomain returns 500 right after reassignment, the new branch hasn't pushed a commit yet — Vercel only builds on new SHAs. An empty commit (`git commit --allow-empty -m "Trigger preview"`) kicks a build.
+If the subdomain returns 500 or 404 right after reassignment, the new branch hasn't pushed a commit yet — Vercel only builds on new SHAs (404 = no deployment exists for that branch; 500 = deployment exists but is broken, usually a different bug). An empty commit (`git commit --allow-empty -m "Trigger preview"`) kicks a build.
 
 ## Versioning
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,6 +317,7 @@ To keep the preview URL bookmarkable on a phone, a fixed subdomain points at whi
 
 **Supabase OAuth allowlist (one-time):**
 - Supabase Dashboard → Authentication → URL Configuration → Redirect URLs → add `https://preview.baybranchfarm.com/**`.
+- **Double-star, not single-star.** `/*` matches one path segment only (so `/auth/callback` fails to match); `/**` matches any path. A single-star slip costs an hour of "auth almost works" debugging — Supabase silently falls back to Site URL on a non-match, and the user lands on `/?code=...` with the callback route never running. Session 19 (2026-05-14) burned this exact hour.
 
 If the subdomain returns 500 right after reassignment, the new branch hasn't pushed a commit yet — Vercel only builds on new SHAs. An empty commit (`git commit --allow-empty -m "Trigger preview"`) kicks a build.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,24 @@ The wrapper only catches CLI ops. The following are **not** guarded — they rel
 - Direct `psql` against the prod URL.
 - Any tool that doesn't go through the `supabase` binary.
 
+### Cross-system env-var sync (Supabase ↔ Vercel)
+
+**Switching Supabase project refs requires re-syncing Vercel env vars in lockstep.** The two systems do not auto-sync.
+
+When `.env.local`'s `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` / `SUPABASE_SERVICE_ROLE_KEY` change (project ref rotated, account split, key rotated), the Vercel **Production AND Preview** environments must be updated to match — same names, same values — and then redeployed. Vercel does not redeploy automatically on env-var change.
+
+Failure mode if missed: `createServerClient()` gets `undefined` for URL or key and the deployed app returns `HTTP 500` site-wide. Local `npm run dev` keeps working because it reads `.env.local` directly, which masks the regression until someone hits the deployed site. Session 19 (2026-05-14) lost an hour to this exact gap during the bushel/sailbook account split.
+
+Diff-check the three vars against `.env.local` after any rotation:
+
+```bash
+vercel env pull --environment=production .env.production.tmp
+vercel env pull --environment=preview    .env.preview.tmp
+diff <(grep -E "SUPABASE" .env.local | sort) <(grep -E "SUPABASE" .env.production.tmp | sort)
+```
+
+Variable names must match exactly — a typo in the Vercel-side name (e.g., `SUPABASE_ANON_KEY` instead of `NEXT_PUBLIC_SUPABASE_ANON_KEY`) will produce the same 500 even when the value is correct.
+
 ## Commands
 ```bash
 # Development
@@ -278,9 +296,29 @@ After that, `/kill-this` PRs into `staging`, bumps are untagged on `staging`, an
 
 ### Mobile PR review (developer notes)
 - GitHub mobile app, not web.
-- Tap the preview URL first.
+- Tap the preview URL first — prefer the stable `preview.baybranchfarm.com` over the per-PR Vercel URL (see below).
 - Auto-merge enabled per PR after CI green.
 - Branch protection: require CI green; skip reviewer-count requirements for solo phase.
+
+### Stable preview URL — `preview.baybranchfarm.com`
+
+To keep the preview URL bookmarkable on a phone, a fixed subdomain points at whichever task branch's preview deployment you're currently reviewing. Reassigned per active branch.
+
+**DNS (Cloudflare, one-time):**
+- Record: `CNAME`, Name `preview`, Target `cname.vercel-dns.com`.
+- **Proxy: DNS only** (gray cloud). Orange-cloud proxying breaks Vercel's TLS chain.
+
+**Vercel domain (one-time):**
+- Project → Settings → Domains → Add `preview.baybranchfarm.com`.
+
+**Per-branch reassignment (every new task branch):**
+- Project → Settings → Domains → `preview.baybranchfarm.com` → **Edit** → Git Branch → select `task/X.Y-current-branch` → Save.
+- New preview build for that branch repoints the subdomain. ~30s.
+
+**Supabase OAuth allowlist (one-time):**
+- Supabase Dashboard → Authentication → URL Configuration → Redirect URLs → add `https://preview.baybranchfarm.com/**`.
+
+If the subdomain returns 500 right after reassignment, the new branch hasn't pushed a commit yet — Vercel only builds on new SHAs. An empty commit (`git commit --allow-empty -m "Trigger preview"`) kicks a build.
 
 ## Versioning
 

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -3,8 +3,7 @@ import { createServerClient } from "@supabase/ssr";
 import type { Database } from "@/lib/supabase/types";
 
 export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
-  const origin = `${request.headers.get("x-forwarded-proto") ?? "http"}://${request.headers.get("host")}`;
+  const { searchParams, origin } = request.nextUrl;
   const code = searchParams.get("code");
   const next = searchParams.get("next") ?? "/";
 

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { createServerClient } from "@supabase/ssr";
+import type { Database } from "@/lib/supabase/types";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -11,7 +12,25 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(`${origin}/login?error=missing_code`);
   }
 
-  const supabase = await createClient();
+  const response = NextResponse.redirect(`${origin}${next}`);
+
+  const supabase = createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            response.cookies.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+
   const { error } = await supabase.auth.exchangeCodeForSession(code);
 
   if (error) {
@@ -20,5 +39,5 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  return NextResponse.redirect(`${origin}${next}`);
+  return response;
 }


### PR DESCRIPTION
closes #60

## Summary

Stands up `preview.baybranchfarm.com` as a stable mobile-review URL and fixes a latent bug in `src/app/auth/callback/route.ts` that prevented OAuth sessions from persisting on any deployed environment.

Issue #69 filed for the follow-up automation that auto-rebinds the preview subdomain on new task branches.

## Files changed

- `.claude/settings.local.json` — permission allowlist for vercel/dig/Skill(kill-this).
- `CLAUDE.md` — two new subsections: §Migration Protocol "Cross-system env-var sync (Supabase ↔ Vercel)" and §PR Workflow "Stable preview URL — preview.baybranchfarm.com". Includes the `/**` vs `/*` Supabase allowlist gotcha and the 404/500 fresh-branch-no-SHA gotcha.
- `src/app/auth/callback/route.ts` — rewritten to attach session cookies directly to the redirect response, mirroring the working pattern in `src/lib/supabase/middleware.ts`. The old code used the `cookies()`-from-`next/headers` helper, which writes into an implicit response that `NextResponse.redirect()` discards — `exchangeCodeForSession` succeeded but cookies never reached the browser, so `/admin/*` bounced back to `/login`.

## Code review

Clean bill from @code-review. Three small nits raised, two folded in (use `request.nextUrl.origin`; clarify 404 vs 500 in the docs). Third nit was a suggestion to add a Playwright test for the callback — explicitly out of scope per user direction this session (no automated coverage for deployment-adjacent infra; real-usage signal is the test).

## Test plan

- [ ] **OAuth on preview** — sign-in already verified end-to-end during the session that produced this PR. On the deployed preview, sign in with Google → navigate to `/admin/inventory` → confirm you reach the admin shell (not bounced to `/login`).
- [ ] **OAuth on prod** (after merge) — `order.baybranchfarm.com/login` → Sign in with Google → `/admin/inventory` → confirm same behavior.
- [ ] **CLAUDE.md sanity** — open the two new subsections (§Migration Protocol "Cross-system env-var sync" and §PR Workflow "Stable preview URL") and skim for accuracy against your current Vercel/Supabase setup.
- [ ] **Build** — `npm run build` already green locally; CI will re-verify.

## Out of scope

- Auto-rebind of `preview.baybranchfarm.com` to new task branches → #69.
- Playwright coverage for the OAuth callback → not filed (rejected per session 19 direction; deployment infra is exempt from automated smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)