### PR TITLE
Phase 4.3 — Order-arrival admin alert via Telegram (#89, DEC-033)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -243,7 +243,9 @@ Locked during planning + poker. New decisions append. Superseded notes stay.
 
 ---
 
-## DEC-027 — Admin order-arrival alert: email primary, PWA push as upgrade
+## DEC-027 — Admin order-arrival alert: email primary, PWA push as upgrade [SUPERSEDED]
+
+**Status:** Superseded 2026-05-15 by DEC-033 — admin alert pivoted from transactional email to Telegram bot push. PWA-push-as-upgrade framing is preserved in DEC-033. Original text retained below for context.
 
 **Decision:** When a customer submits an order, Bushel sends a transactional email to the operator's address. Email push notifications on her phone deliver the buzz. Provider TBD (Resend or similar) — single recipient, low volume, no marketing.
 
@@ -366,6 +368,38 @@ Address pre-fill is unchanged (snapshot from `customers.delivery_address` per DE
 **Known V1 kludge:** for products that genuinely need multiple units in V1 (Annabel will identify these), create them as separate products: "Cherry tomatoes (lb)" and "Cherry tomatoes (pint)" with separately-managed `qty_available`. Annabel reconciles harvest-to-inventory split mentally. Tolerable for ~3 products for ~weeks. If the count is higher, this DEC's V1/V1.5 split should be revisited and multi-unit pulled forward into V1.
 
 **Trigger to validate now:** Annabel-facing question — *"How many of the products you sell need to be sold in different units to different customers?"* If answer is 2–3, V1.5 framing holds. If "most of them," pull forward into V1.
+
+---
+
+## DEC-033 — Admin order-arrival alert: Telegram bot (supersedes DEC-027 email-first)
+
+**Decision:** When a customer submits an order, Bushel POSTs a plain-text message to Annabel's Telegram via the Telegram Bot API. Single recipient (her personal chat_id with the dedicated bot). Server-side `fetch` to `https://api.telegram.org/bot<TOKEN>/sendMessage`. Best-effort: any failure is logged and swallowed so order placement never blocks on a notification miss.
+
+PWA push notification remains the stretch upgrade per DEC-027's framing.
+
+**Why (preferred over DEC-027's email path):**
+- Lower perceived latency. Telegram push lands on the lock screen in 1–3 seconds; email push is typically seconds but sometimes a minute, and the alert hides inside the inbox.
+- No DNS or sender-domain verification. Resend would have required CNAME records on a domain we control + a verified from-address; Telegram requires a one-time `/newbot` exchange in the app.
+- No SDK dep. One `fetch` POST to a single REST endpoint vs. pulling in the Resend SDK.
+- No transactional-email service to onboard or pay. Telegram bot API is free with no published volume cap relevant to our scale.
+- Operator already has the Telegram app open on her Android device for other purposes.
+
+**Trade-offs accepted:**
+- Operator dependency: if Annabel ever drops Telegram, the alert path breaks. (Mitigation: alert wrapper logs every miss; she'd notice within hours that confirmations stopped arriving and we'd switch providers.)
+- Bot token is a long-lived secret; rotation requires `/newbot` again or BotFather's `/revoke`. Same rotation discipline as any other API key.
+- No delivery receipts. We get a 200 from the Telegram API and trust it landed. Same as email.
+
+**Pre-launch one-time setup (Annabel + dev, ~5 min):**
+1. Annabel opens Telegram → messages `@BotFather` → `/newbot` → picks a name + username → BotFather returns a bot token.
+2. Annabel sends any message to the new bot (Telegram won't deliver until she initiates).
+3. Dev: `curl "https://api.telegram.org/bot<TOKEN>/getUpdates"` → reads `result[0].message.chat.id`.
+4. Vercel Production env vars: `TELEGRAM_BOT_TOKEN` + `TELEGRAM_ADMIN_CHAT_ID`. Optionally `NOTIFICATIONS_ENABLED=false` in any env where alerts should be silenced (test, staging if added).
+
+**Failure mode:** if either env var is unset, `sendAdminOrderAlert` no-ops and logs `[admin-alert] skipped (not configured)`. Order placement proceeds normally. The log line in production is the canary for misconfiguration.
+
+**Stretch upgrade still on the table:** PWA push. If reliable on Annabel's Android once the admin shell is installed, push can run primary with Telegram as fallback — same pattern DEC-027 sketched for email.
+
+**Supersedes:** DEC-027 (the "email primary" portion). DEC-027's PWA-push-as-upgrade framing is preserved.
 
 ---
 

--- a/src/actions/place-order.ts
+++ b/src/actions/place-order.ts
@@ -1,12 +1,13 @@
 "use server";
 
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { createAdminClient } from "@/lib/supabase/admin";
 import {
   CUSTOMER_TOKEN_COOKIE,
   lookupCustomerByToken,
 } from "@/lib/customer/session";
+import { sendAdminOrderAlert } from "@/lib/notifications/admin-telegram";
 import type { Json } from "@/lib/supabase/types";
 import { weekOfMondayNY } from "@/lib/week";
 
@@ -54,5 +55,33 @@ export async function placeOrder(
 
   if (error) return { error: error.message };
 
+  // Best-effort admin alert (DEC-033). Failure is swallowed inside the
+  // wrapper — order placement never blocks on a notification miss. We
+  // await so the serverless function doesn't terminate before the POST
+  // completes; ~200ms of customer-perceptible latency on submit.
+  const total = payload.items.reduce(
+    (sum, it) => sum + it.qty * it.unit_price_cents,
+    0,
+  );
+  const adminOrdersUrl = `${await adminBaseUrl()}/admin/orders`;
+  await sendAdminOrderAlert({
+    customerName: customer.name,
+    weekOf: weekOfMondayNY(),
+    lineItemCount: payload.items.length,
+    totalCents: total,
+    adminOrdersUrl,
+  });
+
   redirect(`/c/${token}/confirmed`);
+}
+
+// Derives the admin base URL from request headers (host + protocol). Falls
+// back to prod when called outside a request context.
+async function adminBaseUrl(): Promise<string> {
+  if (process.env.NEXT_PUBLIC_APP_URL) return process.env.NEXT_PUBLIC_APP_URL;
+  const h = await headers();
+  const host = h.get("host");
+  const proto = h.get("x-forwarded-proto") ?? "https";
+  if (host) return `${proto}://${host}`;
+  return "https://order.baybranchfarm.com";
 }

--- a/src/actions/place-order.ts
+++ b/src/actions/place-order.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { createAdminClient } from "@/lib/supabase/admin";
 import {
@@ -59,29 +59,28 @@ export async function placeOrder(
   // wrapper — order placement never blocks on a notification miss. We
   // await so the serverless function doesn't terminate before the POST
   // completes; ~200ms of customer-perceptible latency on submit.
+  //
+  // TODO(DEC-033): once place_order RPC ever applies pricing rules
+  // (discounts, rounding), read the total from the inserted order row
+  // instead of recomputing from the payload here.
   const total = payload.items.reduce(
     (sum, it) => sum + it.qty * it.unit_price_cents,
     0,
   );
-  const adminOrdersUrl = `${await adminBaseUrl()}/admin/orders`;
   await sendAdminOrderAlert({
     customerName: customer.name,
     weekOf: weekOfMondayNY(),
     lineItemCount: payload.items.length,
     totalCents: total,
-    adminOrdersUrl,
+    adminOrdersUrl: `${adminBaseUrl()}/admin/orders`,
   });
 
   redirect(`/c/${token}/confirmed`);
 }
 
-// Derives the admin base URL from request headers (host + protocol). Falls
-// back to prod when called outside a request context.
-async function adminBaseUrl(): Promise<string> {
-  if (process.env.NEXT_PUBLIC_APP_URL) return process.env.NEXT_PUBLIC_APP_URL;
-  const h = await headers();
-  const host = h.get("host");
-  const proto = h.get("x-forwarded-proto") ?? "https";
-  if (host) return `${proto}://${host}`;
-  return "https://order.baybranchfarm.com";
+// Admin link in the Telegram alert must always point at prod (where Annabel
+// works), not at whatever host the customer placed the order from. Preview
+// deployments shouldn't deep-link Annabel into preview data.
+function adminBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_APP_URL ?? "https://order.baybranchfarm.com";
 }

--- a/src/lib/notifications/admin-alert-template.ts
+++ b/src/lib/notifications/admin-alert-template.ts
@@ -1,0 +1,41 @@
+// Pure-function composer for the operator-side order-arrival alert
+// (Phase 4.3, DEC-033 — Telegram bot). Plain text only: Telegram renders
+// URLs as tappable links automatically, no Markdown/HTML needed.
+
+export type AdminOrderAlertInput = {
+  customerName: string;
+  weekOf: string;
+  lineItemCount: number;
+  totalCents: number;
+  adminOrdersUrl: string;
+};
+
+function formatDollars(cents: number): string {
+  const sign = cents < 0 ? "-" : "";
+  const abs = Math.abs(cents);
+  const dollars = Math.floor(abs / 100);
+  const c = abs % 100;
+  const dollarsStr = dollars.toLocaleString("en-US");
+  return `${sign}$${dollarsStr}.${c.toString().padStart(2, "0")}`;
+}
+
+export function adminOrderAlertText({
+  customerName,
+  weekOf,
+  lineItemCount,
+  totalCents,
+  adminOrdersUrl,
+}: AdminOrderAlertInput): string {
+  const total = formatDollars(totalCents);
+  const itemsLabel = lineItemCount === 1 ? "1 line" : `${lineItemCount} lines`;
+  return [
+    `New order — ${customerName}, ${total}`,
+    "",
+    `Customer: ${customerName}`,
+    `Week of: ${weekOf}`,
+    `Items: ${itemsLabel}`,
+    `Total: ${total}`,
+    "",
+    adminOrdersUrl,
+  ].join("\n");
+}

--- a/src/lib/notifications/admin-telegram.ts
+++ b/src/lib/notifications/admin-telegram.ts
@@ -16,7 +16,10 @@ function isEnabled(): boolean {
 
 export async function sendAdminOrderAlert(input: AdminOrderAlertInput): Promise<void> {
   if (!isEnabled()) {
-    console.log(
+    // console.debug so dev/preview/test envs (where env vars are unset)
+    // don't spam Vercel logs on every order. Real misconfiguration on a
+    // configured env surfaces via the .ok check below.
+    console.debug(
       `[admin-alert] skipped (not configured) — ${input.customerName}, ${input.lineItemCount} items`,
     );
     return;

--- a/src/lib/notifications/admin-telegram.ts
+++ b/src/lib/notifications/admin-telegram.ts
@@ -1,0 +1,46 @@
+// Operator-side order-arrival alert via Telegram Bot API (Phase 4.3,
+// DEC-033 — supersedes DEC-027's email-first decision). Single recipient
+// (Annabel's Telegram chat_id). Best-effort: any failure is logged and
+// swallowed so order placement never blocks on a notification miss.
+
+import { adminOrderAlertText, type AdminOrderAlertInput } from "./admin-alert-template";
+
+const TELEGRAM_API = "https://api.telegram.org";
+
+function isEnabled(): boolean {
+  if (process.env.NOTIFICATIONS_ENABLED === "false") return false;
+  if (!process.env.TELEGRAM_BOT_TOKEN) return false;
+  if (!process.env.TELEGRAM_ADMIN_CHAT_ID) return false;
+  return true;
+}
+
+export async function sendAdminOrderAlert(input: AdminOrderAlertInput): Promise<void> {
+  if (!isEnabled()) {
+    console.log(
+      `[admin-alert] skipped (not configured) — ${input.customerName}, ${input.lineItemCount} items`,
+    );
+    return;
+  }
+
+  const token = process.env.TELEGRAM_BOT_TOKEN!;
+  const chatId = process.env.TELEGRAM_ADMIN_CHAT_ID!;
+  const text = adminOrderAlertText(input);
+
+  try {
+    const res = await fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text,
+        disable_web_page_preview: true,
+      }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "(no body)");
+      console.error(`[admin-alert] telegram ${res.status}: ${detail}`);
+    }
+  } catch (err) {
+    console.error(`[admin-alert] telegram fetch failed: ${(err as Error).message}`);
+  }
+}

--- a/tests/admin-alert-template.spec.ts
+++ b/tests/admin-alert-template.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "@playwright/test";
+
+import { adminOrderAlertText } from "@/lib/notifications/admin-alert-template";
+
+// Pure-function unit tests for the Telegram message body sent to the operator
+// when a customer submits an order (Phase 4.3, DEC-033).
+
+test.describe("adminOrderAlertText", () => {
+  test("single-line-item order — singular wording", () => {
+    expect(
+      adminOrderAlertText({
+        customerName: "Hannah",
+        weekOf: "2026-05-11",
+        lineItemCount: 1,
+        totalCents: 3000,
+        adminOrdersUrl: "https://order.baybranchfarm.com/admin/orders",
+      }),
+    ).toBe(
+      [
+        "New order — Hannah, $30.00",
+        "",
+        "Customer: Hannah",
+        "Week of: 2026-05-11",
+        "Items: 1 line",
+        "Total: $30.00",
+        "",
+        "https://order.baybranchfarm.com/admin/orders",
+      ].join("\n"),
+    );
+  });
+
+  test("multi-line-item order — plural wording", () => {
+    const body = adminOrderAlertText({
+      customerName: "Hannah",
+      weekOf: "2026-05-11",
+      lineItemCount: 5,
+      totalCents: 4320,
+      adminOrdersUrl: "https://order.baybranchfarm.com/admin/orders",
+    });
+    expect(body).toContain("Items: 5 lines");
+    expect(body).toContain("Total: $43.20");
+    expect(body).toContain("New order — Hannah, $43.20");
+  });
+
+  test("cents formatting — pads single-digit cents", () => {
+    const body = adminOrderAlertText({
+      customerName: "Tom",
+      weekOf: "2026-05-11",
+      lineItemCount: 2,
+      totalCents: 305,
+      adminOrdersUrl: "x",
+    });
+    expect(body).toContain("$3.05");
+  });
+
+  test("cents formatting — zero cents", () => {
+    const body = adminOrderAlertText({
+      customerName: "Tom",
+      weekOf: "2026-05-11",
+      lineItemCount: 2,
+      totalCents: 1000,
+      adminOrdersUrl: "x",
+    });
+    expect(body).toContain("$10.00");
+  });
+
+  test("large totals format with thousands grouping", () => {
+    const body = adminOrderAlertText({
+      customerName: "Big Order Co",
+      weekOf: "2026-05-11",
+      lineItemCount: 25,
+      totalCents: 123456,
+      adminOrdersUrl: "x",
+    });
+    expect(body).toContain("$1,234.56");
+  });
+
+  test("admin orders URL appears as the last line", () => {
+    const body = adminOrderAlertText({
+      customerName: "Hannah",
+      weekOf: "2026-05-11",
+      lineItemCount: 1,
+      totalCents: 100,
+      adminOrdersUrl: "https://order.baybranchfarm.com/admin/orders",
+    });
+    const lines = body.split("\n");
+    expect(lines[lines.length - 1]).toBe("https://order.baybranchfarm.com/admin/orders");
+  });
+});


### PR DESCRIPTION
## Summary

Per-order alert to Annabel via Telegram bot. Pivoted from DEC-027's email path during planning — Telegram has lower latency, no DNS/sender-verification overhead, no SDK dep, and Annabel already uses the app. DEC-033 records the pivot, DEC-027 marked superseded. Best-effort: any failure is logged and swallowed, never blocks order placement.

Closes #89.

## Files changed

- `src/lib/notifications/admin-alert-template.ts` — pure-function composer for the plain-text body
- `src/lib/notifications/admin-telegram.ts` — `fetch` wrapper around `api.telegram.org/bot<TOKEN>/sendMessage`; env-gated, error-swallowing
- `src/actions/place-order.ts` — fires the alert after successful RPC, before redirect (~200ms awaited)
- `tests/admin-alert-template.spec.ts` — 6 pure-function unit tests
- `docs/DECISIONS.md` — DEC-027 superseded, DEC-033 added

## Code review

3 findings, all addressed in `1a47787`:
- **adminBaseUrl precedence:** dropped the request-header derivation. Alert link must always point at prod regardless of which host the customer placed the order from — preview deployments shouldn't deep-link Annabel into preview data.
- **Log noise:** `console.log` → `console.debug` on the "skipped (not configured)" path. Per-order log spam in dev/preview/test envs would have buried real misconfig logs in prod.
- **Total recompute TODO:** comment notes that we currently recompute the total from payload instead of reading from the inserted order row. Acceptable in V1 (no pricing rules); read-from-row is the right move when discounts/rounding land.

No blocking issues. Best-effort discipline verified clean (wrapper has no escape paths; redirect always runs on RPC success). Secret leakage clean (token never appears in any log line).

## Test plan

- `npx playwright test tests/admin-alert-template.spec.ts --project=desktop` — 6/6 green.
- `npx playwright test tests/customer-place-order.spec.ts --project=desktop` — 3/3 green (regression: alert wrapper no-ops in test env via the env-var gate, place-order flow unaffected).
- `npm run build` — clean.

**Post-merge setup** (Annabel + me, ~5 min):
1. Annabel opens Telegram → messages `@BotFather` → `/newbot` → name + username → grabs token
2. Annabel sends any message to the new bot (Telegram won't deliver until she initiates)
3. `curl "https://api.telegram.org/bot<TOKEN>/getUpdates"` → reads `result[0].message.chat.id`
4. Vercel Production env vars: `TELEGRAM_BOT_TOKEN` + `TELEGRAM_ADMIN_CHAT_ID`. Optionally `NEXT_PUBLIC_APP_URL=https://order.baybranchfarm.com` (the fallback already points there).

In dev/preview without env vars, alert wrapper no-ops and logs a debug line. Right failure mode.

## Notes

- No file overlap with PR #93 (Phase 4.2) or PR #80. Merges in any order.
- PWA push (DEC-027's original stretch) remains deferred — captured in DEC-033's "Stretch upgrade still on the table" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)