### PR TITLE
Phase 3 polish: pgTAP coverage for DEC-029 + DEC-030 columns (closes #67)

### DIFF
--- a/supabase/tests/rls_tables.sql
+++ b/supabase/tests/rls_tables.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(36);
+select plan(41);
 
 -- ============================================================
 -- Schema sanity: RLS enabled on all tables
@@ -43,6 +43,15 @@ select col_has_default('public', 'customers', 'send_weekly_link', 'customers.sen
 select has_column('public', 'customers', 'priority', 'customers.priority column exists');
 select col_not_null('public', 'customers', 'priority', 'customers.priority is not null');
 select col_default_is('public', 'customers', 'priority', '100', 'customers.priority defaults to 100');
+
+-- ============================================================
+-- Schema sanity: Phase 2.0b fulfillment columns (DEC-029 + DEC-030)
+-- ============================================================
+select has_column('public', 'orders', 'pickup_note', 'orders.pickup_note column exists (DEC-029)');
+select col_type_is('public', 'orders', 'pickup_note', 'text', 'orders.pickup_note is text');
+select has_column('public', 'orders', 'delivery_preference', 'orders.delivery_preference column exists (DEC-029)');
+select col_type_is('public', 'orders', 'delivery_preference', 'text', 'orders.delivery_preference is text');
+select col_default_is('public', 'ordering_schedule', 'is_open', 'true', 'ordering_schedule.is_open defaults to true (DEC-030)');
 
 -- ============================================================
 -- Seed test data (postgres role bypasses RLS)


### PR DESCRIPTION
## Summary

Pins the post-Phase-2 fulfillment schema with column-shape assertions so a future migration that drops a column or flips a default fails at `supabase test db` instead of leaking into integration.

## Files changed

- `supabase/tests/rls_tables.sql` — 5 new assertions in the schema-sanity block; plan count 36 → 41.

## Code review

@code-review: clean bill of health. Plan count matches, column types match migrations, ordering vs. seed inserts is fine.

## Test plan

- `supabase db reset` (clear leftover state in local DB).
- `supabase test db` → expect `41` tests pass in `rls_tables.sql` + `16` in `customers_rls.sql` = 57 total.
- Confirm the new assertions individually run:
  - `orders.pickup_note column exists (DEC-029)` ✓
  - `orders.pickup_note is text` ✓
  - `orders.delivery_preference column exists (DEC-029)` ✓
  - `orders.delivery_preference is text` ✓
  - `ordering_schedule.is_open defaults to true (DEC-030)` ✓
- No app code, no migration, no Playwright impact.

## Note worth flagging (separate from #67)

`supabase/tests/rls_tables.sql:181` ("authenticated can read all orders" → expects count = 2) breaks when the local DB has leftover orders from prior Playwright runs. `begin/rollback` doesn't isolate from pre-existing rows committed before the test transaction. Worth a follow-up: filter the assertion by `week_of` or by `customer_id IN (...)` so it counts only the orders the test itself inserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)