### PR TITLE
Phase 5.1 — admin orders list + status UI + reconciliation pin

### DIFF
--- a/src/actions/advance-order-status.ts
+++ b/src/actions/advance-order-status.ts
@@ -1,0 +1,58 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { createClient } from "@/lib/supabase/server";
+import type { OrderStatus } from "@/lib/admin/orders-queries";
+
+// DEC-010: new → ready → (picked-up | delivered).
+// Fulfillment type pins which terminal state is valid.
+function isValidTransition(
+  from: OrderStatus,
+  to: OrderStatus,
+  fulfillmentType: "pickup" | "delivery",
+): boolean {
+  if (from === "new" && to === "ready") return true;
+  if (from === "ready" && to === "picked-up") return fulfillmentType === "pickup";
+  if (from === "ready" && to === "delivered") return fulfillmentType === "delivery";
+  return false;
+}
+
+export async function advanceOrderStatus(
+  orderId: string,
+  nextStatus: OrderStatus,
+): Promise<{ error: string | null }> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized" };
+
+  const { data: order, error: readError } = await supabase
+    .from("orders")
+    .select("status, fulfillment_type")
+    .eq("id", orderId)
+    .single();
+  if (readError) return { error: readError.message };
+  if (!order) return { error: "Order not found" };
+
+  const from = order.status as OrderStatus;
+  const fulfillmentType =
+    order.fulfillment_type === "delivery" ? "delivery" : "pickup";
+
+  if (!isValidTransition(from, nextStatus, fulfillmentType)) {
+    return {
+      error: `Cannot move ${from} → ${nextStatus} (${fulfillmentType})`,
+    };
+  }
+
+  const { error: updateError } = await supabase
+    .from("orders")
+    .update({ status: nextStatus, updated_at: new Date().toISOString() })
+    .eq("id", orderId);
+  if (updateError) return { error: updateError.message };
+
+  revalidatePath("/admin/orders");
+  return { error: null };
+}

--- a/src/actions/advance-order-status.ts
+++ b/src/actions/advance-order-status.ts
@@ -18,6 +18,9 @@ function isValidTransition(
   return false;
 }
 
+// Uses cookie-bound client (not admin) — the admin_all_orders RLS policy
+// (migration 20260508014838) is the gate on writes here. Matches the
+// recordSend pattern.
 export async function advanceOrderStatus(
   orderId: string,
   nextStatus: OrderStatus,

--- a/src/app/(admin)/admin/orders/page.tsx
+++ b/src/app/(admin)/admin/orders/page.tsx
@@ -1,9 +1,6 @@
 import { OrdersPage } from "@/components/admin/orders-page";
-import {
-  currentWeekOf,
-  listOrders,
-  shiftWeek,
-} from "@/lib/admin/orders-queries";
+import { currentWeekOf, listOrders } from "@/lib/admin/orders-queries";
+import { shiftWeek } from "@/lib/week";
 
 export const metadata = { title: "Orders — Bay Branch Farm" };
 

--- a/src/app/(admin)/admin/orders/page.tsx
+++ b/src/app/(admin)/admin/orders/page.tsx
@@ -1,0 +1,44 @@
+import { OrdersPage } from "@/components/admin/orders-page";
+import {
+  currentWeekOf,
+  listOrders,
+  shiftWeek,
+} from "@/lib/admin/orders-queries";
+
+export const metadata = { title: "Orders — Bay Branch Farm" };
+
+function resolveWeekFilter(raw: string | undefined): "this" | "last" {
+  return raw === "last" ? "last" : "this";
+}
+
+export default async function OrdersRoute({
+  searchParams,
+}: {
+  searchParams: Promise<{ week?: string }>;
+}) {
+  const params = await searchParams;
+  const weekFilter = resolveWeekFilter(params.week);
+  const thisWeek = currentWeekOf();
+  const lastWeek = shiftWeek(thisWeek, -1);
+  const selectedWeek = weekFilter === "last" ? lastWeek : thisWeek;
+
+  const [orders, thisWeekOrders, lastWeekOrders] = await Promise.all([
+    listOrders(selectedWeek),
+    weekFilter === "this" ? Promise.resolve(null) : listOrders(thisWeek),
+    weekFilter === "last" ? Promise.resolve(null) : listOrders(lastWeek),
+  ]);
+
+  const thisWeekCount =
+    weekFilter === "this" ? orders.length : (thisWeekOrders?.length ?? 0);
+  const lastWeekCount =
+    weekFilter === "last" ? orders.length : (lastWeekOrders?.length ?? 0);
+
+  return (
+    <OrdersPage
+      orders={orders}
+      weekFilter={weekFilter}
+      thisWeekCount={thisWeekCount}
+      lastWeekCount={lastWeekCount}
+    />
+  );
+}

--- a/src/components/admin/order-detail.tsx
+++ b/src/components/admin/order-detail.tsx
@@ -1,0 +1,109 @@
+import type { OrderRow as OrderRowData } from "@/lib/admin/orders-queries";
+
+function formatMoney(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export function OrderDetail({ order }: { order: OrderRowData }) {
+  return (
+    <div className="ord-detail">
+      <div className="ord-detail-grid">
+        <div className="ord-detail-section">
+          <div className="ord-detail-label">Line items</div>
+          <ul className="ord-detail-list">
+            {order.items.map((i) => {
+              const oversold = i.qty > i.qtyAvailable;
+              const shortBy = oversold ? i.qty - i.qtyAvailable : 0;
+              return (
+                <li key={i.productId} className={oversold ? "is-oversold" : ""}>
+                  <span className="ord-li-qty mono">{i.qty}×</span>
+                  <span className="ord-li-name">
+                    {i.name}
+                    <span className="ord-li-unit"> · {i.unit}</span>
+                  </span>
+                  {oversold && (
+                    <span className="ord-li-flag">
+                      Only {i.qtyAvailable} available — {shortBy} oversold
+                    </span>
+                  )}
+                  <span className="ord-li-amt mono">
+                    {formatMoney(i.qty * i.unitPriceCents)}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+          <div className="ord-li-total">
+            <span>Total</span>
+            <span className="mono">{formatMoney(order.totalCents)}</span>
+          </div>
+        </div>
+
+        <div className="ord-detail-section">
+          <div className="ord-detail-label">Fulfillment</div>
+          <div className="ord-detail-fulfill">
+            <div className="ord-detail-row">
+              <span className="ord-detail-key">Type</span>
+              <span>{order.fulfillmentType === "delivery" ? "Delivery" : "Pickup"}</span>
+            </div>
+            {order.fulfillmentType === "delivery" && order.deliveryAddress && (
+              <div className="ord-detail-row">
+                <span className="ord-detail-key">Address</span>
+                <span>{order.deliveryAddress}</span>
+              </div>
+            )}
+            {order.fulfillmentType === "delivery" && order.deliveryPreference && (
+              <div className="ord-detail-row">
+                <span className="ord-detail-key">Note</span>
+                <span>{order.deliveryPreference}</span>
+              </div>
+            )}
+            {order.fulfillmentType === "pickup" && order.pickupNote && (
+              <div className="ord-detail-row">
+                <span className="ord-detail-key">Pickup</span>
+                <span>{order.pickupNote}</span>
+              </div>
+            )}
+          </div>
+
+          {order.notes && (
+            <>
+              <div className="ord-detail-label" style={{ marginTop: 18 }}>
+                Customer note
+              </div>
+              <div className="ord-detail-note">&ldquo;{order.notes}&rdquo;</div>
+            </>
+          )}
+
+          {order.needsReconciliation && (
+            <div className="callout callout-warn" style={{ marginTop: 16 }}>
+              <strong>This order oversold an item.</strong> The cart was
+              optimistic — actual stock didn&rsquo;t match. Adjust quantities or
+              text the customer before fulfillment.
+              <div style={{ marginTop: 10, display: "flex", gap: 8 }}>
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  style={{ minHeight: 36, padding: "0 12px" }}
+                  disabled
+                  title="Coming in Phase 6"
+                >
+                  Adjust quantities
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-ghost"
+                  style={{ minHeight: 36, padding: "0 12px" }}
+                  disabled
+                  title="Coming in Phase 6"
+                >
+                  Mark resolved
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/order-row.tsx
+++ b/src/components/admin/order-row.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useState, useTransition, Fragment } from "react";
+
+import { advanceOrderStatus } from "@/actions/advance-order-status";
+import type { OrderRow as OrderRowData, OrderStatus } from "@/lib/admin/orders-queries";
+
+type Props = {
+  order: OrderRowData;
+  isOpen: boolean;
+  onToggle: () => void;
+};
+
+function formatMoney(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatPlaced(iso: string): string {
+  const d = new Date(iso);
+  const day = d.toLocaleDateString("en-US", {
+    weekday: "short",
+    timeZone: "America/New_York",
+  });
+  const time = d.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "America/New_York",
+  });
+  return `${day} · ${time.toLowerCase()}`;
+}
+
+function itemsPreview(items: OrderRowData["items"]): string {
+  const names = items.slice(0, 3).map((i) => i.name.toLowerCase()).join(", ");
+  const extra = items.length > 3 ? `, +${items.length - 3} more` : "";
+  return `${names}${extra}`;
+}
+
+function StatusControl({
+  order,
+  onAdvance,
+  pending,
+}: {
+  order: OrderRowData;
+  onAdvance: (next: OrderStatus) => void;
+  pending: boolean;
+}) {
+  if (order.status === "new") {
+    return (
+      <div className="status-control">
+        <span className="pill pill-new">New</span>
+        <button
+          type="button"
+          className="status-advance"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAdvance("ready");
+          }}
+          disabled={pending}
+        >
+          Mark ready →
+        </button>
+      </div>
+    );
+  }
+  if (order.status === "ready") {
+    const terminal: OrderStatus =
+      order.fulfillmentType === "pickup" ? "picked-up" : "delivered";
+    const label = terminal === "picked-up" ? "Picked up ✓" : "Delivered ✓";
+    return (
+      <div className="status-control">
+        <span className="pill pill-ready">Ready</span>
+        <button
+          type="button"
+          className="status-advance"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAdvance(terminal);
+          }}
+          disabled={pending}
+        >
+          {label}
+        </button>
+      </div>
+    );
+  }
+  if (order.status === "picked-up") {
+    return <span className="pill pill-done">Picked up</span>;
+  }
+  return <span className="pill pill-done">Delivered</span>;
+}
+
+function OrderDetail({ order }: { order: OrderRowData }) {
+  return (
+    <div className="ord-detail">
+      <div className="ord-detail-grid">
+        <div className="ord-detail-section">
+          <div className="ord-detail-label">Line items</div>
+          <ul className="ord-detail-list">
+            {order.items.map((i) => {
+              const oversold = i.qty > i.qtyAvailable;
+              const shortBy = oversold ? i.qty - i.qtyAvailable : 0;
+              return (
+                <li key={i.productId} className={oversold ? "is-oversold" : ""}>
+                  <span className="ord-li-qty mono">{i.qty}×</span>
+                  <span className="ord-li-name">
+                    {i.name}
+                    <span className="ord-li-unit"> · {i.unit}</span>
+                  </span>
+                  {oversold && (
+                    <span className="ord-li-flag">
+                      Only {i.qtyAvailable} available — {shortBy} oversold
+                    </span>
+                  )}
+                  <span className="ord-li-amt mono">
+                    {formatMoney(i.qty * i.unitPriceCents)}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+          <div className="ord-li-total">
+            <span>Total</span>
+            <span className="mono">{formatMoney(order.totalCents)}</span>
+          </div>
+        </div>
+
+        <div className="ord-detail-section">
+          <div className="ord-detail-label">Fulfillment</div>
+          <div className="ord-detail-fulfill">
+            <div className="ord-detail-row">
+              <span className="ord-detail-key">Type</span>
+              <span>{order.fulfillmentType === "delivery" ? "Delivery" : "Pickup"}</span>
+            </div>
+            {order.fulfillmentType === "delivery" && order.deliveryAddress && (
+              <div className="ord-detail-row">
+                <span className="ord-detail-key">Address</span>
+                <span>{order.deliveryAddress}</span>
+              </div>
+            )}
+            {order.fulfillmentType === "delivery" && order.deliveryPreference && (
+              <div className="ord-detail-row">
+                <span className="ord-detail-key">Note</span>
+                <span>{order.deliveryPreference}</span>
+              </div>
+            )}
+            {order.fulfillmentType === "pickup" && order.pickupNote && (
+              <div className="ord-detail-row">
+                <span className="ord-detail-key">Pickup</span>
+                <span>{order.pickupNote}</span>
+              </div>
+            )}
+          </div>
+
+          {order.notes && (
+            <>
+              <div className="ord-detail-label" style={{ marginTop: 18 }}>
+                Customer note
+              </div>
+              <div className="ord-detail-note">&ldquo;{order.notes}&rdquo;</div>
+            </>
+          )}
+
+          {order.needsReconciliation && (
+            <div className="callout callout-warn" style={{ marginTop: 16 }}>
+              <strong>This order oversold an item.</strong> The cart was
+              optimistic — actual stock didn&rsquo;t match. Adjust quantities or
+              text the customer before fulfillment.
+              <div style={{ marginTop: 10, display: "flex", gap: 8 }}>
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  style={{ minHeight: 36, padding: "0 12px" }}
+                  disabled
+                  title="Coming in Phase 6"
+                >
+                  Adjust quantities
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-ghost"
+                  style={{ minHeight: 36, padding: "0 12px" }}
+                  disabled
+                  title="Coming in Phase 6"
+                >
+                  Mark resolved
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function OrderRow({ order, isOpen, onToggle }: Props) {
+  const [optimisticStatus, setOptimisticStatus] = useState<OrderStatus>(order.status);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleAdvance(next: OrderStatus) {
+    setError(null);
+    const previous = optimisticStatus;
+    setOptimisticStatus(next);
+    startTransition(async () => {
+      const result = await advanceOrderStatus(order.id, next);
+      if (result.error) {
+        setOptimisticStatus(previous);
+        setError(result.error);
+      }
+    });
+  }
+
+  const view: OrderRowData = { ...order, status: optimisticStatus };
+
+  return (
+    <Fragment>
+      <tr
+        className={
+          "ord-row" +
+          (view.needsReconciliation ? " needs-rec" : "") +
+          (isOpen ? " is-open" : "")
+        }
+        data-order-id={order.id}
+        data-status={view.status}
+        onClick={onToggle}
+      >
+        <td className="col-o-id">
+          <div className="ord-num mono">#{order.id.slice(0, 8)}</div>
+          {view.needsReconciliation && (
+            <span className="badge-recon">Needs reconciliation</span>
+          )}
+        </td>
+        <td className="col-o-cust">
+          <div className="ord-cust-name">{view.customerName}</div>
+        </td>
+        <td className="col-o-when">
+          <div className="ord-when">{formatPlaced(view.placedAt)}</div>
+        </td>
+        <td className="col-o-items">
+          <div className="ord-items-count">
+            <strong>{view.items.length}</strong> items
+          </div>
+          <div className="ord-items-prev">{itemsPreview(view.items)}</div>
+        </td>
+        <td className="col-o-ful">
+          <div className="ord-ful">
+            <span className={`chip chip-ful chip-${view.fulfillmentType}`}>
+              {view.fulfillmentType === "delivery" ? "Delivery" : "Pickup"}
+            </span>
+          </div>
+        </td>
+        <td className="col-o-total">
+          <div className="ord-total mono">{formatMoney(view.totalCents)}</div>
+        </td>
+        <td className="col-o-status" onClick={(e) => e.stopPropagation()}>
+          <StatusControl order={view} onAdvance={handleAdvance} pending={pending} />
+          {error && (
+            <div className="ord-row-error" role="alert">
+              {error}
+            </div>
+          )}
+        </td>
+      </tr>
+      {isOpen && (
+        <tr className="ord-detail-row">
+          <td colSpan={7}>
+            <OrderDetail order={view} />
+          </td>
+        </tr>
+      )}
+    </Fragment>
+  );
+}

--- a/src/components/admin/order-row.tsx
+++ b/src/components/admin/order-row.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition, Fragment } from "react";
 
 import { advanceOrderStatus } from "@/actions/advance-order-status";
+import { OrderDetail } from "@/components/admin/order-detail";
 import type { OrderRow as OrderRowData, OrderStatus } from "@/lib/admin/orders-queries";
 
 type Props = {
@@ -87,110 +88,6 @@ function StatusControl({
     return <span className="pill pill-done">Picked up</span>;
   }
   return <span className="pill pill-done">Delivered</span>;
-}
-
-function OrderDetail({ order }: { order: OrderRowData }) {
-  return (
-    <div className="ord-detail">
-      <div className="ord-detail-grid">
-        <div className="ord-detail-section">
-          <div className="ord-detail-label">Line items</div>
-          <ul className="ord-detail-list">
-            {order.items.map((i) => {
-              const oversold = i.qty > i.qtyAvailable;
-              const shortBy = oversold ? i.qty - i.qtyAvailable : 0;
-              return (
-                <li key={i.productId} className={oversold ? "is-oversold" : ""}>
-                  <span className="ord-li-qty mono">{i.qty}×</span>
-                  <span className="ord-li-name">
-                    {i.name}
-                    <span className="ord-li-unit"> · {i.unit}</span>
-                  </span>
-                  {oversold && (
-                    <span className="ord-li-flag">
-                      Only {i.qtyAvailable} available — {shortBy} oversold
-                    </span>
-                  )}
-                  <span className="ord-li-amt mono">
-                    {formatMoney(i.qty * i.unitPriceCents)}
-                  </span>
-                </li>
-              );
-            })}
-          </ul>
-          <div className="ord-li-total">
-            <span>Total</span>
-            <span className="mono">{formatMoney(order.totalCents)}</span>
-          </div>
-        </div>
-
-        <div className="ord-detail-section">
-          <div className="ord-detail-label">Fulfillment</div>
-          <div className="ord-detail-fulfill">
-            <div className="ord-detail-row">
-              <span className="ord-detail-key">Type</span>
-              <span>{order.fulfillmentType === "delivery" ? "Delivery" : "Pickup"}</span>
-            </div>
-            {order.fulfillmentType === "delivery" && order.deliveryAddress && (
-              <div className="ord-detail-row">
-                <span className="ord-detail-key">Address</span>
-                <span>{order.deliveryAddress}</span>
-              </div>
-            )}
-            {order.fulfillmentType === "delivery" && order.deliveryPreference && (
-              <div className="ord-detail-row">
-                <span className="ord-detail-key">Note</span>
-                <span>{order.deliveryPreference}</span>
-              </div>
-            )}
-            {order.fulfillmentType === "pickup" && order.pickupNote && (
-              <div className="ord-detail-row">
-                <span className="ord-detail-key">Pickup</span>
-                <span>{order.pickupNote}</span>
-              </div>
-            )}
-          </div>
-
-          {order.notes && (
-            <>
-              <div className="ord-detail-label" style={{ marginTop: 18 }}>
-                Customer note
-              </div>
-              <div className="ord-detail-note">&ldquo;{order.notes}&rdquo;</div>
-            </>
-          )}
-
-          {order.needsReconciliation && (
-            <div className="callout callout-warn" style={{ marginTop: 16 }}>
-              <strong>This order oversold an item.</strong> The cart was
-              optimistic — actual stock didn&rsquo;t match. Adjust quantities or
-              text the customer before fulfillment.
-              <div style={{ marginTop: 10, display: "flex", gap: 8 }}>
-                <button
-                  type="button"
-                  className="btn btn-secondary"
-                  style={{ minHeight: 36, padding: "0 12px" }}
-                  disabled
-                  title="Coming in Phase 6"
-                >
-                  Adjust quantities
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-ghost"
-                  style={{ minHeight: 36, padding: "0 12px" }}
-                  disabled
-                  title="Coming in Phase 6"
-                >
-                  Mark resolved
-                </button>
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
 }
 
 export function OrderRow({ order, isOpen, onToggle }: Props) {

--- a/src/components/admin/orders-page.tsx
+++ b/src/components/admin/orders-page.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { OrderRow } from "@/components/admin/order-row";
+import type { OrderRow as OrderRowData } from "@/lib/admin/orders-queries";
+
+type SortKey = "placed" | "customer" | "total";
+type SortDir = "asc" | "desc";
+
+type Props = {
+  orders: OrderRowData[];
+  weekFilter: "this" | "last";
+  thisWeekCount: number;
+  lastWeekCount: number;
+};
+
+function compareOrders(a: OrderRowData, b: OrderRowData, key: SortKey, dir: SortDir): number {
+  let cmp = 0;
+  if (key === "placed") cmp = a.placedAt.localeCompare(b.placedAt);
+  else if (key === "customer") cmp = a.customerName.localeCompare(b.customerName);
+  else if (key === "total") cmp = a.totalCents - b.totalCents;
+  return dir === "asc" ? cmp : -cmp;
+}
+
+function SortHeader({
+  label,
+  sortKey,
+  current,
+  onSort,
+  className,
+}: {
+  label: string;
+  sortKey: SortKey;
+  current: { key: SortKey; dir: SortDir };
+  onSort: (key: SortKey) => void;
+  className?: string;
+}) {
+  const isActive = current.key === sortKey;
+  const indicator = isActive ? (current.dir === "asc" ? " ↑" : " ↓") : "";
+  return (
+    <th className={className}>
+      <button
+        type="button"
+        className="ord-sort-btn"
+        onClick={() => onSort(sortKey)}
+        aria-sort={isActive ? (current.dir === "asc" ? "ascending" : "descending") : "none"}
+      >
+        {label}
+        {indicator}
+      </button>
+    </th>
+  );
+}
+
+export function OrdersPage({ orders, weekFilter, thisWeekCount, lastWeekCount }: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [sort, setSort] = useState<{ key: SortKey; dir: SortDir }>({
+    key: "placed",
+    dir: "desc",
+  });
+
+  const sorted = useMemo(() => {
+    const copy = [...orders];
+    copy.sort((a, b) => {
+      if (a.needsReconciliation !== b.needsReconciliation) {
+        return a.needsReconciliation ? -1 : 1;
+      }
+      return compareOrders(a, b, sort.key, sort.dir);
+    });
+    return copy;
+  }, [orders, sort]);
+
+  function handleSort(key: SortKey) {
+    setSort((prev) => {
+      if (prev.key === key) {
+        return { key, dir: prev.dir === "asc" ? "desc" : "asc" };
+      }
+      return { key, dir: key === "placed" ? "desc" : "asc" };
+    });
+  }
+
+  function setWeek(next: "this" | "last") {
+    const params = new URLSearchParams(searchParams.toString());
+    if (next === "this") params.delete("week");
+    else params.set("week", "last");
+    const qs = params.toString();
+    router.push(`/admin/orders${qs ? `?${qs}` : ""}`);
+  }
+
+  const reconCount = orders.filter((o) => o.needsReconciliation).length;
+
+  return (
+    <div className="ord-page">
+      <div className="page-head">
+        <div>
+          <div className="eyebrow" style={{ marginBottom: 6 }}>
+            {orders.length} orders
+            {reconCount > 0 && ` · ${reconCount} need reconciliation`}
+          </div>
+          <h1 className="page-title">Orders</h1>
+        </div>
+      </div>
+
+      <div className="ord-filters">
+        <button
+          type="button"
+          className={"chip-tab" + (weekFilter === "this" ? " is-on" : "")}
+          onClick={() => setWeek("this")}
+        >
+          This week <span className="chip-count">{thisWeekCount}</span>
+        </button>
+        <button
+          type="button"
+          className={"chip-tab" + (weekFilter === "last" ? " is-on" : "")}
+          onClick={() => setWeek("last")}
+        >
+          Last week <span className="chip-count">{lastWeekCount}</span>
+        </button>
+        <button
+          type="button"
+          className="chip-tab"
+          disabled
+          title="Coming in Phase 6"
+        >
+          Custom range
+        </button>
+      </div>
+
+      {orders.length === 0 ? (
+        <div className="ord-empty">No orders for this week yet.</div>
+      ) : (
+        <div className="ord-tableCard">
+          <table className="ord-table" aria-label="Orders">
+            <thead>
+              <tr>
+                <th className="col-o-id">Order</th>
+                <SortHeader
+                  label="Customer"
+                  sortKey="customer"
+                  current={sort}
+                  onSort={handleSort}
+                  className="col-o-cust"
+                />
+                <SortHeader
+                  label="Placed"
+                  sortKey="placed"
+                  current={sort}
+                  onSort={handleSort}
+                  className="col-o-when"
+                />
+                <th className="col-o-items">Items</th>
+                <th className="col-o-ful">Fulfillment</th>
+                <SortHeader
+                  label="Total"
+                  sortKey="total"
+                  current={sort}
+                  onSort={handleSort}
+                  className="col-o-total"
+                />
+                <th className="col-o-status">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((o) => (
+                <OrderRow
+                  key={o.id}
+                  order={o}
+                  isOpen={expanded === o.id}
+                  onToggle={() => setExpanded(expanded === o.id ? null : o.id)}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/admin/orders-queries.ts
+++ b/src/lib/admin/orders-queries.ts
@@ -1,0 +1,121 @@
+// Admin order-list reads (Phase 5.1). Service-role client — admin only.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { weekOfMondayNY } from "@/lib/week";
+
+export type OrderStatus = "new" | "ready" | "picked-up" | "delivered";
+
+export const ORDER_STATUSES: OrderStatus[] = [
+  "new",
+  "ready",
+  "picked-up",
+  "delivered",
+];
+
+export type OrderItem = {
+  productId: string;
+  name: string;
+  unit: string;
+  qty: number;
+  unitPriceCents: number;
+  qtyAvailable: number;
+};
+
+export type OrderRow = {
+  id: string;
+  customerId: string;
+  customerName: string;
+  placedAt: string;
+  weekOf: string;
+  fulfillmentType: "pickup" | "delivery";
+  deliveryAddress: string | null;
+  deliveryPreference: string | null;
+  pickupNote: string | null;
+  notes: string | null;
+  status: OrderStatus;
+  needsReconciliation: boolean;
+  items: OrderItem[];
+  totalCents: number;
+};
+
+function narrowStatus(s: string): OrderStatus {
+  return (ORDER_STATUSES as string[]).includes(s) ? (s as OrderStatus) : "new";
+}
+
+function narrowFulfillment(s: string): "pickup" | "delivery" {
+  return s === "delivery" ? "delivery" : "pickup";
+}
+
+// Shifts a YYYY-MM-DD Monday by N weeks. Used by week-filter chips.
+export function shiftWeek(weekOf: string, weeks: number): string {
+  const [y, m, d] = weekOf.split("-").map((n) => parseInt(n, 10));
+  const anchor = new Date(Date.UTC(y, m - 1, d));
+  anchor.setUTCDate(anchor.getUTCDate() + weeks * 7);
+  return anchor.toISOString().slice(0, 10);
+}
+
+export function currentWeekOf(): string {
+  return weekOfMondayNY();
+}
+
+// Lists orders for a given week, joined with customer + items + products.
+// Sorted at the DB by created_at desc; reconciliation pinning is applied
+// in the UI so it survives column-sort changes.
+export async function listOrders(weekOf: string): Promise<OrderRow[]> {
+  const supabase = createAdminClient();
+
+  const { data, error } = await supabase
+    .from("orders")
+    .select(
+      `id, customer_id, created_at, week_of, fulfillment_type,
+       delivery_address, delivery_preference, pickup_note, notes,
+       status, needs_reconciliation,
+       customers(id, name),
+       order_items(product_id, qty, unit_price_cents,
+         products(name, unit, qty_available))`,
+    )
+    .eq("week_of", weekOf)
+    .order("created_at", { ascending: false });
+
+  if (error) throw new Error(`listOrders: ${error.message}`);
+
+  return (data ?? [])
+    .filter((o) => o.customers !== null)
+    .map((o) => {
+      const c = o.customers as { id: string; name: string };
+      const items: OrderItem[] = ((o.order_items ?? []) as Array<{
+        product_id: string;
+        qty: number;
+        unit_price_cents: number;
+        products: { name: string; unit: string; qty_available: number } | null;
+      }>)
+        .filter((i) => i.products !== null)
+        .map((i) => ({
+          productId: i.product_id,
+          name: i.products!.name,
+          unit: i.products!.unit,
+          qty: i.qty,
+          unitPriceCents: i.unit_price_cents,
+          qtyAvailable: i.products!.qty_available,
+        }));
+      const totalCents = items.reduce(
+        (s, i) => s + i.qty * i.unitPriceCents,
+        0,
+      );
+      return {
+        id: o.id,
+        customerId: c.id,
+        customerName: c.name,
+        placedAt: o.created_at,
+        weekOf: o.week_of,
+        fulfillmentType: narrowFulfillment(o.fulfillment_type),
+        deliveryAddress: o.delivery_address,
+        deliveryPreference: o.delivery_preference,
+        pickupNote: o.pickup_note,
+        notes: o.notes,
+        status: narrowStatus(o.status),
+        needsReconciliation: o.needs_reconciliation,
+        items,
+        totalCents,
+      };
+    });
+}

--- a/src/lib/admin/orders-queries.ts
+++ b/src/lib/admin/orders-queries.ts
@@ -45,14 +45,6 @@ function narrowFulfillment(s: string): "pickup" | "delivery" {
   return s === "delivery" ? "delivery" : "pickup";
 }
 
-// Shifts a YYYY-MM-DD Monday by N weeks. Used by week-filter chips.
-export function shiftWeek(weekOf: string, weeks: number): string {
-  const [y, m, d] = weekOf.split("-").map((n) => parseInt(n, 10));
-  const anchor = new Date(Date.UTC(y, m - 1, d));
-  anchor.setUTCDate(anchor.getUTCDate() + weeks * 7);
-  return anchor.toISOString().slice(0, 10);
-}
-
 export function currentWeekOf(): string {
   return weekOfMondayNY();
 }

--- a/src/lib/week.ts
+++ b/src/lib/week.ts
@@ -45,6 +45,16 @@ export function weekOfMondayNY(now: Date = new Date()): string {
   return anchor.toISOString().slice(0, 10);
 }
 
+// Shifts a YYYY-MM-DD Monday by N weeks. Used by the orders-list
+// week-filter chips. UTC math is safe here because the input is already
+// anchored at midnight UTC by weekOfMondayNY.
+export function shiftWeek(weekOf: string, weeks: number): string {
+  const [y, m, d] = weekOf.split("-").map((n) => parseInt(n, 10));
+  const anchor = new Date(Date.UTC(y, m - 1, d));
+  anchor.setUTCDate(anchor.getUTCDate() + weeks * 7);
+  return anchor.toISOString().slice(0, 10);
+}
+
 // Shell chrome strings, Sunday-anchored, NY-time. Same tz discipline as
 // weekOfMondayNY — late-Saturday-NY (Sunday UTC) would otherwise jump the
 // admin shell into next week several hours early.

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1801,3 +1801,308 @@
   font-size: 0.82rem;
   color: var(--ink-500);
 }
+
+/* ── Orders (admin/orders, Phase 5.1) ───────────────────── */
+.ord-page { padding: 32px; max-width: 1280px; margin: 0 auto; }
+
+.ord-filters {
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 18px;
+}
+.chip-tab {
+  display: inline-flex; align-items: center; gap: 8px;
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: 999px;
+  padding: 7px 14px;
+  font-family: var(--sans);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--ink-700);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.1s, border-color 0.1s, color 0.1s;
+}
+.chip-tab:hover:not(:disabled) { background: var(--cream); border-color: var(--ink-300); }
+.chip-tab.is-on {
+  background: var(--ink-900); color: var(--paper); border-color: var(--ink-900);
+}
+.chip-tab.is-on .chip-count { background: rgba(251,250,245,0.18); color: var(--paper); }
+.chip-tab:disabled { opacity: 0.45; cursor: not-allowed; }
+.chip-count {
+  background: var(--ink-100);
+  color: var(--ink-500);
+  border-radius: 999px;
+  padding: 1px 8px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.ord-empty {
+  background: var(--paper);
+  border: 1px dashed var(--ink-200);
+  border-radius: var(--r-md);
+  padding: 32px;
+  text-align: center;
+  color: var(--ink-500);
+}
+
+.ord-tableCard {
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-md);
+  overflow: hidden;
+  margin-bottom: 28px;
+}
+.ord-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--sans);
+  font-size: 0.92rem;
+}
+.ord-table thead th {
+  background: var(--cream);
+  text-align: left;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-500);
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--ink-200);
+  white-space: nowrap;
+}
+.ord-sort-btn {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  cursor: pointer;
+}
+.ord-sort-btn:hover { color: var(--ink-900); }
+.ord-row {
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.ord-row td {
+  padding: 14px;
+  border-top: 1px solid var(--ink-200);
+  vertical-align: top;
+}
+.ord-row:hover { background: var(--cream); }
+.ord-row.is-open { background: var(--leaf-50); }
+.ord-row.needs-rec { background: rgba(178,59,46,0.04); }
+.ord-row.needs-rec:hover { background: rgba(178,59,46,0.08); }
+.ord-row.needs-rec.is-open { background: rgba(178,59,46,0.06); }
+
+.col-o-id     { width: 150px; }
+.col-o-cust   { width: 18%; min-width: 160px; }
+.col-o-when   { width: 110px; }
+.col-o-items  { width: 26%; min-width: 220px; }
+.col-o-ful    { width: 140px; }
+.col-o-total  { width: 90px; text-align: right; }
+.col-o-status { width: 200px; }
+
+.ord-num { font-size: 0.82rem; color: var(--ink-700); font-weight: 600; }
+.badge-recon {
+  display: inline-flex; align-items: center; gap: 4px;
+  margin-top: 6px;
+  background: var(--rose-600);
+  color: var(--paper);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.ord-cust-name { font-weight: 600; color: var(--ink-900); }
+.ord-when { font-size: 0.88rem; color: var(--ink-700); white-space: nowrap; }
+
+.ord-items-count { font-size: 0.92rem; color: var(--ink-900); margin-bottom: 2px; }
+.ord-items-count strong { font-weight: 700; }
+.ord-items-prev {
+  font-size: 0.82rem;
+  color: var(--ink-500);
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.ord-ful { display: flex; flex-direction: column; gap: 4px; align-items: flex-start; }
+.chip-ful {
+  display: inline-flex; align-items: center;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+.chip-ful.chip-delivery { background: var(--leaf-50); color: var(--leaf-700); border-color: var(--leaf-100); }
+.chip-ful.chip-pickup   { background: #FAF1DC; color: #8A6210; border-color: #EFD89A; }
+
+.ord-total {
+  font-family: var(--serif);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--ink-900);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.status-control { display: flex; flex-direction: column; align-items: flex-start; gap: 6px; }
+.pill {
+  display: inline-flex; align-items: center;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+.pill-new   { background: rgba(178,59,46,0.1); color: var(--rose-600); }
+.pill-ready { background: var(--leaf-50); color: var(--leaf-700); border: 1px solid var(--leaf-100); }
+.pill-done  { background: var(--ink-100); color: var(--ink-700); }
+
+.status-advance {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: var(--ink-900);
+  color: var(--paper);
+  border: none;
+  border-radius: var(--r-sm);
+  padding: 6px 12px;
+  font-family: var(--sans);
+  font-size: 0.82rem;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.1s;
+}
+.status-advance:hover:not(:disabled) { background: #2c2b27; }
+.status-advance:disabled { opacity: 0.5; cursor: default; }
+
+.ord-row-error {
+  margin-top: 4px;
+  font-size: 0.74rem;
+  color: var(--rose-600);
+}
+
+.ord-detail-row td {
+  padding: 0 !important;
+  border-top: 0 !important;
+  background: var(--leaf-50);
+}
+.ord-row.needs-rec + .ord-detail-row td { background: rgba(178,59,46,0.05); }
+
+.ord-detail {
+  padding: 22px 24px 24px;
+  border-top: 1px dashed var(--leaf-100);
+}
+.ord-detail-grid {
+  display: grid; grid-template-columns: 1.2fr 1fr;
+  gap: 32px;
+}
+.ord-detail-label {
+  font-size: 0.7rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--ink-500);
+  margin-bottom: 10px;
+}
+.ord-detail-list { list-style: none; padding: 0; margin: 0; }
+.ord-detail-list li {
+  display: grid;
+  grid-template-columns: 30px 1fr auto;
+  align-items: baseline;
+  gap: 10px;
+  padding: 8px 0;
+  border-top: 1px solid rgba(59,109,17,0.12);
+}
+.ord-detail-list li:first-child { border-top: 0; padding-top: 0; }
+.ord-detail-list li.is-oversold {
+  grid-template-columns: 30px 1fr;
+  grid-template-areas:
+    "qty name"
+    ".   flag"
+    ".   amt";
+}
+.ord-detail-list li.is-oversold .ord-li-qty  { grid-area: qty; color: var(--rose-600); }
+.ord-detail-list li.is-oversold .ord-li-name { grid-area: name; }
+.ord-detail-list li.is-oversold .ord-li-flag { grid-area: flag; }
+.ord-detail-list li.is-oversold .ord-li-amt  { grid-area: amt; justify-self: end; }
+.ord-li-qty { color: var(--leaf-700); font-weight: 600; }
+.ord-li-name { color: var(--ink-900); }
+.ord-li-unit { color: var(--ink-500); font-size: 0.85rem; }
+.ord-li-amt  { color: var(--ink-900); font-variant-numeric: tabular-nums; }
+.ord-li-flag {
+  display: inline-flex; align-items: center; gap: 5px;
+  background: var(--rose-600);
+  color: var(--paper);
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 4px;
+  margin-top: 4px;
+  width: fit-content;
+}
+
+.ord-li-total {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding-top: 12px;
+  margin-top: 8px;
+  border-top: 2px solid rgba(59,109,17,0.2);
+  font-weight: 600;
+}
+.ord-li-total .mono {
+  font-family: var(--serif);
+  font-size: 1.2rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.ord-detail-fulfill {
+  background: var(--paper);
+  border: 1px solid var(--leaf-100);
+  border-radius: var(--r-sm);
+  padding: 12px 14px;
+}
+.ord-detail-section .ord-detail-row {
+  display: grid; grid-template-columns: 80px 1fr;
+  gap: 12px;
+  padding: 4px 0;
+  font-size: 0.9rem;
+  border-top: 0;
+}
+.ord-detail-key {
+  font-size: 0.72rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--ink-500);
+}
+.ord-detail-note {
+  background: var(--paper);
+  border: 1px solid var(--leaf-100);
+  border-left: 3px solid var(--leaf-600);
+  border-radius: var(--r-sm);
+  padding: 10px 14px;
+  font-style: italic;
+  color: var(--ink-700);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.callout-warn {
+  display: block;
+  background: rgba(178,59,46,0.06);
+  border: 1px solid rgba(178,59,46,0.2);
+  color: var(--ink-900);
+  padding: 14px 16px;
+  border-radius: var(--r-sm);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+.callout-warn strong { color: var(--rose-600); }

--- a/tests/admin-orders.spec.ts
+++ b/tests/admin-orders.spec.ts
@@ -1,0 +1,269 @@
+import { test, expect } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+
+import { ADMIN_STORAGE_STATE, TEST_CUSTOMERS, TEST_PRODUCTS } from "./helpers";
+import { weekOfMondayNY } from "@/lib/week";
+
+function admin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+}
+
+async function customerIds(): Promise<{ farmStand: string; restaurant: string }> {
+  const sb = admin();
+  const { data, error } = await sb
+    .from("customers")
+    .select("id, token")
+    .in("token", [TEST_CUSTOMERS.farmStand.token, TEST_CUSTOMERS.restaurant.token]);
+  if (error || !data) throw new Error(`customerIds: ${error?.message ?? "no rows"}`);
+  const map = new Map(data.map((r) => [r.token, r.id]));
+  return {
+    farmStand: map.get(TEST_CUSTOMERS.farmStand.token)!,
+    restaurant: map.get(TEST_CUSTOMERS.restaurant.token)!,
+  };
+}
+
+async function clearWeek(weekOf: string): Promise<void> {
+  const sb = admin();
+  const ids = await customerIds();
+  await sb
+    .from("orders")
+    .delete()
+    .in("customer_id", [ids.farmStand, ids.restaurant])
+    .eq("week_of", weekOf);
+}
+
+type SeedOrderInput = {
+  customerId: string;
+  weekOf: string;
+  fulfillmentType: "pickup" | "delivery";
+  status?: "new" | "ready" | "picked-up" | "delivered";
+  needsReconciliation?: boolean;
+  items: Array<{ productId: string; qty: number; unitPriceCents: number }>;
+};
+
+async function seedOrder(input: SeedOrderInput): Promise<string> {
+  const sb = admin();
+  const { data: order, error: oErr } = await sb
+    .from("orders")
+    .insert({
+      customer_id: input.customerId,
+      week_of: input.weekOf,
+      fulfillment_type: input.fulfillmentType,
+      delivery_address:
+        input.fulfillmentType === "delivery" ? "123 Test St" : null,
+      delivery_preference:
+        input.fulfillmentType === "delivery" ? "Front door" : null,
+      status: input.status ?? "new",
+      needs_reconciliation: input.needsReconciliation ?? false,
+    })
+    .select("id")
+    .single();
+  if (oErr || !order) throw new Error(`seedOrder: ${oErr?.message}`);
+
+  const rows = input.items.map((i) => ({
+    order_id: order.id,
+    product_id: i.productId,
+    qty: i.qty,
+    unit_price_cents: i.unitPriceCents,
+  }));
+  const { error: iErr } = await sb.from("order_items").insert(rows);
+  if (iErr) throw new Error(`seedOrder items: ${iErr.message}`);
+  return order.id;
+}
+
+test.describe("admin orders list", () => {
+  test.use({ storageState: ADMIN_STORAGE_STATE });
+
+  const thisWeek = weekOfMondayNY();
+
+  test.beforeEach(async () => {
+    await clearWeek(thisWeek);
+  });
+
+  test.afterAll(async () => {
+    await clearWeek(thisWeek);
+  });
+
+  test("renders current-week orders with totals and item counts", async ({ page }) => {
+    const ids = await customerIds();
+    const orderId = await seedOrder({
+      customerId: ids.farmStand,
+      weekOf: thisWeek,
+      fulfillmentType: "pickup",
+      items: [
+        { productId: TEST_PRODUCTS.kale.id, qty: 2, unitPriceCents: 300 },
+        { productId: TEST_PRODUCTS.eggs.id, qty: 1, unitPriceCents: 600 },
+      ],
+    });
+
+    await page.goto("/admin/orders");
+
+    const row = page.locator(`tr.ord-row[data-order-id="${orderId}"]`);
+    await expect(row).toHaveCount(1);
+    await expect(row.locator(".ord-cust-name")).toHaveText(TEST_CUSTOMERS.farmStand.name);
+    await expect(row.locator(".ord-total")).toHaveText("$12.00");
+    await expect(row.locator(".ord-items-count")).toContainText("2");
+    await expect(row.locator(".chip-ful")).toHaveText("Pickup");
+  });
+
+  test("needs_reconciliation row pins to the top regardless of sort", async ({ page }) => {
+    const ids = await customerIds();
+    // Restaurant placed earlier and clean — would normally sort first by placed-desc.
+    const restaurantOrderId = await seedOrder({
+      customerId: ids.restaurant,
+      weekOf: thisWeek,
+      fulfillmentType: "delivery",
+      items: [{ productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 }],
+    });
+    // Farm stand placed later (so newer) AND flagged. With "placed desc" default
+    // the newer farm-stand row would naturally appear first anyway — re-sort by
+    // total ascending below to flip the natural order and prove the pin holds.
+    const farmOrderId = await seedOrder({
+      customerId: ids.farmStand,
+      weekOf: thisWeek,
+      fulfillmentType: "pickup",
+      needsReconciliation: true,
+      items: [{ productId: TEST_PRODUCTS.honey.id, qty: 5, unitPriceCents: 1200 }],
+    });
+
+    await page.goto("/admin/orders");
+
+    // Sort by Total ascending — farm-stand total ($60) > restaurant ($3), so by
+    // pure sort the restaurant row should come first. Reconciliation pin must
+    // override.
+    await page.getByRole("button", { name: /^Total/i }).click();
+
+    const rowIds = await page
+      .locator("tr.ord-row")
+      .evaluateAll((els) =>
+        (els as HTMLElement[]).map((el) => el.dataset.orderId ?? ""),
+      );
+    expect(rowIds[0]).toBe(farmOrderId);
+    expect(rowIds).toContain(restaurantOrderId);
+
+    await expect(
+      page.locator(`tr.ord-row[data-order-id="${farmOrderId}"] .badge-recon`),
+    ).toBeVisible();
+  });
+
+  test("delivery order: new → ready → delivered persists across reload", async ({ page }) => {
+    const ids = await customerIds();
+    const orderId = await seedOrder({
+      customerId: ids.restaurant,
+      weekOf: thisWeek,
+      fulfillmentType: "delivery",
+      items: [{ productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 }],
+    });
+
+    await page.goto("/admin/orders");
+    const row = page.locator(`tr.ord-row[data-order-id="${orderId}"]`);
+    await expect(row).toHaveAttribute("data-status", "new");
+
+    const sb = admin();
+
+    await row.getByRole("button", { name: /mark ready/i }).click();
+    await expect(row).toHaveAttribute("data-status", "ready", { timeout: 5000 });
+    // Wait for first transition to commit to DB before chaining the next click.
+    // useTransition + revalidatePath can swallow a second click while the first
+    // is mid-flight; polling the DB ensures the action's round-trip completed.
+    await expect
+      .poll(
+        async () => {
+          const { data } = await sb.from("orders").select("status").eq("id", orderId).single();
+          return data?.status ?? null;
+        },
+        { timeout: 5000 },
+      )
+      .toBe("ready");
+
+    const deliveredBtn = row.getByRole("button", { name: /delivered/i });
+    await expect(deliveredBtn).toBeEnabled();
+    await deliveredBtn.click();
+    await expect(row).toHaveAttribute("data-status", "delivered", { timeout: 5000 });
+    await expect
+      .poll(
+        async () => {
+          const { data } = await sb.from("orders").select("status").eq("id", orderId).single();
+          return data?.status ?? null;
+        },
+        { timeout: 5000 },
+      )
+      .toBe("delivered");
+
+    // Hard navigation (not page.reload — RSC streaming can hang reload after
+    // chained server actions in dev mode).
+    await page.goto("/admin/orders");
+    const reloadedRow = page.locator(`tr.ord-row[data-order-id="${orderId}"]`);
+    await expect(reloadedRow).toHaveAttribute("data-status", "delivered");
+    await expect(reloadedRow.locator(".pill-done")).toHaveText("Delivered");
+  });
+
+  test("pickup order: ready advances to picked-up (not delivered)", async ({ page }) => {
+    const ids = await customerIds();
+    const orderId = await seedOrder({
+      customerId: ids.farmStand,
+      weekOf: thisWeek,
+      fulfillmentType: "pickup",
+      status: "ready",
+      items: [{ productId: TEST_PRODUCTS.honey.id, qty: 1, unitPriceCents: 1200 }],
+    });
+
+    await page.goto("/admin/orders");
+    const row = page.locator(`tr.ord-row[data-order-id="${orderId}"]`);
+    await expect(row).toHaveAttribute("data-status", "ready");
+
+    // Pickup orders show the "Picked up" advance button, not "Delivered".
+    await expect(row.getByRole("button", { name: /delivered/i })).toHaveCount(0);
+    await row.getByRole("button", { name: /picked up/i }).click();
+    await expect(row).toHaveAttribute("data-status", "picked-up", { timeout: 5000 });
+
+    // DB confirmation
+    const sb = admin();
+    await expect
+      .poll(
+        async () => {
+          const { data } = await sb
+            .from("orders")
+            .select("status")
+            .eq("id", orderId)
+            .single();
+          return data?.status ?? null;
+        },
+        { timeout: 5000 },
+      )
+      .toBe("picked-up");
+  });
+
+  test("expand row reveals line items, customer note, and reconciliation callout", async ({ page }) => {
+    const ids = await customerIds();
+    const sb = admin();
+    const orderId = await seedOrder({
+      customerId: ids.farmStand,
+      weekOf: thisWeek,
+      fulfillmentType: "pickup",
+      needsReconciliation: true,
+      items: [{ productId: TEST_PRODUCTS.kale.id, qty: 4, unitPriceCents: 300 }],
+    });
+    await sb
+      .from("orders")
+      .update({ notes: "Front gate is sticky — knock twice." })
+      .eq("id", orderId);
+
+    await page.goto("/admin/orders");
+    const row = page.locator(`tr.ord-row[data-order-id="${orderId}"]`);
+    await row.click();
+
+    const detail = page.locator("tr.ord-detail-row .ord-detail");
+    await expect(detail).toBeVisible();
+    await expect(detail.locator(".ord-li-name")).toContainText("Kale");
+    await expect(detail.locator(".ord-li-total .mono")).toHaveText("$12.00");
+    await expect(detail.locator(".ord-detail-note")).toContainText("Front gate is sticky");
+    await expect(detail.locator(".callout-warn")).toBeVisible();
+    await expect(detail.locator(".callout-warn button", { hasText: /adjust quantities/i })).toBeDisabled();
+    await expect(detail.locator(".callout-warn button", { hasText: /mark resolved/i })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
Closes #97. New `/admin/orders` route with week filter, sortable columns, per-row status advance (DEC-010), expandable detail, and reconciliation pinning (DEC-022).

## Files changed
- `src/lib/admin/orders-queries.ts` — `listOrders(weekOf)` joining orders → customers → order_items → products with line totals.
- `src/actions/advance-order-status.ts` — DEC-010 transition guard; pickup/delivery terminal state pinned by `fulfillment_type`. Cookie client → `admin_all_orders` RLS gate.
- `src/lib/week.ts` — new `shiftWeek` helper colocated with `weekOfMondayNY`.
- `src/app/(admin)/admin/orders/page.tsx` — server component, `?week=this|last`.
- `src/components/admin/orders-page.tsx` — client; chip-tabs, sortable headers, expand state, reconciliation pin in the sort comparator.
- `src/components/admin/order-row.tsx` — client; optimistic status flip with rollback.
- `src/components/admin/order-detail.tsx` — line items, fulfillment block, reconciliation callout.
- `src/styles/app.css` — Orders section (app.css-only rule held).
- `tests/admin-orders.spec.ts` — 5 desktop tests.

## Code review
Three of eight findings addressed in `b2e4e01`:
- Extracted `OrderDetail` so `order-row.tsx` is back under the 200-line cap.
- Moved `shiftWeek` into `src/lib/week.ts` (one home for week math).
- Added a comment in `advanceOrderStatus` naming the RLS policy it leans on.

Skipped (rationale):
- Relational-embed `as` cast — matches the established `send-queue-queries.ts` pattern; flagging just here would be inconsistent.
- Counts-only query for off-chip week count — 7 customers, the join cost is noise.
- `error.tsx` for the route — V1 doesn't add fallbacks for scenarios that haven't bitten yet (CLAUDE.md).
- Auth-on-server-action gap — pre-existing pattern in `recordSend`; not a regression.
- TODO comments on the three disabled-stub controls — tracked in the Phase 6 plan rather than inline.

## Test plan
- `/admin/orders` with no orders this week → empty state renders.
- Seed an order with `needs_reconciliation=true` and another without; sort by Total ascending → flagged row stays at the top.
- Place a delivery order → click "Mark ready" → "Delivered ✓"; reload → status persists. Pickup order shows "Picked up ✓" (no "Delivered" button).
- Click a row → detail panel reveals line items, customer note, and reconciliation callout (Adjust quantities / Mark resolved disabled).
- Switch to "Last week" chip → URL gets `?week=last`, list updates.
- Repoint Vercel preview to `task/5.1-orders-list`; verify the same on `preview.baybranchfarm.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)