### PR TITLE
Phase 3 polish: admin shell top bar + sidebar footer + nav badges (closes #66)

### DIFF
--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -1,12 +1,51 @@
 import { NavLink } from "@/components/admin/nav-link";
+import { AdminBreadcrumb } from "@/components/admin/admin-breadcrumb";
 import { signOut } from "@/actions/sign-out";
+import {
+  getInventoryCount,
+  getNewOrdersCount,
+  getOrderingOpen,
+} from "@/lib/admin/queries";
+
+const MONTHS_LONG = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+] as const;
+const DAYS_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+const MONTHS_SHORT = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+] as const;
+
+// Sunday-anchored display strings for the shell chrome. The customer-side
+// uses Monday for week_of bucketing (cadence math); the shell chrome shows
+// the broader "this week" feel, Sun–Sat, which is friendlier for a glance.
+function shellWeekStrings(now: Date = new Date()): {
+  topbar: string;
+  range: string;
+} {
+  const utc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const sunday = new Date(utc);
+  sunday.setUTCDate(sunday.getUTCDate() - sunday.getUTCDay());
+  const saturday = new Date(sunday);
+  saturday.setUTCDate(saturday.getUTCDate() + 6);
+
+  const topbar = `${DAYS_SHORT[sunday.getUTCDay()]}, ${MONTHS_SHORT[sunday.getUTCMonth()]} ${sunday.getUTCDate()}`;
+
+  const sameMonth = sunday.getUTCMonth() === saturday.getUTCMonth();
+  const range = sameMonth
+    ? `${MONTHS_SHORT[sunday.getUTCMonth()]} ${sunday.getUTCDate()} – ${saturday.getUTCDate()}`
+    : `${MONTHS_SHORT[sunday.getUTCMonth()]} ${sunday.getUTCDate()} – ${MONTHS_SHORT[saturday.getUTCMonth()]} ${saturday.getUTCDate()}`;
+
+  return { topbar, range };
+}
 
 const NAV_ITEMS = [
   {
     href: "/admin/inventory",
     label: "Inventory",
     icon: (
-      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
         <path d="M20 4c0 8-4.5 14-12 14-1 0-2-.1-3-.4"/>
         <path d="M5 19c0-6 4-12 14-15"/>
       </svg>
@@ -16,7 +55,7 @@ const NAV_ITEMS = [
     href: "/admin/customers",
     label: "Customers",
     icon: (
-      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
         <circle cx="9" cy="8" r="3.5"/>
         <path d="M3 20c0-3.3 2.7-6 6-6s6 2.7 6 6"/>
         <circle cx="17" cy="9" r="2.5"/>
@@ -28,7 +67,7 @@ const NAV_ITEMS = [
     href: "/admin/orders",
     label: "Orders",
     icon: (
-      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
         <path d="M5 8h14l-1 12H6z"/>
         <path d="M9 8V6a3 3 0 0 1 6 0v2"/>
       </svg>
@@ -38,7 +77,7 @@ const NAV_ITEMS = [
     href: "/admin/send",
     label: "Send Update",
     icon: (
-      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
         <path d="M21 4 3 11l7 2 2 7z"/>
         <path d="m10 13 5-5"/>
       </svg>
@@ -48,7 +87,7 @@ const NAV_ITEMS = [
     href: "/admin/settings",
     label: "Settings",
     icon: (
-      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
         <circle cx="12" cy="12" r="3"/>
         <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1-.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h.1a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.9-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v.1a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/>
       </svg>
@@ -56,102 +95,87 @@ const NAV_ITEMS = [
   },
 ];
 
-export default function AdminShellLayout({
+export default async function AdminShellLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const [inventoryCount, newOrdersCount, isOpen] = await Promise.all([
+    getInventoryCount(),
+    getNewOrdersCount(),
+    getOrderingOpen(),
+  ]);
+
+  const week = shellWeekStrings();
+
+  const badgeFor = (href: string): string | undefined => {
+    if (href === "/admin/inventory") return `${inventoryCount} listed`;
+    if (href === "/admin/orders" && newOrdersCount > 0) return `${newOrdersCount} new`;
+    return undefined;
+  };
+
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "grid",
-        gridTemplateColumns: "240px 1fr",
-        background: "var(--cream)",
-        fontFamily: "var(--font-sans)",
-        color: "var(--ink-900)",
-      }}
-    >
-      {/* Sidebar */}
-      <aside
-        style={{
-          background: "var(--ink-900)",
-          color: "var(--paper)",
-          padding: "22px 18px 18px",
-          display: "flex",
-          flexDirection: "column",
-          position: "sticky",
-          top: 0,
-          height: "100dvh",
-          overflowY: "auto",
-        }}
-      >
-        {/* Brand mark */}
-        <div style={{ padding: "0 6px", marginBottom: 4 }}>
-          <div style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="var(--leaf-100)" aria-hidden="true">
-              <path d="M21.5 2.5c0 8-4.5 14.5-12 14.5-1.4 0-2.8-.2-4-.7l1.4-1.4c.8.2 1.7.4 2.6.4 6 0 9.5-5.3 10-12.3-2 .6-7.4 2.6-10.4 7.4-1 1.6-1.5 3.4-1.7 5.4l-1.5 1.5c0-3.3.7-6.3 2.4-8.7C11.4 4 18.4 2.6 21.5 2.5z"/>
-            </svg>
-            <span style={{ fontFamily: "var(--font-display)", fontSize: "1.05rem", fontWeight: 600, color: "var(--paper)", letterSpacing: "-0.005em", whiteSpace: "nowrap" }}>
-              Bay Branch Farm
-            </span>
-          </div>
+    <div className="admin-shell">
+      <aside className="admin-side">
+        <div className="admin-side-mark">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+            <path d="M21.5 2.5c0 8-4.5 14.5-12 14.5-1.4 0-2.8-.2-4-.7l1.4-1.4c.8.2 1.7.4 2.6.4 6 0 9.5-5.3 10-12.3-2 .6-7.4 2.6-10.4 7.4-1 1.6-1.5 3.4-1.7 5.4l-1.5 1.5c0-3.3.7-6.3 2.4-8.7C11.4 4 18.4 2.6 21.5 2.5z"/>
+          </svg>
+          <span className="admin-side-brand">Bay Branch Farm</span>
         </div>
+        <div className="admin-side-eyebrow">admin · bushel</div>
 
-        {/* Eyebrow */}
-        <div
-          style={{
-            fontSize: "0.66rem",
-            fontWeight: 600,
-            textTransform: "uppercase",
-            letterSpacing: "0.12em",
-            color: "rgba(251,250,245,0.5)",
-            padding: "0 6px",
-            marginBottom: 24,
-          }}
-        >
-          admin · bushel
-        </div>
-
-        {/* Nav */}
-        <nav style={{ display: "flex", flexDirection: "column", gap: 2, flex: 1 }} aria-label="Admin navigation">
+        <nav className="admin-nav" aria-label="Admin navigation">
           {NAV_ITEMS.map((item) => (
-            <NavLink key={item.href} href={item.href} label={item.label} icon={item.icon} />
+            <NavLink
+              key={item.href}
+              href={item.href}
+              label={item.label}
+              icon={item.icon}
+              badge={badgeFor(item.href)}
+            />
           ))}
         </nav>
 
-        {/* Sign out */}
-        <div style={{ borderTop: "1px solid rgba(251,250,245,0.08)", paddingTop: 14, marginTop: 14 }}>
-          <form action={signOut}>
-            <button
-              type="submit"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 8,
-                background: "transparent",
-                border: "none",
-                color: "rgba(251,250,245,0.55)",
-                fontSize: "0.82rem",
-                cursor: "pointer",
-                padding: "6px 12px",
-                borderRadius: "var(--r-sm)",
-                width: "100%",
-              }}
-            >
-              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
-                <path d="m16 17 5-5-5-5"/>
-                <path d="M21 12H9"/>
-              </svg>
-              Sign out
-            </button>
-          </form>
+        <div className="admin-side-foot">
+          <div className="admin-side-foot-row">
+            <div className="admin-side-foot-key">This week</div>
+            <div className="admin-side-foot-val">{week.range}</div>
+          </div>
+          <div className="admin-side-foot-row">
+            <div className="admin-side-foot-key">Status</div>
+            <div className="admin-side-foot-val">
+              <span
+                className={"status-dot" + (isOpen ? " is-open" : "")}
+                aria-hidden="true"
+              />
+              {isOpen ? "Open for orders" : "Closed"}
+            </div>
+          </div>
         </div>
       </aside>
 
-      {/* Main content */}
-      <div style={{ display: "flex", flexDirection: "column", minHeight: "100vh", overflow: "auto" }}>
+      <div className="admin-main">
+        <header className="admin-top">
+          <AdminBreadcrumb />
+          <div className="admin-top-right">
+            <div className="admin-week">
+              <div className="admin-week-key">Week of</div>
+              <div className="admin-week-val">{week.topbar}</div>
+            </div>
+            <form action={signOut}>
+              <button type="submit" className="admin-signout">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
+                  <path d="m16 17 5-5-5-5"/>
+                  <path d="M21 12H9"/>
+                </svg>
+                <span>Sign out</span>
+              </button>
+            </form>
+          </div>
+        </header>
+
         {children}
       </div>
     </div>

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -6,39 +6,7 @@ import {
   getNewOrdersCount,
   getOrderingOpen,
 } from "@/lib/admin/queries";
-
-const MONTHS_LONG = [
-  "January", "February", "March", "April", "May", "June",
-  "July", "August", "September", "October", "November", "December",
-] as const;
-const DAYS_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
-const MONTHS_SHORT = [
-  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
-] as const;
-
-// Sunday-anchored display strings for the shell chrome. The customer-side
-// uses Monday for week_of bucketing (cadence math); the shell chrome shows
-// the broader "this week" feel, Sun–Sat, which is friendlier for a glance.
-function shellWeekStrings(now: Date = new Date()): {
-  topbar: string;
-  range: string;
-} {
-  const utc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-  const sunday = new Date(utc);
-  sunday.setUTCDate(sunday.getUTCDate() - sunday.getUTCDay());
-  const saturday = new Date(sunday);
-  saturday.setUTCDate(saturday.getUTCDate() + 6);
-
-  const topbar = `${DAYS_SHORT[sunday.getUTCDay()]}, ${MONTHS_SHORT[sunday.getUTCMonth()]} ${sunday.getUTCDate()}`;
-
-  const sameMonth = sunday.getUTCMonth() === saturday.getUTCMonth();
-  const range = sameMonth
-    ? `${MONTHS_SHORT[sunday.getUTCMonth()]} ${sunday.getUTCDate()} – ${saturday.getUTCDate()}`
-    : `${MONTHS_SHORT[sunday.getUTCMonth()]} ${sunday.getUTCDate()} – ${MONTHS_SHORT[saturday.getUTCMonth()]} ${saturday.getUTCDate()}`;
-
-  return { topbar, range };
-}
+import { shellWeekStringsNY } from "@/lib/week";
 
 const NAV_ITEMS = [
   {
@@ -106,10 +74,10 @@ export default async function AdminShellLayout({
     getOrderingOpen(),
   ]);
 
-  const week = shellWeekStrings();
+  const week = shellWeekStringsNY();
 
   const badgeFor = (href: string): string | undefined => {
-    if (href === "/admin/inventory") return `${inventoryCount} listed`;
+    if (href === "/admin/inventory" && inventoryCount > 0) return `${inventoryCount} listed`;
     if (href === "/admin/orders" && newOrdersCount > 0) return `${newOrdersCount} new`;
     return undefined;
   };

--- a/src/components/admin/admin-breadcrumb.tsx
+++ b/src/components/admin/admin-breadcrumb.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+const PAGE_LABELS: Record<string, string> = {
+  "/admin/inventory": "Inventory",
+  "/admin/customers": "Customers",
+  "/admin/orders": "Orders",
+  "/admin/send": "Send Update",
+  "/admin/settings": "Settings",
+};
+
+function resolveLabel(pathname: string): string {
+  // Exact match first, then longest-prefix match (so /admin/inventory/abc
+  // still resolves to "Inventory" once detail routes exist).
+  if (PAGE_LABELS[pathname]) return PAGE_LABELS[pathname];
+  for (const prefix of Object.keys(PAGE_LABELS)) {
+    if (pathname.startsWith(prefix + "/")) return PAGE_LABELS[prefix];
+  }
+  return "Admin";
+}
+
+export function AdminBreadcrumb() {
+  const pathname = usePathname();
+  const label = resolveLabel(pathname);
+  return (
+    <div className="admin-crumb">
+      <span>Admin</span>
+      <span className="admin-crumb-sep" aria-hidden="true">/</span>
+      <span className="admin-crumb-active">{label}</span>
+    </div>
+  );
+}

--- a/src/components/admin/nav-link.tsx
+++ b/src/components/admin/nav-link.tsx
@@ -7,57 +7,22 @@ interface NavLinkProps {
   href: string;
   label: string;
   icon: React.ReactNode;
+  badge?: string;
 }
 
-export function NavLink({ href, label, icon }: NavLinkProps) {
+export function NavLink({ href, label, icon, badge }: NavLinkProps) {
   const pathname = usePathname();
   const isActive = pathname === href || pathname.startsWith(href + "/");
 
   return (
     <Link
       href={href}
-      style={{
-        position: "relative",
-        display: "flex",
-        alignItems: "center",
-        gap: 12,
-        padding: "10px 12px",
-        borderRadius: "var(--r-sm)",
-        color: isActive ? "var(--paper)" : "rgba(251,250,245,0.78)",
-        background: isActive ? "rgba(251,250,245,0.10)" : "transparent",
-        fontSize: "0.93rem",
-        fontWeight: 500,
-        textDecoration: "none",
-        transition: "background 0.12s, color 0.12s",
-      }}
+      className={"admin-nav-item" + (isActive ? " is-active" : "")}
       aria-current={isActive ? "page" : undefined}
     >
-      {isActive && (
-        <span
-          aria-hidden="true"
-          style={{
-            position: "absolute",
-            left: -18,
-            top: "50%",
-            transform: "translateY(-50%)",
-            width: 3,
-            height: 22,
-            background: "var(--leaf-100)",
-            borderRadius: "0 3px 3px 0",
-          }}
-        />
-      )}
-      <span
-        style={{
-          display: "flex",
-          alignItems: "center",
-          color: isActive ? "var(--leaf-100)" : "rgba(251,250,245,0.6)",
-          flexShrink: 0,
-        }}
-      >
-        {icon}
-      </span>
-      <span style={{ flex: 1 }}>{label}</span>
+      <span className="admin-nav-icon" aria-hidden="true">{icon}</span>
+      <span className="admin-nav-label">{label}</span>
+      {badge ? <span className="admin-nav-badge">{badge}</span> : null}
     </Link>
   );
 }

--- a/src/lib/admin/queries.ts
+++ b/src/lib/admin/queries.ts
@@ -25,6 +25,10 @@ export async function getNewOrdersCount(): Promise<number> {
   return count ?? 0;
 }
 
+// ordering_schedule is a singleton (DEC-030 seeds one row; an is_singleton
+// unique-check constraint enforces it). .single() is intentional — if the
+// row ever goes missing, the admin shell 500s loudly, which is the right
+// signal vs silently defaulting to "open."
 export async function getOrderingOpen(): Promise<boolean> {
   const supabase = createAdminClient();
   const { data, error } = await supabase

--- a/src/lib/admin/queries.ts
+++ b/src/lib/admin/queries.ts
@@ -1,0 +1,36 @@
+// Admin-side reads used to populate the shell chrome (nav badges, footer
+// status). Service-role client — these reads cross every tenant boundary
+// the shell shows. Never expose any of these to the client.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { weekOfMondayNY } from "@/lib/week";
+
+export async function getInventoryCount(): Promise<number> {
+  const supabase = createAdminClient();
+  const { count, error } = await supabase
+    .from("products")
+    .select("id", { count: "exact", head: true })
+    .eq("is_available", true);
+  if (error) throw new Error(`getInventoryCount: ${error.message}`);
+  return count ?? 0;
+}
+
+export async function getNewOrdersCount(): Promise<number> {
+  const supabase = createAdminClient();
+  const { count, error } = await supabase
+    .from("orders")
+    .select("id", { count: "exact", head: true })
+    .eq("status", "new")
+    .eq("week_of", weekOfMondayNY());
+  if (error) throw new Error(`getNewOrdersCount: ${error.message}`);
+  return count ?? 0;
+}
+
+export async function getOrderingOpen(): Promise<boolean> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("ordering_schedule")
+    .select("is_open")
+    .single();
+  if (error) throw new Error(`getOrderingOpen: ${error.message}`);
+  return data.is_open;
+}

--- a/src/lib/week.ts
+++ b/src/lib/week.ts
@@ -44,3 +44,33 @@ export function weekOfMondayNY(now: Date = new Date()): string {
   anchor.setUTCDate(anchor.getUTCDate() - offset);
   return anchor.toISOString().slice(0, 10);
 }
+
+// Shell chrome strings, Sunday-anchored, NY-time. Same tz discipline as
+// weekOfMondayNY — late-Saturday-NY (Sunday UTC) would otherwise jump the
+// admin shell into next week several hours early.
+//
+// Returns:
+//   topbar: "Sun, May 3"          (for the top-bar "Week of" pill)
+//   range:  "May 3 – May 9"        (for the sidebar "This week" row)
+export function shellWeekStringsNY(now: Date = new Date()): {
+  topbar: string;
+  range: string;
+} {
+  // Monday of the current NY week (YYYY-MM-DD), then back up one day to Sunday.
+  const monday = weekOfMondayNY(now);
+  const [y, m, d] = monday.split("-").map((n) => parseInt(n, 10));
+  const sunday = new Date(Date.UTC(y, m - 1, d));
+  sunday.setUTCDate(sunday.getUTCDate() - 1);
+  const saturday = new Date(sunday);
+  saturday.setUTCDate(saturday.getUTCDate() + 6);
+
+  const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const topbar = `${days[sunday.getUTCDay()]}, ${MONTHS[sunday.getUTCMonth()]} ${sunday.getUTCDate()}`;
+
+  const sameMonth = sunday.getUTCMonth() === saturday.getUTCMonth();
+  const range = sameMonth
+    ? `${MONTHS[sunday.getUTCMonth()]} ${sunday.getUTCDate()} – ${saturday.getUTCDate()}`
+    : `${MONTHS[sunday.getUTCMonth()]} ${sunday.getUTCDate()} – ${MONTHS[saturday.getUTCMonth()]} ${saturday.getUTCDate()}`;
+
+  return { topbar, range };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1432,3 +1432,187 @@
   border-color: var(--ink-200);
   cursor: not-allowed;
 }
+
+/* ── Admin shell (Phase 3 polish — #66) ──────────────────── */
+.admin-shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  background: var(--cream);
+  color: var(--ink-900);
+}
+
+.admin-side {
+  background: var(--ink-900);
+  color: var(--paper);
+  padding: 22px 18px 18px;
+  display: flex; flex-direction: column;
+  position: sticky; top: 0; height: 100dvh;
+  overflow-y: auto;
+}
+.admin-side-mark {
+  display: inline-flex; align-items: center; gap: 8px;
+  color: var(--paper);
+  padding: 0 6px;
+  margin-bottom: 4px;
+}
+.admin-side-mark svg { color: var(--leaf-100); flex-shrink: 0; }
+.admin-side-mark .admin-side-brand {
+  font-family: var(--font-display, var(--serif));
+  font-size: 1.05rem; font-weight: 600;
+  letter-spacing: -0.005em;
+  white-space: nowrap;
+}
+.admin-side-eyebrow {
+  font-size: 0.66rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.12em;
+  color: rgba(251,250,245,0.5);
+  padding: 0 6px;
+  margin-bottom: 24px;
+}
+
+.admin-nav {
+  display: flex; flex-direction: column;
+  gap: 2px;
+  flex: 1;
+}
+.admin-nav-item {
+  position: relative;
+  display: flex; align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: var(--r-sm);
+  color: rgba(251,250,245,0.78);
+  font-size: 0.93rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background 0.12s, color 0.12s;
+}
+.admin-nav-item:hover {
+  background: rgba(251,250,245,0.06);
+  color: var(--paper);
+}
+.admin-nav-item.is-active {
+  background: rgba(251,250,245,0.10);
+  color: var(--paper);
+}
+.admin-nav-item.is-active::before {
+  content: "";
+  position: absolute;
+  left: -18px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px; height: 22px;
+  background: var(--leaf-100);
+  border-radius: 0 3px 3px 0;
+}
+.admin-nav-icon {
+  display: flex; align-items: center;
+  color: rgba(251,250,245,0.6);
+  flex-shrink: 0;
+}
+.admin-nav-item.is-active .admin-nav-icon,
+.admin-nav-item:hover .admin-nav-icon { color: var(--leaf-100); }
+.admin-nav-label { flex: 1; }
+.admin-nav-badge {
+  font-size: 0.7rem; font-weight: 500;
+  font-family: var(--mono);
+  background: rgba(251,250,245,0.08);
+  color: rgba(251,250,245,0.75);
+  padding: 2px 7px;
+  border-radius: 10px;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.admin-side-foot {
+  border-top: 1px solid rgba(251,250,245,0.08);
+  padding-top: 14px;
+  margin-top: 14px;
+  display: flex; flex-direction: column;
+  gap: 8px;
+}
+.admin-side-foot-row {
+  display: flex; flex-direction: column;
+  padding: 0 6px;
+}
+.admin-side-foot-key {
+  font-size: 0.66rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.1em;
+  color: rgba(251,250,245,0.45);
+  margin-bottom: 2px;
+}
+.admin-side-foot-val {
+  font-size: 0.85rem;
+  color: rgba(251,250,245,0.85);
+  display: flex; align-items: center; gap: 8px;
+}
+
+.admin-main {
+  display: flex; flex-direction: column;
+  min-width: 0;
+  min-height: 100vh;
+}
+
+.admin-top {
+  background: var(--paper);
+  border-bottom: 1px solid var(--ink-200);
+  padding: 0 32px;
+  height: 60px;
+  display: flex; align-items: center; justify-content: space-between;
+  position: sticky; top: 0; z-index: 5;
+}
+.admin-crumb {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 0.88rem;
+  color: var(--ink-500);
+}
+.admin-crumb-sep { color: var(--ink-300); }
+.admin-crumb-active {
+  color: var(--ink-900);
+  font-weight: 600;
+}
+
+.admin-top-right {
+  display: flex; align-items: center; gap: 18px;
+}
+.admin-week {
+  text-align: right;
+  padding-right: 18px;
+  border-right: 1px solid var(--ink-200);
+}
+.admin-week-key {
+  font-size: 0.68rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.1em;
+  color: var(--ink-500);
+  line-height: 1.2;
+  white-space: nowrap;
+}
+.admin-week-val {
+  font-size: 0.9rem; font-weight: 600;
+  color: var(--ink-900);
+  font-family: var(--serif);
+  letter-spacing: -0.005em;
+  white-space: nowrap;
+}
+
+.admin-signout {
+  background: transparent;
+  border: 1px solid var(--ink-200);
+  color: var(--ink-700);
+  border-radius: var(--r-sm);
+  padding: 7px 12px;
+  font-size: 0.85rem; font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  display: flex; align-items: center; gap: 7px;
+  flex-shrink: 0;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.admin-signout:hover {
+  background: var(--leaf-50);
+  border-color: var(--leaf-100);
+  color: var(--leaf-700);
+}

--- a/tests/admin-inventory.spec.ts
+++ b/tests/admin-inventory.spec.ts
@@ -18,10 +18,13 @@ test.describe("admin inventory", () => {
   test("renders header, meta pills, and product table", async ({ page }) => {
     await page.goto("/admin/inventory");
     await expect(page.getByRole("heading", { name: /inventory/i })).toBeVisible();
-    await expect(page.getByText(/week of/i)).toBeVisible();
+    // Scope page-specific copy to .page-head / .meta-row — Phase 3 admin shell
+    // (#66) added a top bar with its own "Week of" and a sidebar footer with
+    // its own "Open for orders" pill, which collide under page-wide getByText.
+    await expect(page.locator(".page-head").getByText(/week of/i)).toBeVisible();
     await expect(page.getByText(/this week's list/i)).toBeVisible();
-    await expect(page.getByText("Open for orders")).toBeVisible();
-    await expect(page.getByText("Cutoff")).toBeVisible();
+    await expect(page.locator(".meta-row").getByText("Open for orders")).toBeVisible();
+    await expect(page.locator(".meta-row").getByText("Cutoff")).toBeVisible();
     await expect(page.getByRole("table")).toBeVisible();
     await expect(rowByName(page, TEST_PRODUCTS.kale.name)).toBeVisible();
     await expect(rowByName(page, TEST_PRODUCTS.eggs.name)).toBeVisible();

--- a/tests/admin-shell.spec.ts
+++ b/tests/admin-shell.spec.ts
@@ -30,6 +30,46 @@ test.describe("admin shell — authenticated", () => {
     const customersLink = page.getByRole("link", { name: /customers/i });
     await expect(customersLink).not.toHaveAttribute("aria-current");
   });
+
+  test("top bar shows breadcrumb + week pill", async ({ page }) => {
+    await page.goto("/admin/inventory");
+    const top = page.locator(".admin-top");
+    await expect(top).toBeVisible();
+    await expect(top.locator(".admin-crumb")).toContainText("Admin");
+    await expect(top.locator(".admin-crumb-active")).toHaveText("Inventory");
+    await expect(top.locator(".admin-week-key")).toHaveText(/Week of/i);
+    // Pattern: "Sun, May 3" / "Tue, Jul 14" — weekday, comma, space, month, day.
+    await expect(top.locator(".admin-week-val")).toHaveText(
+      /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat), [A-Z][a-z]{2} \d{1,2}$/,
+    );
+  });
+
+  test("breadcrumb updates as you navigate", async ({ page }) => {
+    await page.goto("/admin/customers");
+    await expect(page.locator(".admin-crumb-active")).toHaveText("Customers");
+    await page.goto("/admin/settings");
+    await expect(page.locator(".admin-crumb-active")).toHaveText("Settings");
+  });
+
+  test("sidebar footer shows current-week range + status pill", async ({ page }) => {
+    await page.goto("/admin");
+    const foot = page.locator(".admin-side-foot");
+    await expect(foot).toBeVisible();
+    await expect(foot).toContainText(/This week/i);
+    // Range: "May 3 – May 9" / "Jun 28 – Jul 4" — accept both same-month and
+    // cross-month formats.
+    await expect(foot).toContainText(
+      /[A-Z][a-z]{2} \d{1,2} – ([A-Z][a-z]{2} )?\d{1,2}/,
+    );
+    await expect(foot.locator(".status-dot")).toBeVisible();
+  });
+
+  test("inventory nav has a badge with the listed-product count", async ({ page }) => {
+    await page.goto("/admin");
+    const badge = page.getByRole("link", { name: /inventory/i }).locator(".admin-nav-badge");
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveText(/^\d+ listed$/);
+  });
 });
 
 // Isolated from the shared-session block — sign-out invalidates the refresh


### PR DESCRIPTION
## Summary

Brings the shipped admin shell up to `design/admin-shell.jsx`: top bar with breadcrumb + week pill + sign-out, sidebar footer with this-week range + status pill, and nav badges driven by live counts. All inline styles in `layout.tsx` + `nav-link.tsx` replaced with `.admin-*` classes in `app.css` per DEC-021.

## Files changed

- `src/styles/app.css` — new `.admin-shell` / `.admin-side` / `.admin-nav` / `.admin-side-foot` / `.admin-top` / `.admin-week` / `.admin-signout` block (~180 lines), ported from `design/admin-shell.css` with the existing token names.
- `src/app/(admin)/admin/layout.tsx` — rewrite: server component fetches `getInventoryCount` + `getNewOrdersCount` + `getOrderingOpen` in parallel; renders the new sidebar + top bar.
- `src/components/admin/nav-link.tsx` — drops inline styles for `.admin-nav-item` classes; adds optional `badge` prop.
- `src/components/admin/admin-breadcrumb.tsx` — new client component using `usePathname()` so the layout stays a server component.
- `src/lib/admin/queries.ts` — new; service-role reads for inventory/orders counts + `is_open`. `getOrderingOpen` uses `.single()` intentionally — the singleton row is invariant, missing-row should 500 loudly.
- `src/lib/week.ts` — `shellWeekStringsNY()` returns Sun-anchored topbar + Sun–Sat range, NY-tz, derived from `weekOfMondayNY()`.
- `tests/admin-shell.spec.ts` — 4 new tests (top bar render, breadcrumb navigation, sidebar footer, inventory badge).

## Code review

@code-review surfaced four items; all addressed in the second commit:
- Week math was UTC, not NY — fixed by moving the helper into `lib/week.ts` and deriving Sunday from `weekOfMondayNY()`. Late-Saturday-NY no longer jumps the shell into next week early.
- Inventory badge gated on `count > 0` (mirrors the orders-badge pattern).
- `.single()` on `ordering_schedule` kept and documented — a deleted singleton row should fail loudly, not silently default.
- (Reviewer also noted the `shellWeekStrings` helper belonged in `lib/week.ts` rather than the layout — addressed in the same move.)

## Test plan

- `npx playwright test tests/admin-shell.spec.ts --project=desktop` — 9/9 green (new tests + the 5 pre-existing).
- `npx playwright test tests/admin-customers.spec.ts tests/admin-inventory.spec.ts tests/admin-settings.spec.ts tests/admin-auth.spec.ts tests/admin-prepopulate.spec.ts --project=desktop` — 15/15 green (regression check; layout wraps all of them).
- Manual after deploy: hit `/admin/inventory` → top bar shows `Admin / Inventory` + `Week of Sun, May …`, sidebar shows `This week / May … – May …` + green `Open for orders` dot, Inventory nav shows `<N> listed`. Flip Settings → Close now → reload any admin page → status pill goes grey + reads `Closed`.
- After merge, `preview.baybranchfarm.com` will need rebinding to the next task branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)