### PR TITLE
Phase 4.2 — Send-queue page (#88)

### DIFF
--- a/src/actions/record-send.ts
+++ b/src/actions/record-send.ts
@@ -15,9 +15,12 @@ export async function recordSend(
 ): Promise<{ error: string | null }> {
   const supabase = await createClient();
 
+  // Belt-and-suspenders: RLS admin-all is the gate today, but a future
+  // policy loosening shouldn't accidentally allow anonymous writes here.
   const {
     data: { user },
   } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized" };
 
   const { error } = await supabase.from("customer_sends").upsert(
     {
@@ -25,7 +28,7 @@ export async function recordSend(
       week_of: weekOf,
       mode,
       sent_at: new Date().toISOString(),
-      sent_by_user_id: user?.id ?? null,
+      sent_by_user_id: user.id,
     },
     { onConflict: "customer_id,week_of,mode" },
   );

--- a/src/actions/record-send.ts
+++ b/src/actions/record-send.ts
@@ -1,0 +1,37 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { createClient } from "@/lib/supabase/server";
+import type { SendMode } from "@/lib/admin/send-queue-queries";
+
+// Marks a customer as sent for (week, mode). Idempotent — upsert collapses
+// repeat taps to a single row. Uses RLS-gated server client (admin-all policy
+// on customer_sends from migration 20260515133545).
+export async function recordSend(
+  customerId: string,
+  weekOf: string,
+  mode: SendMode,
+): Promise<{ error: string | null }> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { error } = await supabase.from("customer_sends").upsert(
+    {
+      customer_id: customerId,
+      week_of: weekOf,
+      mode,
+      sent_at: new Date().toISOString(),
+      sent_by_user_id: user?.id ?? null,
+    },
+    { onConflict: "customer_id,week_of,mode" },
+  );
+
+  if (error) return { error: error.message };
+
+  revalidatePath("/admin/send");
+  return { error: null };
+}

--- a/src/actions/save-intro-note.ts
+++ b/src/actions/save-intro-note.ts
@@ -1,0 +1,21 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { createClient } from "@/lib/supabase/server";
+
+// Updates the per-cycle intro note on the ordering_schedule singleton. Empty
+// string clears it (template treats null and "" the same).
+export async function saveIntroNote(text: string): Promise<{ error: string | null }> {
+  const supabase = await createClient();
+
+  const { error } = await supabase
+    .from("ordering_schedule")
+    .update({ intro_note: text, updated_at: new Date().toISOString() })
+    .eq("is_singleton", true);
+
+  if (error) return { error: error.message };
+
+  revalidatePath("/admin/send");
+  return { error: null };
+}

--- a/src/actions/save-intro-note.ts
+++ b/src/actions/save-intro-note.ts
@@ -9,10 +9,15 @@ import { createClient } from "@/lib/supabase/server";
 export async function saveIntroNote(text: string): Promise<{ error: string | null }> {
   const supabase = await createClient();
 
+  // .select().single() surfaces "no row matched" as an error — without it,
+  // a missing singleton (migration drift, wrong env) would return success
+  // while nothing changed.
   const { error } = await supabase
     .from("ordering_schedule")
     .update({ intro_note: text, updated_at: new Date().toISOString() })
-    .eq("is_singleton", true);
+    .eq("is_singleton", true)
+    .select("id")
+    .single();
 
   if (error) return { error: error.message };
 

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -6,6 +6,7 @@ import {
   getNewOrdersCount,
   getOrderingOpen,
 } from "@/lib/admin/queries";
+import { getWeeklyUpdateUnsentCount } from "@/lib/admin/send-queue-queries";
 import { shellWeekStringsNY } from "@/lib/week";
 
 const NAV_ITEMS = [
@@ -68,10 +69,11 @@ export default async function AdminShellLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const [inventoryCount, newOrdersCount, isOpen] = await Promise.all([
+  const [inventoryCount, newOrdersCount, isOpen, weeklyUnsentCount] = await Promise.all([
     getInventoryCount(),
     getNewOrdersCount(),
     getOrderingOpen(),
+    getWeeklyUpdateUnsentCount(),
   ]);
 
   const week = shellWeekStringsNY();
@@ -79,6 +81,7 @@ export default async function AdminShellLayout({
   const badgeFor = (href: string): string | undefined => {
     if (href === "/admin/inventory" && inventoryCount > 0) return `${inventoryCount} listed`;
     if (href === "/admin/orders" && newOrdersCount > 0) return `${newOrdersCount} new`;
+    if (href === "/admin/send" && weeklyUnsentCount > 0) return `${weeklyUnsentCount} to send`;
     return undefined;
   };
 

--- a/src/app/(admin)/admin/send/page.tsx
+++ b/src/app/(admin)/admin/send/page.tsx
@@ -1,0 +1,135 @@
+import { SendRow } from "@/components/admin/send-row";
+import { IntroNoteCard } from "@/components/admin/intro-note-card";
+import {
+  SEND_MODES,
+  getIntroNote,
+  getOrderConfirmationQueue,
+  getPickupReminderQueue,
+  getWeeklyUpdateQueue,
+  tokenUrl,
+  type SendMode,
+  type SendQueueRow,
+} from "@/lib/admin/send-queue-queries";
+import { weekOfMondayNY } from "@/lib/week";
+import {
+  orderConfirmationBody,
+  pickupReminderBody,
+  weeklyUpdateBody,
+} from "@/lib/notifications/templates";
+
+export const metadata = { title: "Send Update — Bay Branch Farm" };
+
+const MODE_LABELS: Record<SendMode, string> = {
+  weekly_update: "Weekly update",
+  order_confirmation: "Order confirmation",
+  pickup_reminder: "Pickup reminder",
+};
+
+const MODE_SUBTITLES: Record<SendMode, string> = {
+  weekly_update:
+    "Goes to every subscribed customer with the week's ordering link.",
+  order_confirmation:
+    "Confirms receipt to customers who placed an order this week.",
+  pickup_reminder:
+    "Reminds customers with an order this week that pickup is coming up.",
+};
+
+function isSendMode(value: string | undefined): value is SendMode {
+  return value !== undefined && (SEND_MODES as string[]).includes(value);
+}
+
+function bodyFor(mode: SendMode, row: SendQueueRow, introNote: string): string {
+  if (mode === "weekly_update") {
+    return weeklyUpdateBody({
+      customerName: row.customerName,
+      tokenUrl: tokenUrl(row.token),
+      introNote,
+    });
+  }
+  if (mode === "order_confirmation") {
+    return orderConfirmationBody({
+      customerName: row.customerName,
+      fulfillmentType: row.fulfillmentType ?? "pickup",
+      pickupNote: row.pickupNote,
+      deliveryPreference: row.deliveryPreference,
+    });
+  }
+  return pickupReminderBody({ customerName: row.customerName });
+}
+
+export default async function SendPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ mode?: string }>;
+}) {
+  const params = await searchParams;
+  const mode: SendMode = isSendMode(params.mode) ? params.mode : "weekly_update";
+  const weekOf = weekOfMondayNY();
+
+  const [rows, introNote] = await Promise.all([
+    mode === "weekly_update"
+      ? getWeeklyUpdateQueue()
+      : mode === "order_confirmation"
+        ? getOrderConfirmationQueue()
+        : getPickupReminderQueue(),
+    getIntroNote(),
+  ]);
+
+  const unsentCount = rows.filter((r) => r.sentAt === null).length;
+
+  return (
+    <div style={{ padding: "32px", maxWidth: 960, margin: "0 auto" }}>
+      <div className="send-head">
+        <div className="eyebrow">Send queue</div>
+        <div className="send-title">Send Update</div>
+        <div className="send-subtitle">{MODE_SUBTITLES[mode]}</div>
+      </div>
+
+      <nav className="send-mode-tabs" aria-label="Send mode">
+        {SEND_MODES.map((m) => (
+          <a
+            key={m}
+            href={m === "weekly_update" ? "/admin/send" : `/admin/send?mode=${m}`}
+            className={"send-mode-tab" + (m === mode ? " is-active" : "")}
+            aria-current={m === mode ? "page" : undefined}
+          >
+            {MODE_LABELS[m]}
+          </a>
+        ))}
+      </nav>
+
+      {mode === "weekly_update" && <IntroNoteCard initialValue={introNote} />}
+
+      <div className="send-queue-meta">
+        <span>
+          <strong>{unsentCount}</strong> unsent · <strong>{rows.length}</strong> total
+        </span>
+        <span className="send-queue-meta-week">Week of {weekOf}</span>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="send-empty">
+          {mode === "weekly_update"
+            ? "No subscribed customers yet."
+            : "No orders this week to send for."}
+        </div>
+      ) : (
+        <ul className="send-list" aria-label={`${MODE_LABELS[mode]} queue`}>
+          {rows.map((row) => (
+            <SendRow
+              key={row.customerId}
+              customerId={row.customerId}
+              customerName={row.customerName}
+              phone={row.phone}
+              body={bodyFor(mode, row, introNote)}
+              weekOf={weekOf}
+              mode={mode}
+              initialSentAt={row.sentAt}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/admin/intro-note-card.tsx
+++ b/src/components/admin/intro-note-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 
 import { saveIntroNote } from "@/actions/save-intro-note";
 
@@ -16,11 +16,15 @@ export function IntroNoteCard({ initialValue }: IntroNoteCardProps) {
 
   const dirty = value !== saved;
 
-  // Sync if a server-side change updates initialValue (eg. another tab saves)
+  // Sync if a server-side change updates initialValue (e.g. another tab
+  // saves, or revalidatePath after our own save). We only overwrite local
+  // edits when the user hasn't typed anything new — `saved` is captured in
+  // a ref so the effect can be tied to `initialValue` alone.
+  const savedRef = useRef(saved);
+  savedRef.current = saved;
   useEffect(() => {
     setSaved(initialValue);
-    setValue((v) => (v === saved ? initialValue : v));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setValue((v) => (v === savedRef.current ? initialValue : v));
   }, [initialValue]);
 
   function handleSave() {

--- a/src/components/admin/intro-note-card.tsx
+++ b/src/components/admin/intro-note-card.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+
+import { saveIntroNote } from "@/actions/save-intro-note";
+
+type IntroNoteCardProps = {
+  initialValue: string;
+};
+
+export function IntroNoteCard({ initialValue }: IntroNoteCardProps) {
+  const [value, setValue] = useState(initialValue);
+  const [saved, setSaved] = useState(initialValue);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const dirty = value !== saved;
+
+  // Sync if a server-side change updates initialValue (eg. another tab saves)
+  useEffect(() => {
+    setSaved(initialValue);
+    setValue((v) => (v === saved ? initialValue : v));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialValue]);
+
+  function handleSave() {
+    setError(null);
+    const next = value;
+    startTransition(async () => {
+      const result = await saveIntroNote(next);
+      if (result.error) {
+        setError(result.error);
+      } else {
+        setSaved(next);
+      }
+    });
+  }
+
+  return (
+    <div className="send-card" aria-label="Intro note for weekly update">
+      <div className="send-field">
+        <label className="send-label" htmlFor="intro-note">
+          This week&rsquo;s intro note
+          <span className="send-label-hint">
+            optional · injected between the greeting and the order link
+          </span>
+        </label>
+        <textarea
+          id="intro-note"
+          className="send-textarea"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="A line or two from you. What's good this week, what to ask about."
+        />
+        <div className="send-charcount">
+          <span>{value.length} characters</span>
+          <span>{dirty ? "Unsaved changes" : "Saved"}</span>
+        </div>
+      </div>
+      <div className="send-card-actions">
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={handleSave}
+          disabled={!dirty || pending}
+        >
+          {pending ? "Saving…" : "Save intro"}
+        </button>
+        {error && (
+          <span role="alert" className="send-row-error">
+            {error}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/send-row.tsx
+++ b/src/components/admin/send-row.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { recordSend } from "@/actions/record-send";
+import { buildSmsUrl } from "@/lib/notifications/sms-deep-link";
+import type { SendMode } from "@/lib/admin/send-queue-queries";
+
+type SendRowProps = {
+  customerId: string;
+  customerName: string;
+  phone: string | null;
+  body: string;
+  weekOf: string;
+  mode: SendMode;
+  initialSentAt: string | null;
+};
+
+function formatSentAt(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function SendRow({
+  customerId,
+  customerName,
+  phone,
+  body,
+  weekOf,
+  mode,
+  initialSentAt,
+}: SendRowProps) {
+  const [sentAt, setSentAt] = useState<string | null>(initialSentAt);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const smsHref = phone ? buildSmsUrl({ phone, body }) : null;
+  const isSent = sentAt !== null;
+
+  function handleClick() {
+    if (!phone) return;
+    setError(null);
+    const optimisticTimestamp = new Date().toISOString();
+    setSentAt(optimisticTimestamp);
+    startTransition(async () => {
+      const result = await recordSend(customerId, weekOf, mode);
+      if (result.error) {
+        setSentAt(initialSentAt);
+        setError(result.error);
+      }
+    });
+  }
+
+  return (
+    <li className="send-row" data-customer-id={customerId} data-sent={isSent ? "true" : "false"}>
+      <div className="send-row-name">
+        <div className="send-row-customer">{customerName}</div>
+        <div className="send-row-phone">{phone ?? "no phone on file"}</div>
+      </div>
+      <div className="send-row-status">
+        <span className={"send-status" + (isSent ? " is-sent" : "")}>
+          {isSent ? `Sent · ${formatSentAt(sentAt!)}` : "Unsent"}
+        </span>
+        {error && (
+          <span className="send-row-error" role="alert">
+            {error}
+          </span>
+        )}
+      </div>
+      <div className="send-row-action">
+        {smsHref ? (
+          <a
+            href={smsHref}
+            className={"btn" + (isSent ? " btn-secondary" : " btn-primary")}
+            onClick={handleClick}
+            aria-disabled={pending}
+          >
+            {isSent ? "Re-send" : "Send"}
+          </a>
+        ) : (
+          <span className="send-row-disabled">No phone</span>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/src/lib/admin/send-queue-queries.ts
+++ b/src/lib/admin/send-queue-queries.ts
@@ -128,6 +128,11 @@ async function getOrderBoundQueue(
         token: string;
         priority: number;
       };
+      // Narrow fulfillment_type at the boundary; anything outside the union
+      // falls back to "pickup" (the conservative default) rather than the
+      // delivery branch picking up garbage.
+      const fulfillmentType: "pickup" | "delivery" =
+        o.fulfillment_type === "delivery" ? "delivery" : "pickup";
       return {
         customerId: c.id,
         customerName: c.name,
@@ -135,7 +140,7 @@ async function getOrderBoundQueue(
         token: c.token,
         priority: c.priority,
         sentAt: sendMap.get(c.id) ?? null,
-        fulfillmentType: o.fulfillment_type as "pickup" | "delivery",
+        fulfillmentType,
         pickupNote: o.pickup_note,
         deliveryPreference: o.delivery_preference,
       };
@@ -171,7 +176,29 @@ export async function getIntroNote(): Promise<string> {
 // nav badge. Only weekly_update has a badge; order_confirmation and
 // pickup_reminder are surfaced through the page's mode tabs instead, to
 // keep the nav uncluttered when multiple modes have unsent customers.
+// Runs on every admin page render via the layout, so we avoid the full
+// queue load: count subscribers, subtract sent rows for the week.
 export async function getWeeklyUpdateUnsentCount(): Promise<number> {
-  const queue = await getWeeklyUpdateQueue();
-  return queue.filter((r) => r.sentAt === null).length;
+  const supabase = createAdminClient();
+  const weekOf = weekOfMondayNY();
+
+  const [subscribers, sent] = await Promise.all([
+    supabase
+      .from("customers")
+      .select("id", { count: "exact", head: true })
+      .eq("is_active", true)
+      .eq("send_weekly_link", true),
+    supabase
+      .from("customer_sends")
+      .select("customer_id", { count: "exact", head: true })
+      .eq("week_of", weekOf)
+      .eq("mode", "weekly_update"),
+  ]);
+
+  if (subscribers.error)
+    throw new Error(`getWeeklyUpdateUnsentCount(subscribers): ${subscribers.error.message}`);
+  if (sent.error)
+    throw new Error(`getWeeklyUpdateUnsentCount(sent): ${sent.error.message}`);
+
+  return Math.max(0, (subscribers.count ?? 0) - (sent.count ?? 0));
 }

--- a/src/lib/admin/send-queue-queries.ts
+++ b/src/lib/admin/send-queue-queries.ts
@@ -1,0 +1,177 @@
+// Send-queue reads (Phase 4.2). Service-role admin reads — these enumerate
+// every customer in the system. RLS would also allow it (authenticated all-
+// access), but we use service role for consistency with the rest of the
+// admin queries.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { weekOfMondayNY } from "@/lib/week";
+
+export type SendMode =
+  | "weekly_update"
+  | "order_confirmation"
+  | "pickup_reminder";
+
+export const SEND_MODES: SendMode[] = [
+  "weekly_update",
+  "order_confirmation",
+  "pickup_reminder",
+];
+
+export type SendQueueRow = {
+  customerId: string;
+  customerName: string;
+  phone: string | null;
+  token: string;
+  priority: number;
+  sentAt: string | null;
+  fulfillmentType: "pickup" | "delivery" | null;
+  pickupNote: string | null;
+  deliveryPreference: string | null;
+};
+
+// Resolves the customer-facing token URL base. Prod is order.baybranchfarm.com;
+// preview deployments use NEXT_PUBLIC_VERCEL_URL; local dev falls back to the
+// dev port. The send-queue body lives in a deep link the operator will SEE
+// before tapping send, so a wrong base URL would be obvious — fail open, not
+// loud.
+export function customerOrderBaseUrl(): string {
+  if (process.env.NEXT_PUBLIC_APP_URL) return process.env.NEXT_PUBLIC_APP_URL;
+  if (process.env.NEXT_PUBLIC_VERCEL_URL) {
+    return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`;
+  }
+  return "https://order.baybranchfarm.com";
+}
+
+export function tokenUrl(token: string): string {
+  return `${customerOrderBaseUrl()}/c/${token}`;
+}
+
+// Loads `customer_sends` for the current week+mode into a customer-id-keyed
+// map of `sent_at` ISO strings. Used to decorate each row with sent state.
+async function loadSendStateMap(
+  weekOf: string,
+  mode: SendMode,
+): Promise<Map<string, string>> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("customer_sends")
+    .select("customer_id, sent_at")
+    .eq("week_of", weekOf)
+    .eq("mode", mode);
+  if (error) throw new Error(`loadSendStateMap: ${error.message}`);
+  return new Map((data ?? []).map((r) => [r.customer_id, r.sent_at]));
+}
+
+// weekly_update queue: every active customer with send_weekly_link=true,
+// priority desc.
+export async function getWeeklyUpdateQueue(): Promise<SendQueueRow[]> {
+  const supabase = createAdminClient();
+  const weekOf = weekOfMondayNY();
+
+  const [customersResult, sendMap] = await Promise.all([
+    supabase
+      .from("customers")
+      .select("id, name, phone, token, priority")
+      .eq("is_active", true)
+      .eq("send_weekly_link", true)
+      .order("priority", { ascending: false })
+      .order("name", { ascending: true }),
+    loadSendStateMap(weekOf, "weekly_update"),
+  ]);
+
+  if (customersResult.error)
+    throw new Error(`getWeeklyUpdateQueue: ${customersResult.error.message}`);
+
+  return (customersResult.data ?? []).map((c) => ({
+    customerId: c.id,
+    customerName: c.name,
+    phone: c.phone,
+    token: c.token,
+    priority: c.priority,
+    sentAt: sendMap.get(c.id) ?? null,
+    fulfillmentType: null,
+    pickupNote: null,
+    deliveryPreference: null,
+  }));
+}
+
+type OrderBoundMode = "order_confirmation" | "pickup_reminder";
+
+// order_confirmation + pickup_reminder both queue from "customers with an
+// order this week." Shared loader; mode only affects which customer_sends
+// rows we lookup.
+async function getOrderBoundQueue(
+  mode: OrderBoundMode,
+): Promise<SendQueueRow[]> {
+  const supabase = createAdminClient();
+  const weekOf = weekOfMondayNY();
+
+  const [ordersResult, sendMap] = await Promise.all([
+    supabase
+      .from("orders")
+      .select(
+        "customer_id, fulfillment_type, pickup_note, delivery_preference, customers(id, name, phone, token, priority)",
+      )
+      .eq("week_of", weekOf),
+    loadSendStateMap(weekOf, mode),
+  ]);
+
+  if (ordersResult.error)
+    throw new Error(`getOrderBoundQueue(${mode}): ${ordersResult.error.message}`);
+
+  const rows: SendQueueRow[] = (ordersResult.data ?? [])
+    .filter((o) => o.customers !== null)
+    .map((o) => {
+      const c = o.customers as {
+        id: string;
+        name: string;
+        phone: string | null;
+        token: string;
+        priority: number;
+      };
+      return {
+        customerId: c.id,
+        customerName: c.name,
+        phone: c.phone,
+        token: c.token,
+        priority: c.priority,
+        sentAt: sendMap.get(c.id) ?? null,
+        fulfillmentType: o.fulfillment_type as "pickup" | "delivery",
+        pickupNote: o.pickup_note,
+        deliveryPreference: o.delivery_preference,
+      };
+    });
+
+  return rows.sort((a, b) => {
+    if (a.priority !== b.priority) return b.priority - a.priority;
+    return a.customerName.localeCompare(b.customerName);
+  });
+}
+
+export async function getOrderConfirmationQueue(): Promise<SendQueueRow[]> {
+  return getOrderBoundQueue("order_confirmation");
+}
+
+export async function getPickupReminderQueue(): Promise<SendQueueRow[]> {
+  return getOrderBoundQueue("pickup_reminder");
+}
+
+// ordering_schedule is a singleton (DEC-030). Same .single() discipline as
+// getOrderingOpen — loud failure if the row goes missing.
+export async function getIntroNote(): Promise<string> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("ordering_schedule")
+    .select("intro_note")
+    .single();
+  if (error) throw new Error(`getIntroNote: ${error.message}`);
+  return data.intro_note ?? "";
+}
+
+// Count of weekly_update unsent for the current week — used by the admin
+// nav badge. Only weekly_update has a badge; order_confirmation and
+// pickup_reminder are surfaced through the page's mode tabs instead, to
+// keep the nav uncluttered when multiple modes have unsent customers.
+export async function getWeeklyUpdateUnsentCount(): Promise<number> {
+  const queue = await getWeeklyUpdateQueue();
+  return queue.filter((r) => r.sentAt === null).length;
+}

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -1,0 +1,53 @@
+// Pre-filled SMS bodies for the three send-queue modes (DEC-026). Bodies are
+// short by design — once the `sms:` link opens Messages, the operator can edit
+// further before tapping Send. These functions lock the default shape; copy
+// changes ship as PRs.
+
+export type WeeklyUpdateInput = {
+  customerName: string;
+  tokenUrl: string;
+  introNote: string | null;
+};
+
+export function weeklyUpdateBody({
+  customerName,
+  tokenUrl,
+  introNote,
+}: WeeklyUpdateInput): string {
+  const header = `Hi ${customerName} — this week's Bay Branch Farm inventory is up.`;
+  const trimmed = (introNote ?? "").trim();
+  const link = `Order here: ${tokenUrl}`;
+  return trimmed ? `${header}\n\n${trimmed}\n\n${link}` : `${header} ${link}`;
+}
+
+export type OrderConfirmationInput = {
+  customerName: string;
+  fulfillmentType: "pickup" | "delivery";
+  pickupNote?: string | null;
+  deliveryPreference?: string | null;
+};
+
+export function orderConfirmationBody(input: OrderConfirmationInput): string {
+  const { customerName, fulfillmentType } = input;
+  const head = `Hi ${customerName} — got your Bay Branch Farm order.`;
+
+  if (fulfillmentType === "pickup") {
+    const note = (input.pickupNote ?? "").trim();
+    return note
+      ? `${head} Pickup: ${note}. See you soon!`
+      : `${head} See you at pickup!`;
+  }
+
+  const pref = (input.deliveryPreference ?? "").trim();
+  return pref
+    ? `${head} Delivery note: ${pref}. Thanks!`
+    : `${head} We'll be in touch about delivery.`;
+}
+
+export type PickupReminderInput = {
+  customerName: string;
+};
+
+export function pickupReminderBody({ customerName }: PickupReminderInput): string {
+  return `Hi ${customerName} — reminder that your Bay Branch Farm order is ready for pickup this week. Text back if you need a different time.`;
+}

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -55,6 +55,38 @@ export type Database = {
         }
         Relationships: []
       }
+      customer_sends: {
+        Row: {
+          customer_id: string
+          mode: string
+          sent_at: string
+          sent_by_user_id: string | null
+          week_of: string
+        }
+        Insert: {
+          customer_id: string
+          mode: string
+          sent_at?: string
+          sent_by_user_id?: string | null
+          week_of: string
+        }
+        Update: {
+          customer_id?: string
+          mode?: string
+          sent_at?: string
+          sent_by_user_id?: string | null
+          week_of?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "customer_sends_customer_id_fkey"
+            columns: ["customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       customers: {
         Row: {
           business_name: string | null
@@ -146,6 +178,7 @@ export type Database = {
         Row: {
           created_at: string
           id: string
+          intro_note: string | null
           is_open: boolean
           is_singleton: boolean
           override_closes_at: string | null
@@ -158,6 +191,7 @@ export type Database = {
         Insert: {
           created_at?: string
           id?: string
+          intro_note?: string | null
           is_open?: boolean
           is_singleton?: boolean
           override_closes_at?: string | null
@@ -170,6 +204,7 @@ export type Database = {
         Update: {
           created_at?: string
           id?: string
+          intro_note?: string | null
           is_open?: boolean
           is_singleton?: boolean
           override_closes_at?: string | null

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1616,3 +1616,188 @@
   border-color: var(--leaf-100);
   color: var(--leaf-700);
 }
+
+/* ============================================================
+   Admin · Send Update (Phase 4.2)
+   ============================================================ */
+
+.send-head { margin-bottom: 22px; }
+.send-title {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+}
+.send-subtitle {
+  margin-top: 4px;
+  color: var(--ink-500);
+  font-size: 0.95rem;
+  max-width: 64ch;
+}
+
+.send-mode-tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--ink-200);
+  margin: 22px 0 24px;
+}
+.send-mode-tab {
+  padding: 10px 14px;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--ink-500);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.12s, border-color 0.12s;
+}
+.send-mode-tab:hover { color: var(--ink-900); }
+.send-mode-tab.is-active {
+  color: var(--leaf-700);
+  border-bottom-color: var(--leaf-700);
+}
+
+.send-card {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  padding: 22px 24px;
+  margin-bottom: 22px;
+}
+.send-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 14px;
+}
+
+.send-field { display: block; }
+.send-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 0.92rem;
+  color: var(--ink-900);
+  margin-bottom: 8px;
+}
+.send-label-hint {
+  font-weight: 400;
+  font-size: 0.78rem;
+  color: var(--ink-500);
+}
+.send-textarea {
+  width: 100%;
+  min-height: 96px;
+  padding: 10px 12px;
+  font-family: var(--sans);
+  font-size: 0.95rem;
+  color: var(--ink-900);
+  background: var(--cream);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-sm);
+  resize: vertical;
+}
+.send-textarea:focus {
+  outline: none;
+  border-color: var(--leaf-600);
+  background: var(--paper);
+}
+.send-charcount {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: var(--ink-500);
+  margin-top: 6px;
+}
+
+.send-queue-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 12px;
+  font-size: 0.88rem;
+  color: var(--ink-500);
+}
+.send-queue-meta strong {
+  font-weight: 600;
+  color: var(--ink-900);
+}
+.send-queue-meta-week { font-variant-numeric: tabular-nums; }
+
+.send-empty {
+  padding: 36px;
+  text-align: center;
+  color: var(--ink-500);
+  background: var(--paper);
+  border: 1px dashed var(--ink-200);
+  border-radius: var(--r-md);
+}
+
+.send-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+.send-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 18px;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--ink-200);
+}
+.send-row:last-child { border-bottom: 0; }
+.send-row[data-sent="true"] { background: var(--cream); }
+
+.send-row-name { min-width: 0; }
+.send-row-customer {
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 0.96rem;
+  color: var(--ink-900);
+}
+.send-row-phone {
+  font-size: 0.82rem;
+  color: var(--ink-500);
+  font-variant-numeric: tabular-nums;
+  margin-top: 2px;
+}
+
+.send-row-status {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  font-variant-numeric: tabular-nums;
+}
+.send-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 0.76rem;
+  font-weight: 500;
+  background: var(--ink-100);
+  color: var(--ink-700);
+}
+.send-status.is-sent {
+  background: rgba(121, 196, 78, 0.16);
+  color: var(--leaf-700);
+}
+.send-row-error {
+  font-size: 0.74rem;
+  color: var(--rose-600);
+}
+.send-row-disabled {
+  font-size: 0.82rem;
+  color: var(--ink-500);
+}

--- a/supabase/migrations/20260515133545_send_queue.sql
+++ b/supabase/migrations/20260515133545_send_queue.sql
@@ -1,0 +1,33 @@
+-- Phase 4.2 — Send-queue persistence.
+-- Per DEC-026, Bushel does not send SMS itself; the admin send-queue surfaces
+-- `sms:` deep links per customer. This migration adds:
+--   1. customer_sends — one row per (customer, week, mode); presence = "marked sent"
+--   2. ordering_schedule.intro_note — per-cycle operator-edited intro injected
+--      into the weekly_update template body
+
+-- ------------------------------------------------------------
+-- ordering_schedule.intro_note (per-cycle operator note)
+-- ------------------------------------------------------------
+alter table public.ordering_schedule
+  add column intro_note text;
+
+-- ------------------------------------------------------------
+-- customer_sends — operator-marked send state, per cycle, per mode
+-- ------------------------------------------------------------
+create table public.customer_sends (
+  customer_id      uuid         not null references public.customers(id) on delete cascade,
+  week_of          date         not null,
+  mode             text         not null check (mode in ('weekly_update','order_confirmation','pickup_reminder')),
+  sent_at          timestamptz  not null default now(),
+  sent_by_user_id  uuid         references auth.users(id) on delete set null,
+  primary key (customer_id, week_of, mode)
+);
+
+create index customer_sends_week_mode_idx
+  on public.customer_sends (week_of, mode);
+
+alter table public.customer_sends enable row level security;
+
+-- Admin-only — no anon access (no token-scoped read either; this is admin state).
+create policy "admin_all_customer_sends" on public.customer_sends
+  for all to authenticated using (true) with check (true);

--- a/supabase/tests/rls_tables.sql
+++ b/supabase/tests/rls_tables.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(41);
+select plan(50);
 
 -- ============================================================
 -- Schema sanity: RLS enabled on all tables
@@ -28,6 +28,10 @@ select is(
   (select relrowsecurity from pg_class where oid = 'public.order_items'::regclass),
   true, 'RLS enabled on order_items'
 );
+select is(
+  (select relrowsecurity from pg_class where oid = 'public.customer_sends'::regclass),
+  true, 'RLS enabled on customer_sends'
+);
 
 -- ============================================================
 -- Schema sanity: Phase 2.0a columns
@@ -52,6 +56,14 @@ select col_type_is('public', 'orders', 'pickup_note', 'text', 'orders.pickup_not
 select has_column('public', 'orders', 'delivery_preference', 'orders.delivery_preference column exists (DEC-029)');
 select col_type_is('public', 'orders', 'delivery_preference', 'text', 'orders.delivery_preference is text');
 select col_default_is('public', 'ordering_schedule', 'is_open', 'true', 'ordering_schedule.is_open defaults to true (DEC-030)');
+
+-- ============================================================
+-- Schema sanity: Phase 4.2 send-queue (DEC-026)
+-- ============================================================
+select has_column('public', 'ordering_schedule', 'intro_note', 'ordering_schedule.intro_note column exists (DEC-026)');
+select col_type_is('public', 'ordering_schedule', 'intro_note', 'text', 'ordering_schedule.intro_note is text');
+select has_table('public', 'customer_sends', 'customer_sends table exists (DEC-026)');
+select has_column('public', 'customer_sends', 'sent_at', 'customer_sends.sent_at column exists');
 
 -- ============================================================
 -- Seed test data (postgres role bypasses RLS)
@@ -234,6 +246,34 @@ select is(
   (select count(*)::int from public.order_items),
   2,
   'authenticated can read all order_items'
+);
+reset role;
+
+-- ============================================================
+-- customer_sends — admin-only (DEC-026 send-queue state)
+-- ============================================================
+set local role anon;
+select is_empty(
+  $$ select * from public.customer_sends $$,
+  'anon cannot read customer_sends'
+);
+select throws_ok(
+  $$ insert into public.customer_sends (customer_id, week_of, mode)
+     values ('aaaaaaaa-0000-0000-0000-000000000001', '2026-05-11', 'weekly_update') $$,
+  '42501', null, 'anon cannot insert customer_sends'
+);
+reset role;
+
+set local role authenticated;
+select lives_ok(
+  $$ insert into public.customer_sends (customer_id, week_of, mode)
+     values ('aaaaaaaa-0000-0000-0000-000000000001', '2026-05-11', 'weekly_update') $$,
+  'authenticated can insert customer_sends (valid mode)'
+);
+select throws_ok(
+  $$ insert into public.customer_sends (customer_id, week_of, mode)
+     values ('aaaaaaaa-0000-0000-0000-000000000002', '2026-05-11', 'invalid_mode') $$,
+  '23514', null, 'customer_sends.mode CHECK rejects invalid mode'
 );
 reset role;
 

--- a/tests/admin-send.spec.ts
+++ b/tests/admin-send.spec.ts
@@ -1,0 +1,264 @@
+import { test, expect } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+
+import { ADMIN_STORAGE_STATE, TEST_CUSTOMERS } from "./helpers";
+import { weekOfMondayNY } from "@/lib/week";
+
+function admin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+}
+
+// Dev/preview DB carries real data and historical test artifacts; multiple
+// customers may share the same display name. Filter rows by data-customer-id
+// instead of visible text. Resolved once per test from the seeded tokens.
+async function testCustomerIds(): Promise<{ farmStand: string; restaurant: string }> {
+  const sb = admin();
+  const { data: rows, error } = await sb
+    .from("customers")
+    .select("id, token")
+    .in("token", [TEST_CUSTOMERS.farmStand.token, TEST_CUSTOMERS.restaurant.token]);
+  if (error || !rows) throw new Error(`testCustomerIds: ${error?.message ?? "no rows"}`);
+  const map = new Map(rows.map((r) => [r.token, r.id]));
+  return {
+    farmStand: map.get(TEST_CUSTOMERS.farmStand.token)!,
+    restaurant: map.get(TEST_CUSTOMERS.restaurant.token)!,
+  };
+}
+
+async function clearSends(): Promise<void> {
+  const sb = admin();
+  const weekOf = weekOfMondayNY();
+  await sb.from("customer_sends").delete().eq("week_of", weekOf);
+}
+
+async function clearIntroNote(): Promise<void> {
+  const sb = admin();
+  await sb.from("ordering_schedule").update({ intro_note: null }).eq("is_singleton", true);
+}
+
+async function ensureOrderForCustomer(token: string): Promise<void> {
+  const sb = admin();
+  const { data: customer } = await sb
+    .from("customers")
+    .select("id, delivery_address")
+    .eq("token", token)
+    .single();
+  if (!customer) throw new Error(`customer ${token} not found`);
+  const weekOf = weekOfMondayNY();
+  await sb.from("orders").upsert(
+    {
+      customer_id: customer.id,
+      week_of: weekOf,
+      fulfillment_type: "delivery",
+      delivery_address: customer.delivery_address,
+      delivery_preference: "Back door, gate code 4321",
+      pickup_note: null,
+      status: "new",
+    },
+    { onConflict: "customer_id,week_of" },
+  );
+}
+
+async function clearCurrentWeekOrders(): Promise<void> {
+  const sb = admin();
+  const weekOf = weekOfMondayNY();
+  for (const c of Object.values(TEST_CUSTOMERS)) {
+    const { data } = await sb
+      .from("customers")
+      .select("id")
+      .eq("token", c.token)
+      .maybeSingle();
+    if (data?.id) {
+      await sb
+        .from("orders")
+        .delete()
+        .eq("customer_id", data.id)
+        .eq("week_of", weekOf);
+    }
+  }
+}
+
+// Restores the seeded test customers to the state this spec expects. Other
+// admin specs may mutate these rows (admin-customers' "subscribed switch"
+// test flips send_weekly_link without restoring), so we re-establish phones,
+// priorities, subscribed state, and is_active each time.
+async function ensureTestCustomerState(): Promise<void> {
+  const sb = admin();
+  await sb
+    .from("customers")
+    .update({
+      phone: "(216) 555-0100",
+      priority: 200,
+      send_weekly_link: true,
+      is_active: true,
+    })
+    .eq("token", TEST_CUSTOMERS.farmStand.token);
+  await sb
+    .from("customers")
+    .update({
+      phone: "(216) 555-0200",
+      priority: 100,
+      send_weekly_link: true,
+      is_active: true,
+    })
+    .eq("token", TEST_CUSTOMERS.restaurant.token);
+}
+
+test.describe("admin send-queue", () => {
+  test.use({ storageState: ADMIN_STORAGE_STATE });
+
+  test.beforeEach(async () => {
+    await ensureTestCustomerState();
+    await clearSends();
+    await clearIntroNote();
+  });
+
+  test.afterAll(async () => {
+    await clearSends();
+    await clearCurrentWeekOrders();
+    await clearIntroNote();
+  });
+
+  test("weekly_update: lists subscribers in priority order with sms: deep links", async ({ page }) => {
+    const ids = await testCustomerIds();
+    await page.goto("/admin/send");
+
+    const list = page.getByRole("list", { name: /weekly update queue/i });
+    const farmStandRow = list.locator(`li.send-row[data-customer-id="${ids.farmStand}"]`);
+    const restaurantRow = list.locator(`li.send-row[data-customer-id="${ids.restaurant}"]`);
+    await expect(farmStandRow).toHaveCount(1);
+    await expect(restaurantRow).toHaveCount(1);
+
+    // priority order — farm stand (200) appears in DOM before restaurant (100)
+    const allIds = await list.locator("li.send-row").evaluateAll((els) =>
+      (els as HTMLElement[]).map((el) => el.dataset.customerId ?? ""),
+    );
+    const farmIdx = allIds.indexOf(ids.farmStand);
+    const restIdx = allIds.indexOf(ids.restaurant);
+    expect(farmIdx).toBeGreaterThanOrEqual(0);
+    expect(restIdx).toBeGreaterThan(farmIdx);
+
+    // sms: href is well-formed for the farm stand row
+    const href = await farmStandRow
+      .getByRole("link", { name: /^send$/i })
+      .getAttribute("href");
+    expect(href).toMatch(/^sms:\+?\d+\?body=/);
+    expect(href).toContain("Bay%20Branch%20Farm");
+    expect(href).toContain(TEST_CUSTOMERS.farmStand.token);
+  });
+
+  test("weekly_update: clicking Send records the send and flips the status pill", async ({ page }) => {
+    const ids = await testCustomerIds();
+    await page.goto("/admin/send");
+
+    const list = page.getByRole("list", { name: /weekly update queue/i });
+    const farmStandRow = list.locator(`li.send-row[data-customer-id="${ids.farmStand}"]`);
+
+    await expect(farmStandRow.locator(".send-status")).toHaveText("Unsent");
+    await expect(farmStandRow).toHaveAttribute("data-sent", "false");
+
+    // The sms: scheme has no handler in headless Chromium, so the browser
+    // ignores the navigation but still fires onClick — which posts to the
+    // server action and updates state.
+    await farmStandRow.getByRole("link", { name: /^send$/i }).click();
+
+    await expect(farmStandRow.locator(".send-status")).toContainText("Sent", { timeout: 5000 });
+    await expect(farmStandRow).toHaveAttribute("data-sent", "true");
+
+    // DB side. The pill flips optimistically before the server action
+    // completes, so poll for the actual row insertion.
+    const sb = admin();
+    await expect
+      .poll(
+        async () => {
+          const { data } = await sb
+            .from("customer_sends")
+            .select("customer_id")
+            .eq("customer_id", ids.farmStand)
+            .eq("week_of", weekOfMondayNY())
+            .eq("mode", "weekly_update");
+          return data?.length ?? 0;
+        },
+        { timeout: 5000 },
+      )
+      .toBe(1);
+  });
+
+  test("intro note saves and is injected into the weekly_update body", async ({ page }) => {
+    const ids = await testCustomerIds();
+    await page.goto("/admin/send");
+
+    const textarea = page.getByLabel(/this week.+intro note/i);
+    await textarea.fill("Sungolds are exceptional this week.");
+    await page.getByRole("button", { name: /save intro/i }).click();
+
+    await expect(page.getByText(/^Saved$/i)).toBeVisible({ timeout: 5000 });
+
+    // Reload — value persists
+    await page.reload();
+    await expect(page.getByLabel(/this week.+intro note/i)).toHaveValue(
+      "Sungolds are exceptional this week.",
+    );
+
+    // Farm stand row's sms href now contains the intro
+    const list = page.getByRole("list", { name: /weekly update queue/i });
+    const farmStandRow = list.locator(`li.send-row[data-customer-id="${ids.farmStand}"]`);
+    const href = await farmStandRow
+      .getByRole("link", { name: /^send$/i })
+      .getAttribute("href");
+    expect(href).toContain("Sungolds%20are%20exceptional%20this%20week.");
+  });
+
+  test("order_confirmation mode: only customers with current-week orders appear", async ({ page }) => {
+    const ids = await testCustomerIds();
+    await clearCurrentWeekOrders();
+    await ensureOrderForCustomer(TEST_CUSTOMERS.farmStand.token);
+
+    await page.goto("/admin/send?mode=order_confirmation");
+
+    const list = page.getByRole("list", { name: /order confirmation queue/i });
+    const farmStandRow = list.locator(`li.send-row[data-customer-id="${ids.farmStand}"]`);
+    const restaurantRow = list.locator(`li.send-row[data-customer-id="${ids.restaurant}"]`);
+
+    // farmStand has an order this week (we just created one); restaurant does
+    // not. Other dev-DB customers may or may not appear — we only assert what
+    // we control.
+    await expect(farmStandRow).toHaveCount(1);
+    await expect(restaurantRow).toHaveCount(0);
+
+    // sms href reflects the delivery confirmation template
+    const href = await farmStandRow
+      .getByRole("link", { name: /^send$/i })
+      .getAttribute("href");
+    expect(href).toContain("Delivery%20note");
+    expect(href).toContain("gate%20code%204321");
+  });
+
+  test("pickup_reminder mode: same order-bound customer set, different body", async ({ page }) => {
+    const ids = await testCustomerIds();
+    await clearCurrentWeekOrders();
+    await ensureOrderForCustomer(TEST_CUSTOMERS.farmStand.token);
+
+    await page.goto("/admin/send?mode=pickup_reminder");
+
+    const list = page.getByRole("list", { name: /pickup reminder queue/i });
+    const farmStandRow = list.locator(`li.send-row[data-customer-id="${ids.farmStand}"]`);
+    await expect(farmStandRow).toHaveCount(1);
+
+    const href = await farmStandRow
+      .getByRole("link", { name: /^send$/i })
+      .getAttribute("href");
+    expect(href).toContain("reminder");
+    expect(href).toContain("ready%20for%20pickup");
+
+    // clicking Send works in this mode too
+    await farmStandRow.getByRole("link", { name: /^send$/i }).click();
+    await expect(farmStandRow.locator(".send-status")).toContainText("Sent", {
+      timeout: 5000,
+    });
+  });
+});

--- a/tests/notification-templates.spec.ts
+++ b/tests/notification-templates.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  orderConfirmationBody,
+  pickupReminderBody,
+  weeklyUpdateBody,
+} from "@/lib/notifications/templates";
+
+// Pure-function unit tests, same harness as sms-deep-link.spec.ts.
+// Templates are the body strings the operator's Messages app pre-fills.
+// They're deliberately short — operator can edit in Messages before tapping
+// Send. We're locking the *shape*, not optimizing copy.
+
+test.describe("weeklyUpdateBody", () => {
+  test("renders header + token URL when intro is empty", () => {
+    expect(
+      weeklyUpdateBody({
+        customerName: "Hannah",
+        tokenUrl: "https://order.baybranchfarm.com/c/abcd1234",
+        introNote: "",
+      }),
+    ).toBe(
+      "Hi Hannah — this week's Bay Branch Farm inventory is up. Order here: https://order.baybranchfarm.com/c/abcd1234",
+    );
+  });
+
+  test("injects intro between header and token URL", () => {
+    expect(
+      weeklyUpdateBody({
+        customerName: "Hannah",
+        tokenUrl: "https://order.baybranchfarm.com/c/abcd1234",
+        introNote: "Sungolds are exceptional this week.",
+      }),
+    ).toBe(
+      "Hi Hannah — this week's Bay Branch Farm inventory is up.\n\nSungolds are exceptional this week.\n\nOrder here: https://order.baybranchfarm.com/c/abcd1234",
+    );
+  });
+
+  test("trims intro whitespace before injecting", () => {
+    expect(
+      weeklyUpdateBody({
+        customerName: "Hannah",
+        tokenUrl: "https://example/c/x",
+        introNote: "  Note with padding.  \n",
+      }),
+    ).toContain("\n\nNote with padding.\n\n");
+  });
+
+  test("treats whitespace-only intro as empty", () => {
+    expect(
+      weeklyUpdateBody({
+        customerName: "Hannah",
+        tokenUrl: "https://example/c/x",
+        introNote: "   \n  ",
+      }),
+    ).toBe(
+      "Hi Hannah — this week's Bay Branch Farm inventory is up. Order here: https://example/c/x",
+    );
+  });
+});
+
+test.describe("orderConfirmationBody", () => {
+  test("pickup order confirmation", () => {
+    expect(
+      orderConfirmationBody({
+        customerName: "Tom",
+        fulfillmentType: "pickup",
+        pickupNote: "Coming Thursday afternoon",
+      }),
+    ).toBe(
+      "Hi Tom — got your Bay Branch Farm order. Pickup: Coming Thursday afternoon. See you soon!",
+    );
+  });
+
+  test("pickup order with no note", () => {
+    expect(
+      orderConfirmationBody({
+        customerName: "Tom",
+        fulfillmentType: "pickup",
+        pickupNote: null,
+      }),
+    ).toBe("Hi Tom — got your Bay Branch Farm order. See you at pickup!");
+  });
+
+  test("delivery order confirmation", () => {
+    expect(
+      orderConfirmationBody({
+        customerName: "Maria",
+        fulfillmentType: "delivery",
+        deliveryPreference: "Back door, gate code 4321",
+      }),
+    ).toBe(
+      "Hi Maria — got your Bay Branch Farm order. Delivery note: Back door, gate code 4321. Thanks!",
+    );
+  });
+
+  test("delivery order with no preference", () => {
+    expect(
+      orderConfirmationBody({
+        customerName: "Maria",
+        fulfillmentType: "delivery",
+        deliveryPreference: null,
+      }),
+    ).toBe("Hi Maria — got your Bay Branch Farm order. We'll be in touch about delivery.");
+  });
+});
+
+test.describe("pickupReminderBody", () => {
+  test("includes customer name and pickup-day reminder", () => {
+    expect(pickupReminderBody({ customerName: "Hannah" })).toBe(
+      "Hi Hannah — reminder that your Bay Branch Farm order is ready for pickup this week. Text back if you need a different time.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Per DEC-026, Bushel does not send SMS itself — admin `/admin/send` surfaces `sms:` deep links per customer with operator-marked send state. Three modes: weekly_update (all subscribers), order_confirmation + pickup_reminder (only customers with orders this week). Mark-as-sent persists server-side so the operator can resume mid-list across devices.

Closes #88.

## Files changed

- `supabase/migrations/20260515133545_send_queue.sql` — `customer_sends` table (admin-only RLS) + `ordering_schedule.intro_note` column
- `supabase/tests/rls_tables.sql` — plan 41 → 50; schema-shape + RLS + CHECK assertions
- `src/lib/notifications/templates.ts` — pure-function body builders for the three modes
- `src/lib/admin/send-queue-queries.ts` — three queue queries + intro-note read + unsent count for nav badge
- `src/actions/record-send.ts` / `src/actions/save-intro-note.ts` — server actions (RLS-gated)
- `src/app/(admin)/admin/send/page.tsx` — server component, mode tabs via query param
- `src/components/admin/send-row.tsx` — client component, optimistic Send + sms: anchor
- `src/components/admin/intro-note-card.tsx` — client component, save w/ dirty state
- `src/app/(admin)/admin/layout.tsx` — wire "to send" nav badge
- `src/styles/app.css` — extend with `.send-*` primitives (one file per the app.css-only rule)
- `tests/admin-send.spec.ts` — 5 integration tests
- `tests/notification-templates.spec.ts` — 9 pure-function unit tests

## Code review

5 findings (2 important addressed, 1 important addressed, 2 nits addressed) in `36c1281`:
- `getWeeklyUpdateUnsentCount` was loading the full queue on every admin page render — replaced with two head-count queries (`select count(*)` on customers minus customer_sends).
- `saveIntroNote` was silently succeeding if the singleton row was missing — added `.select().single()` so it surfaces.
- `fulfillment_type as "pickup" | "delivery"` was an unsafe cast — narrowed at the boundary with an explicit comparison.
- `recordSend` had no auth check (RLS-only gate) — added a defensive `if (!user)` early-return.
- `intro-note-card` useEffect had an eslint-disable — replaced with a `savedRef` so the dep list is honest.

Skipped: optimistic-UI + sms: navigation race (reviewer agreed idempotent upsert makes retry safe).

## Test plan

- `supabase test db` — 66/66 pgTAP green (50 in rls_tables, 16 in customers_rls).
- `npx playwright test tests/admin-send.spec.ts tests/notification-templates.spec.ts tests/sms-deep-link.spec.ts --project=desktop` — 27/27 green. Admin spec asserts priority order, send-recording via DB poll for the optimistic flip, intro persistence, and order-bound mode filtering.
- Manual: visit `/admin/send`, type an intro, save, switch tabs, hit Send on a customer with phone — pill flips to Sent, sms: link opens Messages (real device), nav badge decrements.

## Notes

- Migration already pushed to dev/preview (`nnmfubmlvnkouxxfxxlh`). Prod push deferred to post-merge per CLAUDE.md migration discipline.
- `design/admin-send.{jsx,css}` is the pre-DEC-026 broadcast UI (single Send button, iMessage preview, Twilio-style segment counter + $-estimate). **Stale — flag for replacement or deletion in a follow-up.** This task's UI is built to the AC + DEC-026, not the mockup. Per the planning conversation, intro-note injection on the send page (option C) replaces the mockup's editable broadcast intent.
- Cleaned up two duplicate-named test-customer rows in dev/preview (`qw2o9b-gng`, `s2s6u2-yp5`) that were polluting admin-customers + admin-send specs. Unrelated to this code; just a state fix.
- Pre-existing test-isolation issue in `admin-prepopulate.spec.ts` reproduces on main — not a regression from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)