### PR TITLE
Phase 3.7: closed state + all-sold-out empty state (closes #52)

### DIFF
--- a/src/app/c/[token]/page.tsx
+++ b/src/app/c/[token]/page.tsx
@@ -1,9 +1,12 @@
 import { notFound, redirect } from "next/navigation";
+import { AllSoldOutShell } from "@/components/customer/AllSoldOutShell";
+import { ClosedShell } from "@/components/customer/ClosedShell";
 import { OrderForm } from "@/components/customer/OrderForm";
 import {
   getAvailableProducts,
   getCurrentWeekOrder,
   getLatestDeliveryPreference,
+  getOrderingScheduleStatus,
 } from "@/lib/customer/queries";
 import { lookupCustomerByToken } from "@/lib/customer/session";
 import { weekOfLabel, weekOfMondayNY } from "@/lib/week";
@@ -25,16 +28,31 @@ export default async function CustomerTokenPage({
   const existingOrder = await getCurrentWeekOrder(customer.id, weekOfMondayNY());
   if (existingOrder) redirect(`/c/${token}/confirmed`);
 
-  const [products, priorDeliveryPreference] = await Promise.all([
+  const [products, priorDeliveryPreference, schedule] = await Promise.all([
     getAvailableProducts(),
     getLatestDeliveryPreference(customer.id),
+    getOrderingScheduleStatus(),
   ]);
+
+  const greetingName = customer.business_name ?? customer.name;
+
+  // DEC-031: four customer-side states keyed off ordering_schedule.is_open
+  // and product inventory. Server-side `is_open` is a soft UI hint only;
+  // submission enforcement remains DEC-012's job.
+  if (!schedule.is_open) {
+    return <ClosedShell customerName={greetingName} />;
+  }
+
+  const anyOrderable = products.some((p) => p.qty_available > 0);
+  if (!anyOrderable) {
+    return <AllSoldOutShell customerName={greetingName} />;
+  }
 
   return (
     <OrderForm
       customer={{
         id: customer.id,
-        name: customer.business_name ?? customer.name,
+        name: greetingName,
         delivery_address: customer.delivery_address,
       }}
       products={products}

--- a/src/components/customer/AllSoldOutShell.tsx
+++ b/src/components/customer/AllSoldOutShell.tsx
@@ -1,0 +1,15 @@
+import { StatusShell } from "@/components/customer/StatusShell";
+import { weekOfLabel } from "@/lib/week";
+
+export function AllSoldOutShell({ customerName }: { customerName: string }) {
+  return (
+    <StatusShell>
+      <div className="status-eyebrow eyebrow">this week · {weekOfLabel()}</div>
+      <h1 className="status-title">Everything is sold out for this week.</h1>
+      <p className="status-lede">
+        Hi, {customerName}. Check back next week — Annabel re-stocks Sunday and
+        Monday. Text 216-202-5718 with any questions.
+      </p>
+    </StatusShell>
+  );
+}

--- a/src/components/customer/ClosedShell.tsx
+++ b/src/components/customer/ClosedShell.tsx
@@ -1,0 +1,15 @@
+import { StatusShell } from "@/components/customer/StatusShell";
+import { weekOfLabel } from "@/lib/week";
+
+export function ClosedShell({ customerName }: { customerName: string }) {
+  return (
+    <StatusShell>
+      <div className="status-eyebrow eyebrow">this week · {weekOfLabel()}</div>
+      <h1 className="status-title">Orders are closed this week.</h1>
+      <p className="status-lede">
+        Hi, {customerName}. Annabel will text you when we re-open. Text
+        216-202-5718 with any questions.
+      </p>
+    </StatusShell>
+  );
+}

--- a/src/lib/customer/queries.ts
+++ b/src/lib/customer/queries.ts
@@ -22,16 +22,16 @@ export async function getAvailableProducts(): Promise<ProductRow[]> {
 
 // Reads the ordering_schedule singleton. Customer page uses this to decide
 // between the open form, the manual-closed shell, and the all-sold-out shell
-// (DEC-031). Defaults to open on missing row so a broken seed never locks
-// out customers.
+// (DEC-031). DEC-030 guarantees a single row exists — .single() lets a
+// missing row surface as a real error rather than silently defaulting.
 export async function getOrderingScheduleStatus(): Promise<{ is_open: boolean }> {
   const supabase = createAdminClient();
   const { data, error } = await supabase
     .from("ordering_schedule")
     .select("is_open")
-    .maybeSingle();
+    .single();
   if (error) throw new Error(`getOrderingScheduleStatus: ${error.message}`);
-  return { is_open: data?.is_open ?? true };
+  return { is_open: data.is_open };
 }
 
 export async function getLatestDeliveryPreference(

--- a/src/lib/customer/queries.ts
+++ b/src/lib/customer/queries.ts
@@ -20,6 +20,20 @@ export async function getAvailableProducts(): Promise<ProductRow[]> {
   return data ?? [];
 }
 
+// Reads the ordering_schedule singleton. Customer page uses this to decide
+// between the open form, the manual-closed shell, and the all-sold-out shell
+// (DEC-031). Defaults to open on missing row so a broken seed never locks
+// out customers.
+export async function getOrderingScheduleStatus(): Promise<{ is_open: boolean }> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("ordering_schedule")
+    .select("is_open")
+    .maybeSingle();
+  if (error) throw new Error(`getOrderingScheduleStatus: ${error.message}`);
+  return { is_open: data?.is_open ?? true };
+}
+
 export async function getLatestDeliveryPreference(
   customerId: string,
 ): Promise<string | null> {

--- a/tests/customer-closed-and-soldout.spec.ts
+++ b/tests/customer-closed-and-soldout.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from "@playwright/test";
+import {
+  TEST_CUSTOMERS,
+  TEST_PRODUCTS,
+  customerOrderUrl,
+  resetCustomerOrderState,
+  restoreProductQty,
+  setAllProductsSoldOut,
+  setOrderingOpen,
+} from "./helpers";
+
+// Phase 3.7 / DEC-031 — closed-state + all-sold-out empty state + per-item
+// sold-out filtering. Per-item sold-out is also exercised by the existing
+// order-form spec; this file owns the page-level state transitions.
+
+test.describe("/c/[token] state — closed + all sold out (DEC-031)", () => {
+  test.beforeEach(async () => {
+    await resetCustomerOrderState();
+  });
+
+  test.afterEach(async () => {
+    // Failure mid-test could leave is_open=false or qty=0 — other specs
+    // would then see ClosedShell / AllSoldOutShell and fail. Reset hard.
+    await resetCustomerOrderState();
+  });
+
+  test("closed state: ordering_schedule.is_open=false hides the form", async ({ page }) => {
+    await setOrderingOpen(false);
+
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+
+    await expect(
+      page.getByRole("heading", { name: /Orders are closed this week/i }),
+    ).toBeVisible();
+    await expect(page.getByText(/Test Farm Stand/)).toBeVisible();
+    await expect(page.locator(".inv")).toHaveCount(0);
+    await expect(page.locator(".submit-btn")).toHaveCount(0);
+    await expect(page.locator(".sticky-bar")).toHaveCount(0);
+  });
+
+  test("all sold out: every product qty_available=0 renders the empty state", async ({ page }) => {
+    // Snapshot + restore needed because the dev DB may carry non-test products
+    // with their own qty_available values. resetCustomerOrderState only knows
+    // about TEST_PRODUCTS — anything else we touch we have to clean up here.
+    const snapshot = await setAllProductsSoldOut();
+    try {
+      await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+
+      await expect(
+        page.getByRole("heading", { name: /Everything is sold out/i }),
+      ).toBeVisible();
+      await expect(page.locator(".inv")).toHaveCount(0);
+      await expect(page.locator(".submit-btn")).toHaveCount(0);
+    } finally {
+      await restoreProductQty(snapshot);
+    }
+  });
+
+  test("per-item sold out: one product qty=0 greys that row but leaves the form", async ({ page }) => {
+    // Drop kale to 0 directly — other items stay seeded.
+    const { createClient } = await import("@supabase/supabase-js");
+    const sb = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      { auth: { autoRefreshToken: false, persistSession: false } },
+    );
+    await sb
+      .from("products")
+      .update({ qty_available: 0 })
+      .eq("id", TEST_PRODUCTS.kale.id);
+
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+
+    const kaleRow = page.locator(".item-row", { hasText: TEST_PRODUCTS.kale.name });
+    await expect(kaleRow).toHaveClass(/is-sold-out/);
+    await expect(kaleRow.getByText("Sold out")).toBeVisible();
+    await expect(kaleRow.getByRole("button", { name: "increase" })).toBeDisabled();
+
+    // Other rows + form remain interactive.
+    const eggsRow = page.locator(".item-row", { hasText: TEST_PRODUCTS.eggs.name });
+    await expect(eggsRow).not.toHaveClass(/is-sold-out/);
+    await eggsRow.getByRole("button", { name: "increase" }).click();
+    await expect(eggsRow.locator(".stepper-val")).toHaveValue("1");
+  });
+
+  test("closed mid-order race: page loaded open, schedule flips closed, submit still succeeds (DEC-031 soft hint)", async ({ page }) => {
+    // Customer loads the open page.
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    const eggsRow = page.locator(".item-row", { hasText: TEST_PRODUCTS.eggs.name });
+    await eggsRow.getByRole("button", { name: "increase" }).click();
+
+    // Annabel closes the store while the customer is filling the form.
+    await setOrderingOpen(false);
+
+    // Submit goes through — the closed toggle is a UI hint, not enforcement.
+    // DEC-012's optimistic placement still owns the decision at submit time.
+    await page.locator(".submit-btn").click();
+    await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
+    await expect(
+      page.getByRole("heading", { name: /Order received/i }),
+    ).toBeVisible();
+  });
+});

--- a/tests/customer-closed-and-soldout.spec.ts
+++ b/tests/customer-closed-and-soldout.spec.ts
@@ -7,6 +7,7 @@ import {
   restoreProductQty,
   setAllProductsSoldOut,
   setOrderingOpen,
+  setProductQty,
 } from "./helpers";
 
 // Phase 3.7 / DEC-031 — closed-state + all-sold-out empty state + per-item
@@ -57,17 +58,9 @@ test.describe("/c/[token] state — closed + all sold out (DEC-031)", () => {
   });
 
   test("per-item sold out: one product qty=0 greys that row but leaves the form", async ({ page }) => {
-    // Drop kale to 0 directly — other items stay seeded.
-    const { createClient } = await import("@supabase/supabase-js");
-    const sb = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!,
-      { auth: { autoRefreshToken: false, persistSession: false } },
-    );
-    await sb
-      .from("products")
-      .update({ qty_available: 0 })
-      .eq("id", TEST_PRODUCTS.kale.id);
+    // kale is in TEST_PRODUCTS, so resetCustomerOrderState in afterEach
+    // restores it. No snapshot needed.
+    await setProductQty(TEST_PRODUCTS.kale.id, 0);
 
     await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -95,6 +95,11 @@ export async function setOrderingOpen(open: boolean): Promise<void> {
 // products beyond TEST_PRODUCTS (real seed data), so zeroing only the test
 // rows leaves the page able to render any non-test row. Snapshot returned so
 // the spec can restore.
+//
+// TOCTOU caveat: snapshot SELECT and zero-out UPDATE are two statements. A
+// concurrent insert between them would be zeroed but not in the snapshot,
+// so cleanup misses it. Acceptable in the solo phase; revisit if multiple
+// devs run tests against the same dev DB in parallel.
 export type ProductQtySnapshot = Array<{ id: string; qty_available: number }>;
 export async function setAllProductsSoldOut(): Promise<ProductQtySnapshot> {
   const sb = adminClient();
@@ -119,4 +124,12 @@ export async function restoreProductQty(snapshot: ProductQtySnapshot): Promise<v
       .update({ qty_available: row.qty_available })
       .eq("id", row.id);
   }
+}
+
+// Sets a single product's qty_available. Tests that mutate one product (e.g.
+// per-item sold-out) call this; cleanup is via resetCustomerOrderState in
+// afterEach, which only knows about TEST_PRODUCTS — pass an id in that set.
+export async function setProductQty(id: string, qty: number): Promise<void> {
+  const sb = adminClient();
+  await sb.from("products").update({ qty_available: qty }).eq("id", id);
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -71,4 +71,52 @@ export async function resetCustomerOrderState(): Promise<void> {
       .update({ qty_available: p.qty_available })
       .eq("id", p.id);
   }
+  // Phase 3.7 tests can flip is_open=false; restoring here means specs that
+  // run after them still see the open form.
+  await sb
+    .from("ordering_schedule")
+    .update({ is_open: true })
+    .eq("is_singleton", true);
+}
+
+// Toggles the singleton ordering_schedule row's is_open flag for Phase 3.7
+// state tests. The schedule table has a single row by design; updating any
+// row updates the schedule.
+export async function setOrderingOpen(open: boolean): Promise<void> {
+  const sb = adminClient();
+  await sb
+    .from("ordering_schedule")
+    .update({ is_open: open })
+    .eq("is_singleton", true);
+}
+
+// Drops every is_available=true product to qty_available = 0 — exercises
+// DEC-031's "everything sold out" empty state. The dev DB usually contains
+// products beyond TEST_PRODUCTS (real seed data), so zeroing only the test
+// rows leaves the page able to render any non-test row. Snapshot returned so
+// the spec can restore.
+export type ProductQtySnapshot = Array<{ id: string; qty_available: number }>;
+export async function setAllProductsSoldOut(): Promise<ProductQtySnapshot> {
+  const sb = adminClient();
+  const { data } = await sb
+    .from("products")
+    .select("id, qty_available")
+    .eq("is_available", true);
+  const snapshot: ProductQtySnapshot =
+    data?.map((r) => ({ id: r.id, qty_available: r.qty_available })) ?? [];
+  await sb
+    .from("products")
+    .update({ qty_available: 0 })
+    .eq("is_available", true);
+  return snapshot;
+}
+
+export async function restoreProductQty(snapshot: ProductQtySnapshot): Promise<void> {
+  const sb = adminClient();
+  for (const row of snapshot) {
+    await sb
+      .from("products")
+      .update({ qty_available: row.qty_available })
+      .eq("id", row.id);
+  }
 }


### PR DESCRIPTION
## Summary

Implements DEC-031's four customer-side states: closed (manual), open + all items orderable, open + some items sold out, and open + nothing orderable. Server-side enforcement stays with DEC-012 / `place_order` — `is_open` is a soft UI hint.

## Files changed

- `src/app/c/[token]/page.tsx` — fetches schedule + products in parallel; branches on `is_open` then `anyOrderable`.
- `src/components/customer/ClosedShell.tsx` — new, uses `StatusShell`.
- `src/components/customer/AllSoldOutShell.tsx` — new, same pattern.
- `src/lib/customer/queries.ts` — new `getOrderingScheduleStatus()`; uses `.single()` so a missing schedule row fails loudly (DEC-030 guarantees it exists).
- `tests/customer-closed-and-soldout.spec.ts` — new spec (closed, all-sold-out, per-item, closed-mid-order race).
- `tests/helpers.ts` — `setOrderingOpen`, `setAllProductsSoldOut` (snapshot/restore, since the dev DB has products beyond `TEST_PRODUCTS`), `restoreProductQty`, `setProductQty`. `resetCustomerOrderState` also resets `is_open=true`.

No new CSS — reused existing `.status-title` / `.status-lede` / `.status-eyebrow` primitives. App.css-only rule stands.

## Code review

@code-review flagged three items, all addressed in the second commit:
- `getOrderingScheduleStatus` switched from `.maybeSingle()` + default to `.single()` — a broken seed now surfaces, doesn't get masked.
- Added `setProductQty` helper; the per-item sold-out test now uses it instead of an inline `createClient`.
- TOCTOU caveat on `setAllProductsSoldOut` documented in a comment (solo phase — acceptable).

## Test plan

- `npx playwright test tests/customer-closed-and-soldout.spec.ts --project=desktop` — 4/4 green.
- `npx playwright test tests/customer-closed-and-soldout.spec.ts --project=mobile` (WebKit, 375px) — 4/4 green.
- `npx playwright test tests/customer-order-form.spec.ts tests/customer-place-order.spec.ts --project=desktop` — 11/11 green (no regression).
- Manual: in dev/preview, flip Settings → Close now → reload `/c/<token>` → see closed shell; reset.

After merge, `preview.baybranchfarm.com` will need rebinding to a new branch for the next task (per CLAUDE.md preview-rebind protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)