### PR TITLE
Phase 3.4 — Customer inventory page + order form (no submission)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,9 @@
       "Bash(vercel whoami *)",
       "Bash(dig +short preview.baybranchfarm.com CNAME)",
       "Bash(dig +short preview.baybranchfarm.com)",
-      "Skill(kill-this)"
+      "Skill(kill-this)",
+      "Bash(kill 3819251)",
+      "Bash(kill 4010112)"
     ]
   }
 }

--- a/sessions/2026-05-14-0346-eric-main.md
+++ b/sessions/2026-05-14-0346-eric-main.md
@@ -11,9 +11,9 @@ review_time:
 duration:
 points:
 status: open
-pr_number:
-pr_url:
-pr_opened_at:
+pr_number: 72
+pr_url: https://github.com/mobiustripper42/bushel/pull/72
+pr_opened_at: 2026-05-14T10:44:57Z
 transcript: /home/eric/.claude/projects/-home-eric-bushel/f1486eba-2cf3-4611-8068-d4d9177b4d6c.jsonl
 ---
 

--- a/src/app/c/[token]/not-found.tsx
+++ b/src/app/c/[token]/not-found.tsx
@@ -1,0 +1,56 @@
+import { StatusShell } from "@/components/customer/StatusShell";
+
+export default function CustomerTokenNotFound() {
+  return (
+    <StatusShell>
+      <div className="status-art">
+        <svg
+          viewBox="0 0 200 140"
+          width="180"
+          height="126"
+          aria-hidden="true"
+        >
+          <path
+            d="M40 100 L80 70"
+            stroke="#3B6D11"
+            strokeOpacity="0.5"
+            strokeWidth="3"
+            strokeLinecap="round"
+          />
+          <path
+            d="M120 70 L160 40"
+            stroke="#3B6D11"
+            strokeOpacity="0.5"
+            strokeWidth="3"
+            strokeLinecap="round"
+          />
+          <circle cx="92" cy="62" r="2.5" fill="#3B6D11" opacity="0.4" />
+          <circle cx="100" cy="56" r="2" fill="#3B6D11" opacity="0.3" />
+          <circle cx="108" cy="62" r="2.5" fill="#3B6D11" opacity="0.4" />
+          <path
+            d="M40 100 Q30 96 28 88 Q36 90 42 96 Z"
+            fill="#3B6D11"
+            opacity="0.45"
+          />
+          <path
+            d="M160 40 Q170 44 172 52 Q164 50 158 44 Z"
+            fill="#3B6D11"
+            opacity="0.45"
+          />
+        </svg>
+      </div>
+      <div className="status-eyebrow eyebrow">link expired</div>
+      <h1 className="status-title">This link doesn&rsquo;t work anymore.</h1>
+      <p className="status-lede">Text Annabel and she&rsquo;ll send a fresh one.</p>
+      <div className="status-actions">
+        <a href="sms:2162025718" className="btn btn-primary status-btn">
+          Text Annabel · 216-202-5718
+        </a>
+      </div>
+      <p className="status-fine">
+        Links expire when they&rsquo;re regenerated — usually if a phone changes
+        hands at one of our partners.
+      </p>
+    </StatusShell>
+  );
+}

--- a/src/app/c/[token]/page.tsx
+++ b/src/app/c/[token]/page.tsx
@@ -1,8 +1,18 @@
+import { notFound } from "next/navigation";
 import { StatusShell } from "@/components/customer/StatusShell";
+import { lookupCustomerByToken } from "@/lib/customer/session";
 
-// TODO Phase 3: look up token — show InvalidPage if expired, OrderPage if open
-// For now: ordering is always closed (correct for Phase 0)
-export default function CustomerTokenPage() {
+// Phase 3.3: token validated here; cookie set by middleware. Phase 3.4 will
+// replace the closed-state placeholder with the real order form.
+export default async function CustomerTokenPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const customer = await lookupCustomerByToken(token);
+  if (!customer) notFound();
+
   return (
     <StatusShell>
       <div className="status-art" aria-hidden="true">

--- a/src/app/c/[token]/page.tsx
+++ b/src/app/c/[token]/page.tsx
@@ -1,9 +1,12 @@
 import { notFound } from "next/navigation";
-import { StatusShell } from "@/components/customer/StatusShell";
+import { OrderForm } from "@/components/customer/OrderForm";
+import {
+  getAvailableProducts,
+  getLatestDeliveryPreference,
+} from "@/lib/customer/queries";
 import { lookupCustomerByToken } from "@/lib/customer/session";
+import { weekOfLabel } from "@/lib/week";
 
-// Phase 3.3: token validated here; cookie set by middleware. Phase 3.4 will
-// replace the closed-state placeholder with the real order form.
 export default async function CustomerTokenPage({
   params,
 }: {
@@ -13,50 +16,21 @@ export default async function CustomerTokenPage({
   const customer = await lookupCustomerByToken(token);
   if (!customer) notFound();
 
+  const [products, priorDeliveryPreference] = await Promise.all([
+    getAvailableProducts(),
+    getLatestDeliveryPreference(customer.id),
+  ]);
+
   return (
-    <StatusShell>
-      <div className="status-art" aria-hidden="true">
-        <svg viewBox="0 0 240 160" width="220" height="146">
-          <path d="M30 110 Q120 152 210 110" fill="none" stroke="#3B6D11" strokeOpacity="0.35" strokeWidth="1.5" />
-          <path d="M40 108 Q120 138 200 108" fill="#EDF5E5" stroke="#3B6D11" strokeOpacity="0.5" strokeWidth="1" />
-          <g transform="translate(60 92) rotate(-12)">
-            <path d="M0 0 L48 4 L52 12 L4 14 Z" fill="#E6A817" />
-            <path d="M-6 -6 Q-3 -10 0 -8 M-2 -10 Q1 -14 4 -12 M2 -8 Q5 -14 9 -10" stroke="#3B6D11" strokeWidth="1.4" fill="none" strokeLinecap="round" />
-          </g>
-          <g transform="translate(120 80)">
-            <ellipse cx="0" cy="14" rx="18" ry="14" fill="#B23B2E" opacity="0.85" />
-            <path d="M-8 0 Q-6 -10 0 -12 M0 0 Q1 -12 6 -14 M6 0 Q10 -10 14 -8" stroke="#3B6D11" strokeWidth="1.6" fill="none" strokeLinecap="round" />
-          </g>
-          <g transform="translate(170 90)">
-            <circle r="16" fill="#4F8A1B" opacity="0.85" />
-            <circle r="11" fill="#5fa825" opacity="0.6" />
-            <path d="M-10 -6 Q-4 -12 4 -10 M-6 0 Q2 -8 10 -4" stroke="#FBFAF5" strokeOpacity="0.6" strokeWidth="1" fill="none" />
-          </g>
-          <text x="100" y="36" fontFamily="serif" fontStyle="italic" fontSize="22" fill="#3B6D11" opacity="0.55">z</text>
-          <text x="118" y="26" fontFamily="serif" fontStyle="italic" fontSize="16" fill="#3B6D11" opacity="0.4">z</text>
-          <text x="132" y="20" fontFamily="serif" fontStyle="italic" fontSize="12" fill="#3B6D11" opacity="0.3">z</text>
-        </svg>
-      </div>
-
-      <div className="status-eyebrow eyebrow">this week · closed</div>
-      <h1 className="status-title">Ordering&rsquo;s closed for this week.</h1>
-      <p className="status-lede">
-        We open again <strong>Sunday morning</strong>. You&rsquo;ll get a text from Annabel
-        when this week&rsquo;s list is up.
-      </p>
-
-      <div className="status-meta">
-        <div className="status-meta-row">
-          <span className="status-meta-key">Next opening</span>
-          <span className="status-meta-val">Sun · ~8am</span>
-        </div>
-      </div>
-
-      <div className="status-actions">
-        <a href="sms:2162025718" className="btn btn-secondary status-btn">
-          Text Annabel · 216-202-5718
-        </a>
-      </div>
-    </StatusShell>
+    <OrderForm
+      customer={{
+        id: customer.id,
+        name: customer.business_name ?? customer.name,
+        delivery_address: customer.delivery_address,
+      }}
+      products={products}
+      priorDeliveryPreference={priorDeliveryPreference}
+      weekLabel={weekOfLabel()}
+    />
   );
 }

--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { ProductRow } from "@/lib/customer/queries";
+
+type Customer = {
+  id: string;
+  name: string;
+  delivery_address: string | null;
+};
+
+type Props = {
+  customer: Customer;
+  products: ProductRow[];
+  priorDeliveryPreference: string | null;
+  weekLabel: string;
+};
+
+type Mode = "delivery" | "pickup";
+
+function formatPrice(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+function Stepper({
+  value,
+  onChange,
+  max,
+}: {
+  value: number;
+  onChange: (n: number) => void;
+  max: number;
+}) {
+  const canDec = value > 0;
+  const canInc = value < max;
+  return (
+    <div className="stepper" role="group" aria-label="quantity">
+      <button
+        type="button"
+        className="stepper-btn"
+        onClick={() => canDec && onChange(value - 1)}
+        disabled={!canDec}
+        aria-label="decrease"
+      >
+        −
+      </button>
+      <div className="stepper-val">{value}</div>
+      <button
+        type="button"
+        className="stepper-btn"
+        onClick={() => canInc && onChange(value + 1)}
+        disabled={!canInc}
+        aria-label="increase"
+      >
+        +
+      </button>
+    </div>
+  );
+}
+
+export function OrderForm({
+  customer,
+  products,
+  priorDeliveryPreference,
+  weekLabel,
+}: Props) {
+  const [qty, setQty] = useState<Record<string, number>>({});
+  const [mode, setMode] = useState<Mode>("delivery");
+  const [pickupNote, setPickupNote] = useState("");
+  const [deliveryPreference, setDeliveryPreference] = useState(
+    priorDeliveryPreference ?? "",
+  );
+  const [notes, setNotes] = useState("");
+
+  const itemsWithQty = useMemo(
+    () => products.filter((p) => (qty[p.id] ?? 0) > 0),
+    [products, qty],
+  );
+  const subtotalCents = useMemo(
+    () =>
+      itemsWithQty.reduce((sum, p) => sum + (qty[p.id] ?? 0) * p.price_cents, 0),
+    [itemsWithQty, qty],
+  );
+  const itemCount = useMemo(
+    () => itemsWithQty.reduce((sum, p) => sum + (qty[p.id] ?? 0), 0),
+    [itemsWithQty, qty],
+  );
+  const lineCount = itemsWithQty.length;
+
+  const setItemQty = (id: string, n: number) =>
+    setQty((q) => ({ ...q, [id]: n }));
+
+  return (
+    <div className="order-page">
+      <div className="brand-strip">
+        <div className="brand-mark">
+          <span className="brand-leaf" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+              <path d="M21.5 2.5c0 8-4.5 14.5-12 14.5-1.4 0-2.8-.2-4-.7l1.4-1.4c.8.2 1.7.4 2.6.4 6 0 9.5-5.3 10-12.3-2 .6-7.4 2.6-10.4 7.4-1 1.6-1.5 3.4-1.7 5.4l-1.5 1.5c0-3.3.7-6.3 2.4-8.7C11.4 4 18.4 2.6 21.5 2.5z" />
+            </svg>
+          </span>
+          <span className="brand-name">Bay Branch Farm</span>
+        </div>
+      </div>
+
+      <div className="page-shell">
+        <header className="page-head">
+          <div className="eyebrow">this week · {weekLabel}</div>
+          <h1 className="page-title">What&rsquo;s available</h1>
+          <p className="page-greet">
+            Hi, <span className="customer-name">{customer.name}</span>.
+          </p>
+        </header>
+
+        <div className="page-cols">
+          <div className="page-main">
+            <section className="inv">
+              <div className="inv-head">
+                <div className="eyebrow">availability</div>
+                <span className="inv-count">
+                  {products.filter((p) => p.qty_available > 0).length} items
+                </span>
+              </div>
+              <div className="item-list">
+                {products.map((p) => {
+                  const current = qty[p.id] ?? 0;
+                  const out = p.qty_available === 0;
+                  const remaining = out ? 0 : p.qty_available - current;
+                  return (
+                    <div
+                      key={p.id}
+                      className={"item-row" + (out ? " is-sold-out" : "")}
+                    >
+                      <div className="item-thumb" aria-hidden="true">
+                        <div className="item-thumb-inner"></div>
+                      </div>
+                      <div className="item-body">
+                        <div className="item-line1">
+                          <div className="item-name">{p.name}</div>
+                          <div className="item-price">
+                            <span className="mono">${formatPrice(p.price_cents)}</span>
+                            <span className="item-per"> / {p.unit}</span>
+                          </div>
+                        </div>
+                        <div className="item-line2">
+                          {out ? (
+                            <span className="item-meta meta-sold-out">Sold out</span>
+                          ) : remaining <= 3 ? (
+                            <span className="item-meta meta-low">
+                              only {remaining} {p.unit}
+                              {remaining !== 1 ? "s" : ""} left
+                            </span>
+                          ) : (
+                            <span className="item-meta">
+                              {remaining} {p.unit}
+                              {remaining !== 1 ? "s" : ""} available
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <div className="item-stepper">
+                        <Stepper
+                          value={current}
+                          onChange={(n) => setItemQty(p.id, n)}
+                          max={p.qty_available}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="fulfill">
+              <div className="eyebrow">fulfillment</div>
+              <h2 className="section-title">How would you like it?</h2>
+              <div className="fulfill-tabs" role="tablist">
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={mode === "delivery"}
+                  className={"fulfill-tab" + (mode === "delivery" ? " is-active" : "")}
+                  onClick={() => setMode("delivery")}
+                >
+                  <div className="fulfill-tab-label">Delivery</div>
+                  <div className="fulfill-tab-sub">Wednesday morning</div>
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={mode === "pickup"}
+                  className={"fulfill-tab" + (mode === "pickup" ? " is-active" : "")}
+                  onClick={() => setMode("pickup")}
+                >
+                  <div className="fulfill-tab-label">Pickup at farm</div>
+                  <div className="fulfill-tab-sub">3612 W 114th, Cleveland</div>
+                </button>
+              </div>
+
+              {mode === "delivery" ? (
+                <div className="fulfill-detail">
+                  <div className="addr-stack">
+                    <div className="label-sm">Delivery to</div>
+                    <div className="addr-text">
+                      {customer.delivery_address ?? "(no address on file — text Annabel)"}
+                    </div>
+                  </div>
+                  <label className="field-label" htmlFor="delivery-pref">
+                    Delivery preference
+                  </label>
+                  <textarea
+                    id="delivery-pref"
+                    className="textarea"
+                    rows={3}
+                    placeholder="e.g. Leave at back door, gate code 4321."
+                    value={deliveryPreference}
+                    onChange={(e) => setDeliveryPreference(e.target.value)}
+                  />
+                  <div className="fulfill-help">
+                    Wednesday between 8am and noon. We&rsquo;ll text when we&rsquo;re 30 minutes out.
+                  </div>
+                </div>
+              ) : (
+                <div className="fulfill-detail">
+                  <label className="field-label" htmlFor="pickup-note">
+                    When are you picking up?
+                  </label>
+                  <textarea
+                    id="pickup-note"
+                    className="textarea"
+                    rows={3}
+                    placeholder="e.g. Wednesday afternoon, around 3."
+                    value={pickupNote}
+                    onChange={(e) => setPickupNote(e.target.value)}
+                  />
+                  <div className="fulfill-help">
+                    Pick up at the farm. Annabel will text you the morning of.
+                  </div>
+                </div>
+              )}
+            </section>
+
+            <section className="notes">
+              <div className="eyebrow">notes</div>
+              <h2 className="section-title">Anything else?</h2>
+              <textarea
+                className="textarea"
+                rows={3}
+                placeholder="Optional. Anything Annabel should know — substitutions you're open to, bunch sizes, etc."
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+              />
+            </section>
+
+            <section className="submit-block">
+              <div className="submit-summary">
+                <div className="summary-line">
+                  <span className="summary-label">
+                    {lineCount} item{lineCount !== 1 ? "s" : ""}
+                  </span>
+                  <span className="summary-total mono">
+                    ${formatPrice(subtotalCents)}
+                  </span>
+                </div>
+                <div className="summary-sub">
+                  {mode === "delivery"
+                    ? customer.delivery_address
+                      ? `Wednesday delivery to ${customer.delivery_address.split(",")[0]}`
+                      : "Wednesday delivery"
+                    : "Pickup at the farm"}
+                </div>
+              </div>
+              <button
+                type="button"
+                className="btn btn-primary submit-btn"
+                disabled={lineCount === 0}
+              >
+                Submit order
+              </button>
+              <p className="submit-fine">
+                You&rsquo;ll get a text confirmation. To change anything, text
+                Annabel at 216-202-5718.
+              </p>
+            </section>
+          </div>
+
+          <aside className="page-rail">
+            <div className="rail-card">
+              <div className="eyebrow">your order</div>
+              {lineCount === 0 ? (
+                <div className="rail-empty">
+                  Nothing selected yet. Tap <span className="mono">+</span> on
+                  items above.
+                </div>
+              ) : (
+                <ul className="rail-list">
+                  {itemsWithQty.map((p) => (
+                    <li key={p.id}>
+                      <span className="rail-name">
+                        <span className="rail-qty mono">{qty[p.id]}×</span>{" "}
+                        {p.name}
+                      </span>
+                      <span className="rail-amt mono">
+                        ${formatPrice((qty[p.id] ?? 0) * p.price_cents)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <div className="rail-totals">
+                <div className="rail-row rail-row-total">
+                  <span>Total</span>
+                  <span className="mono">${formatPrice(subtotalCents)}</span>
+                </div>
+              </div>
+              <button
+                type="button"
+                className="btn btn-primary rail-submit"
+                disabled={lineCount === 0}
+              >
+                Submit order
+              </button>
+              <div className="rail-fine">
+                Text Annabel to change anything · 216-202-5718
+              </div>
+            </div>
+          </aside>
+        </div>
+
+        <footer className="page-foot">
+          <div>Bay Branch Farm · 3612 W 114th St, Cleveland</div>
+        </footer>
+      </div>
+
+      <div className={"sticky-bar" + (lineCount > 0 ? " is-active" : "")}>
+        <div className="sticky-summary">
+          <div className="sticky-count">
+            {itemCount} item{itemCount !== 1 ? "s" : ""}
+          </div>
+          <div className="sticky-total mono">${formatPrice(subtotalCents)}</div>
+        </div>
+        <button
+          type="button"
+          className="btn btn-primary sticky-btn"
+          disabled={lineCount === 0}
+        >
+          Review &amp; submit
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/customer/queries.ts
+++ b/src/lib/customer/queries.ts
@@ -1,0 +1,32 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { Database } from "@/lib/supabase/types";
+
+export type ProductRow = Database["public"]["Tables"]["products"]["Row"];
+
+export async function getAvailableProducts(): Promise<ProductRow[]> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("products")
+    .select("*")
+    .eq("is_available", true)
+    .order("sort_order", { ascending: true });
+  if (error) throw new Error(`getAvailableProducts: ${error.message}`);
+  return data ?? [];
+}
+
+export async function getLatestDeliveryPreference(
+  customerId: string,
+): Promise<string | null> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("orders")
+    .select("delivery_preference")
+    .eq("customer_id", customerId)
+    .eq("fulfillment_type", "delivery")
+    .not("delivery_preference", "is", null)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw new Error(`getLatestDeliveryPreference: ${error.message}`);
+  return data?.delivery_preference ?? null;
+}

--- a/src/lib/customer/session.ts
+++ b/src/lib/customer/session.ts
@@ -1,0 +1,23 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { Database } from "@/lib/supabase/types";
+
+export const CUSTOMER_TOKEN_COOKIE = "bbf_customer_token";
+
+// 1 year. Token rotation (admin Regenerate) invalidates server-side on next lookup.
+export const CUSTOMER_TOKEN_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+export type Customer = Database["public"]["Tables"]["customers"]["Row"];
+
+export async function lookupCustomerByToken(
+  token: string | undefined,
+): Promise<Customer | null> {
+  if (!token) return null;
+  const supabase = createAdminClient();
+  const { data } = await supabase
+    .from("customers")
+    .select("*")
+    .eq("token", token)
+    .eq("is_active", true)
+    .maybeSingle();
+  return data ?? null;
+}

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,0 +1,17 @@
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "./types";
+
+// Service-role client. Bypasses RLS (DEC: service-role-as-gate + RLS-as-backstop).
+// Use only on the server — never expose the service role key to the client.
+export function createAdminClient() {
+  return createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    },
+  );
+}

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -3,6 +3,8 @@ import type { Database } from "./types";
 
 // Service-role client. Bypasses RLS (DEC: service-role-as-gate + RLS-as-backstop).
 // Use only on the server — never expose the service role key to the client.
+// Uses `supabase-js` directly (not `@supabase/ssr`) — service role doesn't
+// need cookie/session plumbing.
 export function createAdminClient() {
   return createClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,10 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { updateSession } from "@/lib/supabase/middleware";
+import {
+  CUSTOMER_TOKEN_COOKIE,
+  CUSTOMER_TOKEN_COOKIE_MAX_AGE,
+  lookupCustomerByToken,
+} from "@/lib/customer/session";
 
 export async function proxy(request: NextRequest) {
   const { response, user } = await updateSession(request);
@@ -11,6 +16,21 @@ export async function proxy(request: NextRequest) {
       request.nextUrl.pathname + request.nextUrl.search,
     );
     return NextResponse.redirect(loginUrl);
+  }
+
+  const customerMatch = request.nextUrl.pathname.match(/^\/c\/([^/]+)/);
+  if (customerMatch) {
+    const token = customerMatch[1];
+    const customer = await lookupCustomerByToken(token);
+    if (customer) {
+      response.cookies.set(CUSTOMER_TOKEN_COOKIE, token, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        maxAge: CUSTOMER_TOKEN_COOKIE_MAX_AGE,
+        path: "/",
+      });
+    }
   }
 
   return response;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -18,7 +18,12 @@ export async function proxy(request: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
-  const customerMatch = request.nextUrl.pathname.match(/^\/c\/([^/]+)/);
+  // Token shape: 6+3 alphanumeric with a dash (src/lib/tokens.ts). Min length
+  // 8 also covers the longer testtoken-* fixtures; rejects scanner traffic
+  // (e.g. /c/wp-admin, /c/.env) before any DB lookup.
+  const customerMatch = request.nextUrl.pathname.match(
+    /^\/c\/([a-z0-9-]{8,})(?:[/?#]|$)/,
+  );
   if (customerMatch) {
     const token = customerMatch[1];
     const customer = await lookupCustomerByToken(token);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -30,7 +30,9 @@ export async function proxy(request: NextRequest) {
     if (customer) {
       response.cookies.set(CUSTOMER_TOKEN_COOKIE, token, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
+        // Gate on actual transport, not NODE_ENV: WebKit refuses Secure cookies
+        // on HTTP localhost, which broke CI (`npm start` → NODE_ENV=production).
+        secure: request.nextUrl.protocol === "https:",
         sameSite: "lax",
         maxAge: CUSTOMER_TOKEN_COOKIE_MAX_AGE,
         path: "/",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -815,3 +815,261 @@
 }
 .confirm-fulfill-val { font-size: 0.95rem; color: var(--ink-900); font-weight: 600; }
 .confirm-fulfill-sub { font-size: 0.85rem; color: var(--ink-700); font-weight: 400; margin-top: 2px; }
+
+/* ── Customer pages: order form (Phase 3.4) ──────────────── */
+.order-page {
+  background: var(--cream);
+  min-height: 100vh;
+  color: var(--ink-900);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.55;
+  padding-bottom: 96px; /* room for mobile sticky bar */
+}
+.order-page .page-shell {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 28px 20px 24px;
+}
+
+.page-head { margin-bottom: 28px; }
+.page-title {
+  font-family: var(--sans);
+  font-size: 2rem;
+  font-weight: 600;
+  line-height: 1.1;
+  margin-top: 6px;
+  margin-bottom: 10px;
+  letter-spacing: -0.01em;
+}
+.page-greet { font-size: 1rem; color: var(--ink-700); }
+.customer-name { font-weight: 600; color: var(--ink-900); }
+
+.section-title {
+  font-family: var(--sans);
+  font-size: 1.3rem;
+  font-weight: 600;
+  line-height: 1.2;
+  margin-top: 4px;
+  margin-bottom: 14px;
+}
+
+.inv { margin-bottom: 36px; }
+.inv-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  margin-bottom: 10px;
+}
+.inv-count { font-size: 0.82rem; color: var(--ink-500); }
+
+.item-list {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+.item-row {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 14px;
+  border-top: 1px solid var(--ink-200);
+}
+.item-row:first-child { border-top: 0; }
+.item-row.is-sold-out { background: var(--leaf-50); opacity: 0.78; }
+.item-row.is-sold-out .item-name { color: var(--ink-500); }
+.item-row.is-sold-out .item-thumb { opacity: 0.55; }
+
+.item-thumb {
+  width: 44px; height: 44px; border-radius: 8px;
+  background: var(--leaf-50);
+  border: 1px solid var(--leaf-100);
+  overflow: hidden;
+}
+.item-thumb-inner {
+  width: 100%; height: 100%;
+  background-image:
+    repeating-linear-gradient(
+      45deg,
+      transparent 0,
+      transparent 6px,
+      rgba(59,109,17,0.08) 6px,
+      rgba(59,109,17,0.08) 7px
+    );
+}
+
+.item-body { min-width: 0; }
+.item-line1 {
+  display: flex; justify-content: space-between; align-items: baseline;
+  gap: 12px;
+}
+.item-name {
+  font-weight: 600; color: var(--ink-900);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.item-price { font-size: 0.92rem; white-space: nowrap; }
+.item-price .mono { font-weight: 600; color: var(--ink-900); }
+.item-per { color: var(--ink-500); }
+.item-line2 { font-size: 0.82rem; }
+.item-meta { color: var(--ink-500); }
+.item-meta.meta-low { color: var(--leaf-700); font-weight: 600; }
+.item-meta.meta-sold-out { color: var(--rose-600); font-weight: 600; }
+
+.stepper {
+  display: inline-flex; align-items: center;
+  border: 1px solid var(--ink-300);
+  border-radius: var(--r-pill, 999px);
+  background: var(--paper);
+}
+.stepper-btn {
+  width: 32px; height: 32px;
+  background: transparent; border: 0;
+  font-size: 1.1rem; font-weight: 600; color: var(--ink-700);
+  cursor: pointer;
+}
+.stepper-btn:hover:not(:disabled) { background: var(--leaf-50); }
+.stepper-btn:disabled { color: var(--ink-300); cursor: default; }
+.stepper-val {
+  min-width: 28px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.fulfill { margin-bottom: 36px; }
+.fulfill-tabs {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 10px; margin-bottom: 14px;
+}
+.fulfill-tab {
+  text-align: left;
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  padding: 12px 14px;
+  cursor: pointer;
+}
+.fulfill-tab:hover { border-color: var(--leaf-600); }
+.fulfill-tab.is-active {
+  border-color: var(--leaf-600);
+  box-shadow: 0 0 0 2px rgba(79,138,27,0.12);
+}
+.fulfill-tab-label { font-weight: 600; font-size: 1rem; color: var(--ink-900); margin-bottom: 2px; }
+.fulfill-tab-sub { font-size: 0.82rem; color: var(--ink-500); }
+.fulfill-tab.is-active .fulfill-tab-sub { color: var(--leaf-700); }
+
+.fulfill-detail {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  padding: 14px 16px;
+}
+.addr-stack { margin-bottom: 14px; }
+.label-sm,
+.order-page .field-label {
+  font-size: 0.78rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--ink-500); margin-bottom: 6px; display: block;
+}
+.addr-text { font-size: 0.95rem; color: var(--ink-900); }
+.fulfill-help { margin-top: 10px; font-size: 0.82rem; color: var(--ink-500); }
+
+.order-page .textarea {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--paper);
+  border: 1px solid var(--ink-300);
+  border-radius: var(--r-sm);
+  font-family: var(--sans);
+  font-size: 0.95rem;
+  color: var(--ink-900);
+  line-height: 1.4;
+  resize: vertical;
+}
+.order-page .textarea:focus {
+  outline: none;
+  border-color: var(--leaf-600);
+  box-shadow: 0 0 0 3px rgba(79,138,27,0.12);
+}
+
+.notes { margin-bottom: 28px; }
+
+.submit-block {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  padding: 16px;
+}
+.submit-summary { margin-bottom: 12px; }
+.summary-line {
+  display: flex; justify-content: space-between; align-items: baseline;
+  margin-bottom: 4px;
+}
+.summary-label { font-weight: 600; color: var(--ink-900); }
+.summary-total { font-weight: 600; font-size: 1.05rem; color: var(--ink-900); }
+.summary-sub { font-size: 0.85rem; color: var(--ink-500); }
+.submit-btn { width: 100%; }
+.submit-fine { margin-top: 10px; font-size: 0.78rem; color: var(--ink-500); }
+
+.page-cols { display: block; }
+.page-rail { display: none; }
+.rail-card {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  padding: 16px;
+}
+.rail-empty { color: var(--ink-500); font-size: 0.92rem; margin: 8px 0 12px; }
+.rail-list { list-style: none; padding: 0; margin: 8px 0 12px; }
+.rail-list li {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding: 4px 0;
+  font-size: 0.92rem;
+}
+.rail-name { color: var(--ink-900); }
+.rail-qty { font-weight: 600; color: var(--leaf-700); margin-right: 4px; }
+.rail-amt { color: var(--ink-700); }
+.rail-totals { border-top: 1px solid var(--ink-200); padding-top: 10px; margin-bottom: 12px; }
+.rail-row {
+  display: flex; justify-content: space-between;
+  font-size: 0.92rem; color: var(--ink-700);
+  padding: 2px 0;
+}
+.rail-row-total { font-weight: 600; font-size: 1rem; color: var(--ink-900); }
+.rail-submit { width: 100%; margin-top: 6px; }
+.rail-fine { margin-top: 10px; font-size: 0.78rem; color: var(--ink-500); }
+
+.page-foot {
+  margin-top: 24px;
+  padding-top: 14px;
+  border-top: 1px solid var(--ink-200);
+  font-size: 0.82rem; color: var(--ink-500);
+}
+
+.sticky-bar {
+  position: fixed; left: 0; right: 0; bottom: 0;
+  background: var(--paper);
+  border-top: 1px solid var(--ink-200);
+  padding: 10px 16px;
+  display: flex; align-items: center; gap: 12px;
+  transform: translateY(100%);
+  transition: transform 180ms ease;
+  z-index: 40;
+}
+.sticky-bar.is-active { transform: translateY(0); }
+.sticky-summary { flex: 1; min-width: 0; }
+.sticky-count { font-size: 0.85rem; color: var(--ink-500); }
+.sticky-total { font-weight: 600; font-size: 1.05rem; color: var(--ink-900); }
+.sticky-btn { flex-shrink: 0; }
+
+@media (min-width: 880px) {
+  .page-cols {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 280px;
+    gap: 28px;
+    align-items: start;
+  }
+  .page-rail { display: block; position: sticky; top: 20px; }
+  .sticky-bar { display: none; }
+  .order-page { padding-bottom: 0; }
+}

--- a/tests/customer-order-form.spec.ts
+++ b/tests/customer-order-form.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "@playwright/test";
+import { TEST_CUSTOMERS, TEST_PRODUCTS, customerOrderUrl } from "./helpers";
+
+test.describe("/c/[token] order form", () => {
+  test("renders header and the seeded products", async ({ page }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    await expect(page.getByRole("heading", { name: /What.s available/i })).toBeVisible();
+    await expect(page.getByText(/Test Farm Stand/)).toBeVisible();
+    for (const p of Object.values(TEST_PRODUCTS)) {
+      await expect(page.getByText(p.name, { exact: true }).first()).toBeVisible();
+    }
+  });
+
+  test("stepper increments and the running total updates", async ({ page }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+
+    // Find the Kale row and tap + twice
+    const kaleRow = page.locator(".item-row", { hasText: TEST_PRODUCTS.kale.name });
+    await kaleRow.getByRole("button", { name: "increase" }).click();
+    await kaleRow.getByRole("button", { name: "increase" }).click();
+    await expect(kaleRow.locator(".stepper-val")).toHaveText("2");
+
+    // Sticky bar + submit-block totals reflect 2 × $3.00 = $6.00
+    await expect(page.locator(".sticky-total").first()).toContainText("6.00");
+    await expect(page.locator(".summary-total")).toContainText("6.00");
+  });
+
+  test("submit button disabled with no items, enabled after stepping up", async ({ page }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    const submit = page.locator(".submit-btn");
+    await expect(submit).toBeDisabled();
+
+    const kaleRow = page.locator(".item-row", { hasText: TEST_PRODUCTS.kale.name });
+    await kaleRow.getByRole("button", { name: "increase" }).click();
+    await expect(submit).toBeEnabled();
+  });
+
+  test("delivery mode shows the delivery-preference textarea, prefilled from prior order", async ({ page }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    // Delivery is the default mode
+    const pref = page.locator("#delivery-pref");
+    await expect(pref).toBeVisible();
+    await expect(pref).toHaveValue("Back door, gate code 4321");
+
+    await pref.click();
+    await pref.press("ControlOrMeta+A");
+    await pref.press("Delete");
+    await pref.pressSequentially("Leave with security desk.");
+    await expect(pref).toHaveValue("Leave with security desk.");
+  });
+
+  test("pickup mode swaps to the pickup-note textarea", async ({ page }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    await page.getByRole("tab", { name: /Pickup at farm/i }).click();
+
+    const note = page.locator("#pickup-note");
+    await expect(note).toBeVisible();
+    await note.fill("Wednesday around 3pm.");
+    await expect(note).toHaveValue("Wednesday around 3pm.");
+
+    // Delivery textarea is gone
+    await expect(page.locator("#delivery-pref")).toHaveCount(0);
+  });
+
+  test("notes textarea accepts input", async ({ page }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    const notes = page.locator(".notes textarea");
+    await notes.fill("Loose bunches are fine.");
+    await expect(notes).toHaveValue("Loose bunches are fine.");
+  });
+
+  test("restaurant customer has no prior order — delivery textarea starts empty", async ({ page }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.restaurant.token));
+    await expect(page.locator("#delivery-pref")).toHaveValue("");
+  });
+});

--- a/tests/customer-token.spec.ts
+++ b/tests/customer-token.spec.ts
@@ -6,7 +6,7 @@ const COOKIE = "bbf_customer_token";
 test.describe("/c/[token] route", () => {
   test("valid token renders the page and sets the cookie", async ({ page, context }) => {
     await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
-    await expect(page.getByText(/Ordering.s closed/i)).toBeVisible();
+    await expect(page.getByRole("heading", { name: /What.s available/i })).toBeVisible();
 
     const cookie = (await context.cookies()).find((c) => c.name === COOKIE);
     expect(cookie?.value).toBe(TEST_CUSTOMERS.farmStand.token);

--- a/tests/customer-token.spec.ts
+++ b/tests/customer-token.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+import { TEST_CUSTOMERS, customerOrderUrl } from "./helpers";
+
+const COOKIE = "bbf_customer_token";
+
+test.describe("/c/[token] route", () => {
+  test("valid token renders the page and sets the cookie", async ({ page, context }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    await expect(page.getByText(/Ordering.s closed/i)).toBeVisible();
+
+    const cookie = (await context.cookies()).find((c) => c.name === COOKIE);
+    expect(cookie?.value).toBe(TEST_CUSTOMERS.farmStand.token);
+  });
+
+  test("invalid token 404s and does not set the cookie", async ({ page, context }) => {
+    const response = await page.goto(customerOrderUrl("not-a-real-token"));
+    expect(response?.status()).toBe(404);
+    await expect(page.getByText(/This link doesn.t work anymore/i)).toBeVisible();
+
+    const cookie = (await context.cookies()).find((c) => c.name === COOKIE);
+    expect(cookie).toBeUndefined();
+  });
+
+  test("cookie persists across reloads", async ({ page, context }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    await page.reload();
+    const cookie = (await context.cookies()).find((c) => c.name === COOKIE);
+    expect(cookie?.value).toBe(TEST_CUSTOMERS.farmStand.token);
+  });
+
+  test("visiting a second customer overwrites the cookie (no cross-customer leak)", async ({
+    page,
+    context,
+  }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    let cookie = (await context.cookies()).find((c) => c.name === COOKIE);
+    expect(cookie?.value).toBe(TEST_CUSTOMERS.farmStand.token);
+
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.restaurant.token));
+    cookie = (await context.cookies()).find((c) => c.name === COOKIE);
+    expect(cookie?.value).toBe(TEST_CUSTOMERS.restaurant.token);
+  });
+});

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -92,13 +92,42 @@ export default async function globalSetup() {
   // is_active defaults true; tests that deactivate must reset to true.
   const { error: customersError } = await adminClient.from("customers").upsert(
     [
-      { name: "Test Farm Stand", token: "testtoken-farmstand-0001",  is_active: true, send_weekly_link: true, priority: 100, business_name: null, email: null, phone: null, delivery_address: null },
-      { name: "Test Restaurant", token: "testtoken-restaurant-0001", is_active: true, send_weekly_link: true, priority: 100, business_name: null, email: null, phone: null, delivery_address: null },
+      { name: "Test Farm Stand", token: "testtoken-farmstand-0001",  is_active: true, send_weekly_link: true, priority: 100, business_name: null, email: null, phone: null, delivery_address: "100 Farm Stand Way, Lakewood, OH 44107" },
+      { name: "Test Restaurant", token: "testtoken-restaurant-0001", is_active: true, send_weekly_link: true, priority: 100, business_name: null, email: null, phone: null, delivery_address: "200 Restaurant Row, Cleveland, OH 44102" },
     ],
     { onConflict: "token" },
   );
   if (customersError)
     throw new Error(`customers upsert failed: ${customersError.message}`);
+
+  // Seed a prior delivery order for Test Farm Stand so 3.4 delivery_preference
+  // prefill is testable. week_of is in the past so it doesn't collide with the
+  // current week's order in 3.5+ tests. unique (customer_id, week_of) → upsert.
+  const { data: farmStandRow, error: lookupError } = await adminClient
+    .from("customers")
+    .select("id")
+    .eq("token", "testtoken-farmstand-0001")
+    .single();
+  if (lookupError || !farmStandRow)
+    throw new Error(`farm stand lookup failed: ${lookupError?.message ?? "no row"}`);
+
+  const { error: priorOrderError } = await adminClient.from("orders").upsert(
+    [
+      {
+        customer_id: farmStandRow.id,
+        week_of: "2026-04-27",
+        fulfillment_type: "delivery",
+        delivery_address: "100 Farm Stand Way, Lakewood, OH 44107",
+        delivery_preference: "Back door, gate code 4321",
+        status: "delivered",
+        notes: null,
+        pickup_note: null,
+      },
+    ],
+    { onConflict: "customer_id,week_of" },
+  );
+  if (priorOrderError)
+    throw new Error(`prior order upsert failed: ${priorOrderError.message}`);
 
   // Sign in to get a real, server-verified session
   const anonClient = createClient(supabaseUrl, anonKey, {


### PR DESCRIPTION
## Summary

Replaces the `/c/[token]` closed-state placeholder with the real customer order form: header, item list with steppers, fulfillment tabs (free-text textareas per DEC-029, no pickup windows), notes, mobile sticky bar, desktop right rail. Submit is a no-op stub — submission lands in #50 (Phase 3.5).

Closes #49.

> ⚠ **Stacked on #72.** Branched off `task/3.3-customer-token-route`. Merge #72 first; after that, GitHub's "Update branch" on this PR will reconcile against `main`. Don't merge this one first.

## Files changed

- `src/app/c/[token]/page.tsx` — server component fetches products + prior delivery preference in parallel, renders `<OrderForm>`
- `src/components/customer/OrderForm.tsx` (new) — client component, full order UI
- `src/lib/customer/queries.ts` (new) — `getAvailableProducts()` + `getLatestDeliveryPreference(customerId)`
- `src/styles/app.css` — appended `/* Customer pages: order form (Phase 3.4) */` section (~225 lines)
- `tests/global-setup.ts` — seeded `delivery_address` for both test customers + a prior delivered order for Test Farm Stand
- `tests/customer-order-form.spec.ts` (new) — 7 Playwright tests
- `tests/customer-token.spec.ts` — updated 3.3 valid-token assertion (closed-state placeholder is gone)

## Code review

@code-review: no bugs, no RLS gaps, no type issues. Four findings, all deferred:

- **No `error.tsx` / `loading.tsx` for `/c/[token]`** — on a Supabase outage, the customer hits the default Next error UI. Cold loads show blank ~100ms. Small file each; worth doing before real customers see it. **Deferred to a follow-up (new issue worth filing).**
- **Hardcoded farm address + Annabel's phone** repeated across `OrderForm.tsx` + `app.css` + `not-found.tsx`. Lift to `src/lib/constants.ts` when 3.6 (`#51`) lands — single sweep.
- **Naive pluralization** ("bunchs", "dozens"). Tiny pluralize map or `unit_plural` on products. Fold into 3.5 polish.
- **`OrderForm.tsx` is 352 lines** vs the 200-line guideline. Natural splits: `ItemRow`, `FulfillmentSection`, `OrderRail`. Submission wiring in 3.5 will force the refactor anyway — defer.

## Test plan

- [ ] Tap preview URL `/c/testtoken-farmstand-0001` at 375px → confirm header reads "What's available", "Test Farm Stand" greeting, three product rows (Kale, Eggs, Honey)
- [ ] Tap `+` on Kale twice → stepper shows `2`, mobile sticky bar appears with `$6.00`, submit-block summary shows `1 item · $6.00`
- [ ] Tap `−` to zero → sticky bar disappears, submit button disabled
- [ ] Default fulfillment tab is **Delivery** → see "Delivery to: 100 Farm Stand Way…" and the `delivery-pref` textarea prefilled with "Back door, gate code 4321"
- [ ] Tap **Pickup at farm** → `delivery-pref` textarea is gone, `pickup-note` textarea appears empty with the "When are you picking up?" label
- [ ] Type into Notes textarea → text persists across tab switches
- [ ] Visit `/c/testtoken-restaurant-0001` (no prior order) → `delivery-pref` starts empty
- [ ] Visit `/c/garbage` → still 404s (3.3 regression check)
- [ ] Resize to desktop (≥880px) → mobile sticky bar hides, right rail appears with running order summary
- [ ] Run `npx playwright test tests/customer-order-form.spec.ts --project=mobile`, confirm 7 tests pass
- [ ] Run `npx playwright test tests/customer-order-form.spec.ts tests/customer-token.spec.ts --project=desktop`, confirm 11 tests pass