### PR TITLE
read-the-tape session 20: settings, retro Read-before-Edit, P17

### DIFF
--- a/.claude/agents/tape-reader.md
+++ b/.claude/agents/tape-reader.md
@@ -1,6 +1,6 @@
 ---
 name: tape-reader
-description: Analyzes session JSONL transcripts for workflow anti-patterns and proposes targeted improvements to skill and agent files. Invoked by /read-the-tape. Covers known patterns P1–P16 and surfaces new candidates to grow its own checklist.
+description: Analyzes session JSONL transcripts for workflow anti-patterns and proposes targeted improvements to skill and agent files. Invoked by /read-the-tape. Covers known patterns P1–P17 and surfaces new candidates to grow its own checklist.
 tools: Read, Edit, Write, Bash, Glob, Grep
 ---
 
@@ -169,9 +169,17 @@ For each pattern, note: **occurred / not found / inconclusive**.
 
 ---
 
+### P17 — Edit on a file the skill never Read first
+**Signal:** A skill instructs Edit (or "append to") a file without an explicit prior Read step, and the run fails with "File has not been read yet." Most common on optional/conditional files the skill creates-or-appends-to: `docs/RETROSPECTIVES.md`, `CHANGELOG.md`, `docs/DECISIONS.md`, any "append a section to X" pattern. Usually surfaces the first time the file actually exists — the create-branch worked, the append-branch fails.
+**Why it hurts:** Mid-skill failure forces the user to either re-run the whole skill (losing intermediate state — computed metrics, prompted answers, version bumps already committed) or hand-patch the file. Either way the skill's atomicity guarantee is broken. Particularly bad for `/retro` and `/kill-this` where the failed step sits between a successful commit and a successful push.
+**Fix:** Any skill step that may Edit a file must Read it first in the same step. The standard idiom: "Read `<file>` first (Edit requires a prior Read). If it doesn't exist, create it with Write and `<header>`. Otherwise Edit by replacing `<known-anchor>` with `<known-anchor>\n<new content>\n`." This handles both the create and append branches without a separate "does it exist" probe that the model is free to skip.
+**Files:** The calling skill's SKILL.md — typically wherever an "append to / create if missing" pattern lives
+
+---
+
 ## Step 3 — Look for new patterns
 
-Beyond P1–P15, scan for friction signals not yet on the list:
+Beyond P1–P17, scan for friction signals not yet on the list:
 
 - Any tool call that failed and was retried 2+ times
 - The same file being read multiple times in the same session

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -35,7 +35,15 @@
       "Bash(python3 -c \"import json,sys; d=json.loads\\(sys.stdin.read\\(\\)\\); print\\('timestamp:', d.get\\('timestamp'\\)\\)\")",
       "Bash(lsof -ti:3001)",
       "Bash(lsof -ti:3001 | xargs -r kill -9)",
-      "Bash(lsof -ti:3001 | xargs kill -9)"
+      "Bash(lsof -ti:3001 | xargs kill -9)",
+      "Bash([ -f \"$TRANSCRIPT\" ])",
+      "Read(//tmp/**)",
+      "Bash(python3 -c \"import json,sys; d=json.loads\\(sys.stdin.read\\(\\)\\); print\\(list\\(d.keys\\(\\)\\)\\)\")",
+      "Bash(python3 *)",
+      "Bash(awk '{print $1, $2, $3}')",
+      "Bash(source .envrc && *)",
+      "Bash(kill $(lsof -ti:3001) 2>/dev/null)",
+      "Bash(kill $(lsof -ti:3001))"
     ]
   }
 }

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -157,7 +157,7 @@ Show the commentary verbatim:
 
 ## Step 6 — Append to RETROSPECTIVES.md
 
-If `docs/RETROSPECTIVES.md` doesn't exist, create it with `# Retrospectives\n\n`. Append:
+Read `docs/RETROSPECTIVES.md` first (Edit requires a prior Read). If it doesn't exist, create it with Write and the header `# Retrospectives\n\n`. Otherwise Edit the file by replacing the `# Retrospectives\n\n` header with `# Retrospectives\n\n## Phase <N> — <YYYY-MM-DD>\n\n...full block...\n\n` so the new phase lands at the top. Block template:
 
 ```
 ## Phase <N> — <YYYY-MM-DD>


### PR DESCRIPTION
Audit of session 20 transcript. Four fixes applied.

## Patterns found and fixed

- **P2 — Repeated permission prompt:** `source .envrc && supabase ...` prompted on each invocation because the leading `source` falls outside `Bash(supabase *)`. Added `Bash(source .envrc && *)` to `.claude/settings.local.json`.
- **P3 — Edit failure: file not read first:** `/retro` Step 6 told the skill to "append" to `docs/RETROSPECTIVES.md` without a preceding Read. The append-branch fails the first time the file actually exists (Edit requires a prior Read), mid-skill, between a successful commit and a successful push. Rewrote Step 6 to Read-first, then Write-if-missing or Edit-prepend-at-top.
- **P16 — Stale dev-server kill:** Added `Bash(kill $(lsof -ti:3001) 2>/dev/null)` and `Bash(kill $(lsof -ti:3001))` to settings allowlist. `lsof -ti:3001 | xargs -r kill -9` was already there; the `kill $(lsof -ti:3001)` shape kept prompting separately.
- **CX1 → new P17 — Edit on a file the skill never Read first:** Generalizes the retro failure into a checklist pattern. Added to `.claude/agents/tape-reader.md` as P17. Signal: skill instructs Edit (or "append to") an optional/conditional file (`RETROSPECTIVES.md`, `CHANGELOG.md`, `DECISIONS.md`) without a prior Read, fails with "File has not been read yet" the first time the file exists. Fix: Read-first idiom in the skill step.

## Patterns found but skipped

None — all approved.

## Candidate patterns discovered

P17 (now applied).

Note: Run `/push-seeds` after merge to backport to seeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)