### PR TITLE
Phase 4.1 — `sms:` deep-link builder utility (#87)

### DIFF
--- a/src/lib/notifications/sms-deep-link.ts
+++ b/src/lib/notifications/sms-deep-link.ts
@@ -9,13 +9,20 @@ export type SmsTarget = {
   body: string;
 };
 
+// Builder is never-throw and always emits `?body=` (even for empty bodies) so
+// callers get a single stable shape. Caller is responsible for validating that
+// `phone` is non-empty and dialable — an empty phone produces `sms:?body=...`,
+// which the OS will reject silently. Extension syntax (`555-1234 x123`) is not
+// detected; non-digit chars are stripped wholesale, so extension digits glue
+// onto the main number. See the spec for the pinned-behavior tests.
 export function buildSmsUrl({ phone, body }: SmsTarget): string {
   return `sms:${normalizePhone(phone)}?body=${encodeURIComponent(body)}`;
 }
 
 export function normalizePhone(raw: string): string {
   if (!raw) return "";
-  const hasLeadingPlus = raw.trimStart().startsWith("+");
-  const digits = raw.replace(/\D/g, "");
+  const trimmed = raw.trim();
+  const hasLeadingPlus = trimmed.startsWith("+");
+  const digits = trimmed.replace(/\D/g, "");
   return hasLeadingPlus ? `+${digits}` : digits;
 }

--- a/src/lib/notifications/sms-deep-link.ts
+++ b/src/lib/notifications/sms-deep-link.ts
@@ -1,0 +1,21 @@
+// `sms:` deep-link builder. Per DEC-026, Bushel does not send SMS itself;
+// the admin send-queue surfaces `sms:` URIs as per-customer Send buttons that
+// open the operator's native Messages app with the recipient and body
+// pre-filled. RFC 5724 specifies `sms:NUMBER?body=...`; iOS 8+ and Android
+// Chrome both honor this form.
+
+export type SmsTarget = {
+  phone: string;
+  body: string;
+};
+
+export function buildSmsUrl({ phone, body }: SmsTarget): string {
+  return `sms:${normalizePhone(phone)}?body=${encodeURIComponent(body)}`;
+}
+
+export function normalizePhone(raw: string): string {
+  if (!raw) return "";
+  const hasLeadingPlus = raw.trimStart().startsWith("+");
+  const digits = raw.replace(/\D/g, "");
+  return hasLeadingPlus ? `+${digits}` : digits;
+}

--- a/tests/sms-deep-link.spec.ts
+++ b/tests/sms-deep-link.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+
+import { buildSmsUrl, normalizePhone } from "@/lib/notifications/sms-deep-link";
+
+// Pure-function unit tests. No browser, no page, no network.
+// Bushel doesn't carry vitest/jest — Playwright's runner is the only test
+// harness in the repo (DEC-023: light unit / heavy integration), so unit tests
+// for pure libs ride here. Project tablet/mobile inherit and run the same
+// assertions; harmless duplication for a 2-pt utility.
+
+test.describe("buildSmsUrl", () => {
+  test("basic ASCII body", () => {
+    expect(buildSmsUrl({ phone: "+12162025718", body: "Hello" })).toBe(
+      "sms:+12162025718?body=Hello",
+    );
+  });
+
+  test("spaces encode as %20 (not +)", () => {
+    expect(buildSmsUrl({ phone: "+12162025718", body: "Hello world" })).toBe(
+      "sms:+12162025718?body=Hello%20world",
+    );
+  });
+
+  test("newlines encode as %0A", () => {
+    expect(
+      buildSmsUrl({ phone: "+12162025718", body: "Line one\nLine two" }),
+    ).toBe("sms:+12162025718?body=Line%20one%0ALine%20two");
+  });
+
+  test("URL-reserved characters are percent-encoded", () => {
+    expect(
+      buildSmsUrl({ phone: "+12162025718", body: "a&b?c=d#e+f/g" }),
+    ).toBe("sms:+12162025718?body=a%26b%3Fc%3Dd%23e%2Bf%2Fg");
+  });
+
+  test("multi-byte UTF-8 emoji encoded", () => {
+    // 🌱 (U+1F331) → F0 9F 8C B1
+    expect(buildSmsUrl({ phone: "+12162025718", body: "Order ready 🌱" })).toBe(
+      "sms:+12162025718?body=Order%20ready%20%F0%9F%8C%B1",
+    );
+  });
+
+  test("empty body still produces ?body= (consistent shape)", () => {
+    expect(buildSmsUrl({ phone: "+12162025718", body: "" })).toBe(
+      "sms:+12162025718?body=",
+    );
+  });
+
+  test("normalizes phone formatting in the URL", () => {
+    expect(buildSmsUrl({ phone: "(216) 202-5718", body: "hi" })).toBe(
+      "sms:2162025718?body=hi",
+    );
+  });
+});
+
+test.describe("normalizePhone", () => {
+  test("strips parens, dashes, dots, and whitespace", () => {
+    expect(normalizePhone("(216) 202-5718")).toBe("2162025718");
+    expect(normalizePhone("216-202-5718")).toBe("2162025718");
+    expect(normalizePhone("216.202.5718")).toBe("2162025718");
+    expect(normalizePhone(" 216 202 5718 ")).toBe("2162025718");
+  });
+
+  test("preserves a leading +", () => {
+    expect(normalizePhone("+1 216-202-5718")).toBe("+12162025718");
+    expect(normalizePhone("+1 (216) 202-5718")).toBe("+12162025718");
+  });
+
+  test("a + only counts when it leads — interior + chars are stripped", () => {
+    // No legitimate phone format has a non-leading +, but we don't want to
+    // silently pass one through and have the device do something weird.
+    expect(normalizePhone("216+202+5718")).toBe("2162025718");
+  });
+
+  test("empty input → empty output (no throw)", () => {
+    expect(normalizePhone("")).toBe("");
+  });
+});

--- a/tests/sms-deep-link.spec.ts
+++ b/tests/sms-deep-link.spec.ts
@@ -75,4 +75,17 @@ test.describe("normalizePhone", () => {
   test("empty input → empty output (no throw)", () => {
     expect(normalizePhone("")).toBe("");
   });
+
+  test("leading whitespace before + is tolerated", () => {
+    expect(normalizePhone(" +1 216-202-5718")).toBe("+12162025718");
+    expect(normalizePhone("\t+12162025718")).toBe("+12162025718");
+  });
+
+  test("extension digits glue onto the main number (pinned behavior, V1)", () => {
+    // We strip all non-digit chars wholesale, so `x123` becomes `123` and
+    // concatenates to produce a wrong number. Annabel does not enter
+    // extensions today; if she ever does, this test documents the gotcha
+    // and we add ext-aware parsing then.
+    expect(normalizePhone("216-202-5718 x123")).toBe("2162025718123");
+  });
 });


### PR DESCRIPTION
## Summary

Pure-function builder for `sms:` deep links per DEC-026. Admin send-queue (4.2) will consume this — operator taps a per-customer Send button, native Messages app opens with phone + body pre-filled, operator hits Send. Bushel never touches the carrier.

RFC 5724 `sms:NUMBER?body=...` form; iOS 8+ and Android Chrome both honor.

Closes #87.

## Files changed

- `src/lib/notifications/sms-deep-link.ts` — `buildSmsUrl({ phone, body })`, `normalizePhone(raw)`
- `tests/sms-deep-link.spec.ts` — 13 unit-style Playwright tests (no `page`, no browser, pure-function assertions)

## Code review

3 of 5 findings addressed in `ccafb38`:
- JSDoc on `buildSmsUrl` pinning the never-throw / always-`?body=` contract + empty-phone + extension-syntax gotchas.
- `trim()` pulled once in `normalizePhone` so the `+`-check and digit-strip operate on the same string.
- Two new tests: leading-whitespace-before-`+`, and a pinning test for extension digits gluing onto the main number (`216-202-5718 x123` → `2162025718123`, documents V1 behavior).

Skipped (not blocking):
- 3-project duplication note — pure-function tests run on desktop/tablet/mobile (~3 sec total, harmless; already documented in the test file header).

## Test plan

Pure functions, no integration surface. Coverage is locked by the spec:

- `npx playwright test tests/sms-deep-link.spec.ts --project=desktop` → 13/13 green.
- Encoding correctness: spaces → `%20`, newlines → `%0A`, reserved chars (`&?=#+/`) percent-encoded, multi-byte emoji (`🌱` → `%F0%9F%8C%B1`), empty body → `?body=` (consistent shape).
- Phone normalization: `(216) 202-5718` / `216-202-5718` / `216.202.5718` / `+1 216-202-5718` all collapse correctly; interior `+` stripped; leading whitespace before `+` tolerated; empty → empty.

Manual device verification (deferred to 4.2 when the builder is wired into a real button):
- iOS Safari: tap `<a href="sms:+1...?body=Hello%20world">` → Messages opens with recipient + body filled.
- Android Chrome: same, opens default SMS app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)