### PR TITLE
auto-sync downstream — 2026-05-14

### DIFF
--- a/.claude/agents/tape-reader.md
+++ b/.claude/agents/tape-reader.md
@@ -1,6 +1,6 @@
 ---
 name: tape-reader
-description: Analyzes session JSONL transcripts for workflow anti-patterns and proposes targeted improvements to skill and agent files. Invoked by /read-the-tape. Covers known patterns P1–P11 and surfaces new candidates to grow its own checklist.
+description: Analyzes session JSONL transcripts for workflow anti-patterns and proposes targeted improvements to skill and agent files. Invoked by /read-the-tape. Covers known patterns P1–P15 and surfaces new candidates to grow its own checklist.
 tools: Read, Edit, Write, Bash, Glob, Grep
 ---
 
@@ -129,9 +129,41 @@ For each pattern, note: **occurred / not found / inconclusive**.
 
 ---
 
+### P12 — /its-dead invoked twice in the same session
+**Signal:** Two /its-dead invocations in same session within 90-120s
+**Why it hurts:** Second run finds no [open] entry, produces corrupt log
+**Fix:** Guard check at top of its-dead Step 0
+**Files:** `.claude/skills/its-dead/SKILL.md`
+
+---
+
+### P13 — Bash cat used instead of Read tool
+**Signal:** `cat <file>` or `cat <file> | head -N` to read source files
+**Why it hurts:** Loses line-numbered format; unbounded cat is P1 violation
+**Fix:** Use Read tool with offset/limit
+**Files:** The calling skill's SKILL.md
+
+---
+
+### P14 — Repeated reads of same error-context file
+**Signal:** Same `test-results/*/error-context.md` read 2+ times
+**Why it hurts:** Multiple round trips to recover info available in first read
+**Fix:** `grep -A 50 "Error details" <error-context-file>`
+**Files:** Not a skill file — note in findings report
+
+---
+
+### P15 — Test retries masking shared-state race conditions
+**Signal:** `{ retries: N }` on specific test with race condition comment
+**Why it hurts:** Papers over isolation problem; gets worse as suite grows
+**Fix:** Namespace shared resource by test ID, proper isolation
+**Files:** Not a skill file — flag in findings report
+
+---
+
 ## Step 3 — Look for new patterns
 
-Beyond P1–P11, scan for friction signals not yet on the list:
+Beyond P1–P15, scan for friction signals not yet on the list:
 
 - Any tool call that failed and was retried 2+ times
 - The same file being read multiple times in the same session
@@ -194,7 +226,7 @@ If nothing was approved, skip the PR entirely. Report findings only.
 If Step 3 found new patterns, list them clearly:
 
 > **Candidate patterns for @tape-reader:**
-> - CX: [description] — suggest adding as P12
+> - CX: [description] — suggest adding as P16
 >
 > To add: edit `.claude/agents/tape-reader.md` and add to the known-patterns section. Then `/push-seeds` to backport.
 


### PR DESCRIPTION
## Classification table

| File | Hunk | Provenance | Classification | Action |
|------|------|------------|----------------|--------|
| `.claude/agents/tape-reader.md` | description line "P1–P11" → "P1–P15" | Template-only | Structural: pattern count updated | Forward-port |
| `.claude/agents/tape-reader.md` | P12 — /its-dead invoked twice | Template-only | Structural: new pattern definition | Forward-port |
| `.claude/agents/tape-reader.md` | P13 — Bash cat instead of Read tool | Template-only | Structural: new pattern definition | Forward-port |
| `.claude/agents/tape-reader.md` | P14 — Repeated reads of error-context file | Template-only | Structural: new pattern definition | Forward-port |
| `.claude/agents/tape-reader.md` | P15 — Test retries masking race conditions | Template-only | Structural: new pattern definition | Forward-port |
| `.claude/agents/tape-reader.md` | Step 3 "Beyond P1–P11" → "Beyond P1–P15" | Template-only | Structural: scan range updated | Forward-port |
| `.claude/agents/tape-reader.md` | Step 7 candidate numbering "P12" → "P16" | Template-only | Structural: next candidate slot updated | Forward-port |
| `.claude/agents/ui-reviewer.md` | Entire file — design system content | Both-modified | Project-specific rewrite vs generic template | Skip |
| `.claude/skills/kill-this/SKILL.md` | Step 3 example wording (supabase-specific vs generic) | Project-only | Project-specific stack reference | Skip |
| `CLAUDE.md` | All sections | Both-modified | Extensive project customization | Skip |
| `docs/BRAND.md` | Entire file | Project-only | Project-specific branding | Skip |
| `docs/DECISIONS.md` | Entire file | Project-only | Project-specific decisions | Skip |
| `docs/PROJECT_PLAN.md` | Entire file | Project-only | Project-specific plan | Skip |
| `docs/RETROSPECTIVES.md` | Entire file | Project-only | Project-specific retros | Skip |
| `docs/SPEC.md` | Entire file | Project-only | Project-specific spec | Skip |
| `docs/USER_STORIES.md` | Entire file | Project-only | Project-specific stories | Skip |

## Files changed
- `.claude/agents/tape-reader.md` — added P12–P15 pattern definitions, updated description and step references

## Pattern flags
None

## Skipped hunks
- `ui-reviewer.md` — entire content is Both-modified (project rewrote for Bay Branch Farm two-surface design system vs generic shadcn template); no template-only structural improvements identifiable without risk of overwriting project content
- `kill-this/SKILL.md` — only diff is project-specific stack reference in an example comment (seeds generic "a generator command", bushel specific "`supabase migration new`"); seeds version is already more generic, no downstream action needed
- `CLAUDE.md` — extensively project-customized on both sides; all seeds-side content is placeholder/template text that bushel has already filled in; no structural template improvements to carry over
- All `docs/` files except matching SHAs — project-only content (decisions, plan, retros, spec, user stories, brand)

## Base
Targeting `main` — staging not found, using main

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bo85PSwZXnojK2tcYFYjYU)_