### PR TITLE
Phase 5 recovery — re-land #103/#104/#105 code (closes #114)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -48,7 +48,9 @@
       "Bash(NOTIFICATIONS_ENABLED=false npm start *)",
       "Bash(pkill -f \"playwright test\")",
       "Bash(awk '{print $NF}')",
-      "Skill(its-dead)"
+      "Skill(its-dead)",
+      "Bash(disown)",
+      "Bash(NOTIFICATIONS_ENABLED=false npx playwright test tests/admin-orders.spec.ts tests/admin-orders-export.spec.ts tests/orders-flow.spec.ts tests/notifications-flow.spec.ts tests/admin-shell.spec.ts --project=desktop)"
     ]
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,13 +23,25 @@ export default defineConfig({
     {
       name: "tablet",
       // Admin is desktop-only (DEC-019); admin specs run on desktop project only.
-      testIgnore: ["**/admin*.spec.ts"],
+      // notifications-flow.spec.ts + orders-flow.spec.ts exercise admin pages,
+      // so they belong in the same admin-desktop-only bucket.
+      testIgnore: [
+        "**/admin*.spec.ts",
+        "**/notifications-flow.spec.ts",
+        "**/orders-flow.spec.ts",
+      ],
       use: { ...devices["Desktop Chrome"], viewport: { width: 768, height: 1024 } },
     },
     {
       name: "mobile",
       // Admin is desktop-only (DEC-019); admin specs run on desktop project only.
-      testIgnore: ["**/admin*.spec.ts"],
+      // notifications-flow.spec.ts + orders-flow.spec.ts exercise admin pages,
+      // so they belong in the same admin-desktop-only bucket.
+      testIgnore: [
+        "**/admin*.spec.ts",
+        "**/notifications-flow.spec.ts",
+        "**/orders-flow.spec.ts",
+      ],
       use: { ...devices["iPhone 13"], browserName: "webkit", viewport: { width: 375, height: 812 } },
     },
   ],

--- a/src/actions/sign-out.ts
+++ b/src/actions/sign-out.ts
@@ -3,9 +3,14 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 
+// scope: "local" — sign out this session only, not every session for the
+// user. Default ("global") revokes the refresh token server-side, which is
+// surprising for an operator UI (kicks Annabel out of her phone if she
+// signs out on the laptop) and breaks Playwright's shared storageState
+// across specs that run after admin-shell's sign-out test.
 export async function signOut() {
   const supabase = await createClient();
-  const { error } = await supabase.auth.signOut();
+  const { error } = await supabase.auth.signOut({ scope: "local" });
   if (error) {
     redirect("/login?error=signout_failed");
   }

--- a/src/app/(admin)/admin/orders/page.tsx
+++ b/src/app/(admin)/admin/orders/page.tsx
@@ -34,6 +34,7 @@ export default async function OrdersRoute({
     <OrdersPage
       orders={orders}
       weekFilter={weekFilter}
+      weekOf={selectedWeek}
       thisWeekCount={thisWeekCount}
       lastWeekCount={lastWeekCount}
     />

--- a/src/components/admin/export-orders-button.tsx
+++ b/src/components/admin/export-orders-button.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { csvFilename, toCsv, toTsv } from "@/lib/admin/export-orders";
+import type { OrderRow } from "@/lib/admin/orders-queries";
+
+type Props = {
+  orders: OrderRow[];
+  weekOf: string;
+};
+
+export function ExportOrdersButton({ orders, weekOf }: Props) {
+  const [open, setOpen] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const disabled = orders.length === 0;
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  useEffect(() => {
+    if (!feedback) return;
+    const id = window.setTimeout(() => setFeedback(null), 4000);
+    return () => window.clearTimeout(id);
+  }, [feedback]);
+
+  function downloadCsv() {
+    const blob = new Blob([toCsv(orders)], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = csvFilename(weekOf);
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+    setOpen(false);
+    setFeedback("CSV downloaded");
+  }
+
+  async function copyTsv() {
+    try {
+      await navigator.clipboard.writeText(toTsv(orders));
+      setFeedback("Copied to clipboard");
+    } catch (err) {
+      console.warn("copyTsv: clipboard write failed", err);
+      setFeedback("Clipboard blocked — try CSV");
+    }
+    setOpen(false);
+  }
+
+  return (
+    <div className="split-btn-wrap" ref={wrapRef} data-testid="export-orders">
+      <button
+        type="button"
+        className="split-btn-main"
+        onClick={() => setOpen((o) => !o)}
+        disabled={disabled}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <span>Export to Wave</span>
+        <span className="split-btn-divider" aria-hidden="true"></span>
+        <span className="split-btn-chev" aria-hidden="true">▾</span>
+      </button>
+      {open && (
+        <>
+          <div
+            className="split-scrim"
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          ></div>
+          {/* Plain popover with two buttons — not a true ARIA menu
+              (no arrow-key nav, no focus trap, no roving tabindex). Avoid
+              role="menu" so assistive tech doesn't promise behavior we
+              don't implement. */}
+          <div className="split-menu">
+            <button
+              type="button"
+              className="split-item"
+              onClick={downloadCsv}
+            >
+              <div>
+                <div className="split-item-title">Download CSV</div>
+                <div className="split-item-sub">Open in Wave&rsquo;s import flow.</div>
+              </div>
+            </button>
+            <button
+              type="button"
+              className="split-item"
+              onClick={copyTsv}
+            >
+              <div>
+                <div className="split-item-title">Copy as TSV</div>
+                <div className="split-item-sub">Paste into a spreadsheet directly.</div>
+              </div>
+            </button>
+          </div>
+        </>
+      )}
+      {feedback && (
+        <span className="export-feedback" role="status" aria-live="polite">
+          {feedback}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/orders-page.tsx
+++ b/src/components/admin/orders-page.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import { OrderRow } from "@/components/admin/order-row";
+import { ExportOrdersButton } from "@/components/admin/export-orders-button";
 import type { OrderRow as OrderRowData } from "@/lib/admin/orders-queries";
 
 type SortKey = "placed" | "customer" | "total";
@@ -12,6 +13,7 @@ type SortDir = "asc" | "desc";
 type Props = {
   orders: OrderRowData[];
   weekFilter: "this" | "last";
+  weekOf: string;
   thisWeekCount: number;
   lastWeekCount: number;
 };
@@ -54,7 +56,7 @@ function SortHeader({
   );
 }
 
-export function OrdersPage({ orders, weekFilter, thisWeekCount, lastWeekCount }: Props) {
+export function OrdersPage({ orders, weekFilter, weekOf, thisWeekCount, lastWeekCount }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -103,6 +105,9 @@ export function OrdersPage({ orders, weekFilter, thisWeekCount, lastWeekCount }:
             {reconCount > 0 && ` · ${reconCount} need reconciliation`}
           </div>
           <h1 className="page-title">Orders</h1>
+        </div>
+        <div className="page-actions">
+          <ExportOrdersButton orders={sorted} weekOf={weekOf} />
         </div>
       </div>
 

--- a/src/lib/admin/export-orders.ts
+++ b/src/lib/admin/export-orders.ts
@@ -1,0 +1,115 @@
+// Wave-compatible export for the admin orders list (Phase 5.2, DEC-016).
+// Two formats from the same row shape:
+//   - CSV  → file download (RFC 4180 quoting)
+//   - TSV  → clipboard paste into Wave's Sheets import
+//
+// Columns match Wave's Sheets import exactly (7 cols, no Invoice Number —
+// Wave assigns the invoice number itself when the sheet is imported):
+//   Customer Name | Item Number | Quantity | Unit Price | Description |
+//   Sales Taxes  | Messages
+//
+// HEADER ROW IS INTENTIONALLY OMITTED. Wave's import flow expects raw data
+// rows; Annabel's sheet template already labels the columns. Emitting a
+// header would import as a phantom invoice for a customer named
+// "Customer Name." EXPORT_COLUMNS stays exported for documentation +
+// test assertions.
+//
+// One row per LINE ITEM. Per-product mapping:
+//   Wave "Item Number" ← products.description (used as a slug, e.g.
+//     "KALE-BUNCH" — Annabel populates this in the inventory editor).
+//     Empty cell when the slug isn't set; she fills it in Wave before
+//     posting.
+//   Wave "Description" ← products.name (the human-readable product name).
+//   products.unit is no longer in the export; it lives in the customer-
+//     facing UI and the admin row detail, not the invoice.
+//
+// Sales Taxes + Messages are intentionally blank (no tax in V1, no per-line
+// note channel from the customer order form).
+
+import type { OrderRow } from "@/lib/admin/orders-queries";
+
+export const EXPORT_COLUMNS = [
+  "Customer Name",
+  "Item Number",
+  "Quantity",
+  "Unit Price",
+  "Description",
+  "Sales Taxes",
+  "Messages",
+] as const;
+
+type ExportRow = {
+  customerName: string;
+  itemNumber: string;
+  quantity: string;
+  unitPrice: string;
+  description: string;
+  salesTaxes: string;
+  messages: string;
+};
+
+function money(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+export function ordersToRows(orders: OrderRow[]): ExportRow[] {
+  const rows: ExportRow[] = [];
+  for (const o of orders) {
+    for (const i of o.items) {
+      rows.push({
+        customerName: o.customerName,
+        itemNumber: i.description ?? "",
+        quantity: String(i.qty),
+        unitPrice: money(i.unitPriceCents),
+        description: i.name,
+        salesTaxes: "",
+        messages: "",
+      });
+    }
+  }
+  return rows;
+}
+
+// RFC 4180: quote if the field contains a comma, double-quote, or newline.
+// Double internal quotes by doubling them.
+function csvEscape(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+// TSV: tab-separated, no field quoting in the typical paste-to-Sheets flow.
+// Tabs and newlines inside fields would break the row shape — strip them.
+// Bushel product names are short and operator-entered; no tabs expected.
+function tsvEscape(value: string): string {
+  return value.replace(/[\t\n\r]+/g, " ");
+}
+
+function rowToValues(row: ExportRow): string[] {
+  return [
+    row.customerName,
+    row.itemNumber,
+    row.quantity,
+    row.unitPrice,
+    row.description,
+    row.salesTaxes,
+    row.messages,
+  ];
+}
+
+export function toCsv(orders: OrderRow[]): string {
+  return ordersToRows(orders)
+    .map((row) => rowToValues(row).map(csvEscape).join(","))
+    .join("\r\n");
+}
+
+export function toTsv(orders: OrderRow[]): string {
+  return ordersToRows(orders)
+    .map((row) => rowToValues(row).map(tsvEscape).join("\t"))
+    .join("\n");
+}
+
+export function csvFilename(weekOf: string): string {
+  return `bushel-orders-${weekOf}.csv`;
+}

--- a/src/lib/admin/orders-queries.ts
+++ b/src/lib/admin/orders-queries.ts
@@ -14,6 +14,10 @@ export const ORDER_STATUSES: OrderStatus[] = [
 export type OrderItem = {
   productId: string;
   name: string;
+  // products.description doubles as the Wave-export "Item Number" slug per the
+  // 5.2 mapping (e.g. "KALE-BUNCH"). Null when unset — Wave just gets a blank
+  // Item Number cell, which Annabel fills before posting the invoice.
+  description: string | null;
   unit: string;
   qty: number;
   unitPriceCents: number;
@@ -63,7 +67,7 @@ export async function listOrders(weekOf: string): Promise<OrderRow[]> {
        status, needs_reconciliation,
        customers(id, name),
        order_items(product_id, qty, unit_price_cents,
-         products(name, unit, qty_available))`,
+         products(name, description, unit, qty_available))`,
     )
     .eq("week_of", weekOf)
     .order("created_at", { ascending: false });
@@ -78,12 +82,18 @@ export async function listOrders(weekOf: string): Promise<OrderRow[]> {
         product_id: string;
         qty: number;
         unit_price_cents: number;
-        products: { name: string; unit: string; qty_available: number } | null;
+        products: {
+          name: string;
+          description: string | null;
+          unit: string;
+          qty_available: number;
+        } | null;
       }>)
         .filter((i) => i.products !== null)
         .map((i) => ({
           productId: i.product_id,
           name: i.products!.name,
+          description: i.products!.description,
           unit: i.products!.unit,
           qty: i.qty,
           unitPriceCents: i.unit_price_cents,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2106,3 +2106,63 @@
   line-height: 1.5;
 }
 .callout-warn strong { color: var(--rose-600); }
+
+/* Split button — Export to Wave (Phase 5.2) */
+.split-btn-wrap { position: relative; display: inline-flex; align-items: center; gap: 12px; }
+.split-btn-main {
+  display: inline-flex; align-items: center; gap: 8px;
+  background: var(--leaf-600);
+  color: var(--paper);
+  border: none;
+  border-radius: var(--r-sm);
+  padding: 0 16px;
+  font-family: var(--sans);
+  font-size: 0.95rem;
+  font-weight: 600;
+  height: 44px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.1s;
+}
+.split-btn-main:hover:not(:disabled) { background: var(--leaf-700); }
+.split-btn-main:disabled { opacity: 0.5; cursor: not-allowed; }
+.split-btn-divider {
+  width: 1px;
+  height: 24px;
+  background: rgba(255,255,255,0.25);
+  margin: 0 4px;
+}
+.split-btn-chev { font-size: 0.7rem; }
+
+.split-scrim { position: fixed; inset: 0; z-index: 30; }
+.split-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  background: var(--paper);
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-sm);
+  box-shadow: 0 10px 30px -8px rgba(31,30,26,0.2);
+  width: 240px;
+  padding: 6px;
+  z-index: 40;
+}
+.split-item {
+  display: block;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 10px 12px;
+  text-align: left;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: var(--sans);
+}
+.split-item:hover { background: var(--leaf-50); }
+.split-item-title { font-weight: 600; color: var(--ink-900); margin-bottom: 2px; }
+.split-item-sub { font-size: 0.8rem; color: var(--ink-500); }
+
+.export-feedback {
+  font-size: 0.82rem;
+  color: var(--ink-700);
+}

--- a/tests/admin-orders-export.spec.ts
+++ b/tests/admin-orders-export.spec.ts
@@ -1,0 +1,316 @@
+import { test, expect } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+
+import { ADMIN_STORAGE_STATE, TEST_CUSTOMERS, TEST_PRODUCTS } from "./helpers";
+import { weekOfMondayNY } from "@/lib/week";
+import {
+  EXPORT_COLUMNS,
+  ordersToRows,
+  toCsv,
+  toTsv,
+} from "@/lib/admin/export-orders";
+import type { OrderRow } from "@/lib/admin/orders-queries";
+
+function admin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+}
+
+async function customerIds(): Promise<{ farmStand: string; restaurant: string }> {
+  const sb = admin();
+  const { data, error } = await sb
+    .from("customers")
+    .select("id, token")
+    .in("token", [TEST_CUSTOMERS.farmStand.token, TEST_CUSTOMERS.restaurant.token]);
+  if (error || !data) throw new Error(`customerIds: ${error?.message ?? "no rows"}`);
+  const map = new Map(data.map((r) => [r.token, r.id]));
+  return {
+    farmStand: map.get(TEST_CUSTOMERS.farmStand.token)!,
+    restaurant: map.get(TEST_CUSTOMERS.restaurant.token)!,
+  };
+}
+
+async function clearWeek(weekOf: string): Promise<void> {
+  const sb = admin();
+  const ids = await customerIds();
+  await sb
+    .from("orders")
+    .delete()
+    .in("customer_id", [ids.farmStand, ids.restaurant])
+    .eq("week_of", weekOf);
+}
+
+type SeedOrderInput = {
+  customerId: string;
+  weekOf: string;
+  fulfillmentType: "pickup" | "delivery";
+  items: Array<{ productId: string; qty: number; unitPriceCents: number }>;
+};
+
+async function seedOrder(input: SeedOrderInput): Promise<string> {
+  const sb = admin();
+  const { data: order } = await sb
+    .from("orders")
+    .insert({
+      customer_id: input.customerId,
+      week_of: input.weekOf,
+      fulfillment_type: input.fulfillmentType,
+      status: "new",
+    })
+    .select("id")
+    .single();
+  await sb.from("order_items").insert(
+    input.items.map((i) => ({
+      order_id: order!.id,
+      product_id: i.productId,
+      qty: i.qty,
+      unit_price_cents: i.unitPriceCents,
+    })),
+  );
+  return order!.id;
+}
+
+// --- unit-style tests (no `page`) ----------------------------------------
+
+function mockOrder(over: Partial<OrderRow> = {}): OrderRow {
+  return {
+    id: "order-1",
+    customerId: "cust-1",
+    customerName: "Test Customer",
+    placedAt: "2026-05-12T15:30:00Z",
+    weekOf: "2026-05-11",
+    fulfillmentType: "pickup",
+    deliveryAddress: null,
+    deliveryPreference: null,
+    pickupNote: null,
+    notes: null,
+    status: "new",
+    needsReconciliation: false,
+    items: [
+      {
+        productId: "p1",
+        name: "Kale",
+        description: "KALE-BUNCH",
+        unit: "bunch",
+        qty: 2,
+        unitPriceCents: 300,
+        qtyAvailable: 10,
+      },
+    ],
+    totalCents: 600,
+    ...over,
+  };
+}
+
+test("toCsv: no header row; line items only, RFC 4180 quoting", () => {
+  const csv = toCsv([
+    mockOrder({
+      customerName: 'Bar Cento, Cleveland "Westside"',
+      items: [
+        {
+          productId: "p1",
+          name: "Heirloom\ntomatoes",
+          description: "HEIRLOOM-LB",
+          unit: "lb",
+          qty: 3,
+          unitPriceCents: 550,
+          qtyAvailable: 10,
+        },
+      ],
+    }),
+  ]);
+  // First (and only) data row — header is intentionally omitted so Wave
+  // doesn't import a phantom "Customer Name" invoice.
+  const lines = csv.split("\r\n");
+  expect(lines).toHaveLength(1);
+  // EXPORT_COLUMNS still exists as a doc constant — confirm the data line
+  // is NOT a header.
+  expect(lines[0]).not.toBe(EXPORT_COLUMNS.join(","));
+  // Comma in customer name → quoted; embedded quotes doubled
+  expect(lines[0]).toContain('"Bar Cento, Cleveland ""Westside"""');
+  // Newline in product name (now the Description column) → quoted, preserved
+  expect(lines[0]).toContain('"Heirloom\ntomatoes"');
+  // Item Number column carries the slug
+  expect(lines[0]).toContain(",HEIRLOOM-LB,3,5.50,");
+});
+
+test("toCsv: empty Item Number when product description (slug) is null", () => {
+  const csv = toCsv([
+    mockOrder({
+      customerName: "Plum Café",
+      items: [
+        {
+          productId: "p1",
+          name: "Garlic scapes",
+          description: null,
+          unit: "bunch",
+          qty: 4,
+          unitPriceCents: 400,
+          qtyAvailable: 10,
+        },
+      ],
+    }),
+  ]);
+  const lines = csv.split("\r\n");
+  // Customer Name, then empty Item Number (",,"), then Quantity, Unit Price, ...
+  expect(lines).toHaveLength(1);
+  expect(lines[0]).toBe("Plum Café,,4,4.00,Garlic scapes,,");
+});
+
+test("toCsv: one row per line item; multi-item order keeps per-line slugs", () => {
+  const csv = toCsv([
+    mockOrder({
+      customerName: "A",
+      items: [
+        { productId: "p1", name: "Kale", description: "KALE-BU", unit: "bunch", qty: 1, unitPriceCents: 300, qtyAvailable: 5 },
+        { productId: "p2", name: "Eggs", description: "EGG-DZ", unit: "dozen", qty: 2, unitPriceCents: 600, qtyAvailable: 5 },
+      ],
+    }),
+    mockOrder({
+      customerName: "B",
+      items: [
+        { productId: "p3", name: "Honey", description: "HON-JAR", unit: "jar", qty: 1, unitPriceCents: 1200, qtyAvailable: 5 },
+      ],
+    }),
+  ]);
+  const lines = csv.split("\r\n");
+  expect(lines).toHaveLength(3); // 3 line items, no header
+  expect(lines[0]).toBe("A,KALE-BU,1,3.00,Kale,,");
+  expect(lines[1]).toBe("A,EGG-DZ,2,6.00,Eggs,,");
+  expect(lines[2]).toBe("B,HON-JAR,1,12.00,Honey,,");
+});
+
+test("toCsv: empty orders → empty string (no header)", () => {
+  expect(toCsv([])).toBe("");
+});
+
+test("toTsv: tab-separated, strips embedded tabs/newlines from fields", () => {
+  const tsv = toTsv([
+    mockOrder({
+      customerName: "Has\ttab",
+      items: [
+        {
+          productId: "p1",
+          name: "Has\nnewline",
+          description: "SLUG-WITH\nNEWLINE",
+          unit: "lb",
+          qty: 1,
+          unitPriceCents: 100,
+          qtyAvailable: 5,
+        },
+      ],
+    }),
+  ]);
+  const lines = tsv.split("\n");
+  // No header — one data row only.
+  expect(lines).toHaveLength(1);
+  expect(lines[0]).toContain("Has tab");
+  expect(lines[0]).toContain("Has newline");
+  expect(lines[0]).toContain("SLUG-WITH NEWLINE");
+});
+
+test("ordersToRows: itemNumber = product description (slug); description = product name", () => {
+  const rows = ordersToRows([
+    mockOrder({
+      items: [
+        { productId: "p", name: "Honey", description: "HONEY-JAR", unit: "jar", qty: 7, unitPriceCents: 125, qtyAvailable: 10 },
+      ],
+    }),
+  ]);
+  expect(rows[0].itemNumber).toBe("HONEY-JAR");
+  expect(rows[0].description).toBe("Honey");
+  expect(rows[0].quantity).toBe("7");
+  expect(rows[0].unitPrice).toBe("1.25");
+  expect(rows[0].salesTaxes).toBe("");
+  expect(rows[0].messages).toBe("");
+});
+
+// --- integration tests (admin page) --------------------------------------
+
+test.describe("admin orders export — UI", () => {
+  test.use({ storageState: ADMIN_STORAGE_STATE });
+
+  const thisWeek = weekOfMondayNY();
+
+  test.beforeEach(async () => {
+    await clearWeek(thisWeek);
+  });
+
+  test.afterAll(async () => {
+    await clearWeek(thisWeek);
+  });
+
+  // Set a product slug for the download test so we exercise the non-empty
+  // Item Number path. Restored in afterEach.
+  async function setProductSlug(productId: string, slug: string | null): Promise<void> {
+    await admin().from("products").update({ description: slug }).eq("id", productId);
+  }
+
+  test.afterEach(async () => {
+    // Restore seed shape — description is null for all TEST_PRODUCTS in seed.
+    await setProductSlug(TEST_PRODUCTS.kale.id, null);
+    await setProductSlug(TEST_PRODUCTS.honey.id, null);
+  });
+
+  test("Download CSV produces a file with the expected header + body", async ({ page }) => {
+    const ids = await customerIds();
+    await setProductSlug(TEST_PRODUCTS.kale.id, "KALE-BU");
+    await seedOrder({
+      customerId: ids.farmStand,
+      weekOf: thisWeek,
+      fulfillmentType: "pickup",
+      items: [
+        { productId: TEST_PRODUCTS.kale.id, qty: 2, unitPriceCents: 300 },
+      ],
+    });
+
+    await page.goto("/admin/orders");
+    await page.getByRole("button", { name: /export to wave/i }).click();
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.getByRole("button", { name: /download csv/i }).click(),
+    ]);
+    expect(download.suggestedFilename()).toBe(`bushel-orders-${thisWeek}.csv`);
+    const stream = await download.createReadStream();
+    let text = "";
+    for await (const chunk of stream) text += chunk.toString();
+    const lines = text.split("\r\n");
+    // No header row — first line is the seeded order's data.
+    const line = lines.find((l) => l.includes(TEST_CUSTOMERS.farmStand.name));
+    expect(line).toBe(`${TEST_CUSTOMERS.farmStand.name},KALE-BU,2,3.00,Kale,,`);
+  });
+
+  test("Copy as TSV writes to clipboard; empty Item Number when slug is null", async ({ page, context }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    const ids = await customerIds();
+    // Honey has no slug (seed default) — assert the Item Number cell is empty.
+    await seedOrder({
+      customerId: ids.restaurant,
+      weekOf: thisWeek,
+      fulfillmentType: "delivery",
+      items: [
+        { productId: TEST_PRODUCTS.honey.id, qty: 1, unitPriceCents: 1200 },
+      ],
+    });
+
+    await page.goto("/admin/orders");
+    await page.getByRole("button", { name: /export to wave/i }).click();
+    await page.getByRole("button", { name: /copy as tsv/i }).click();
+    await expect(page.getByText(/copied to clipboard/i)).toBeVisible({ timeout: 3000 });
+
+    const clip: string = await page.evaluate(() => navigator.clipboard.readText());
+    const lines = clip.split("\n");
+    const line = lines.find((l) => l.includes(TEST_CUSTOMERS.restaurant.name));
+    // Tab-separated: Customer, '', 1, 12.00, Honey, '', ''
+    expect(line).toBe(`${TEST_CUSTOMERS.restaurant.name}\t\t1\t12.00\tHoney\t\t`);
+  });
+
+  test("Export button disabled when no orders for the week", async ({ page }) => {
+    await page.goto("/admin/orders");
+    const btn = page.getByRole("button", { name: /export to wave/i });
+    await expect(btn).toBeDisabled();
+  });
+});

--- a/tests/admin-shell.spec.ts
+++ b/tests/admin-shell.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { ADMIN_STORAGE_STATE } from "./helpers";
+import { writeAdminStorageState } from "./global-setup";
 
 test.describe("admin shell — unauthenticated", () => {
   test("unauthenticated /admin redirects to /login", async ({ page }) => {
@@ -76,6 +77,15 @@ test.describe("admin shell — authenticated", () => {
 // token server-side (scope: global), which would corrupt retries of sibling tests.
 test.describe("admin shell — sign-out", () => {
   test.use({ storageState: ADMIN_STORAGE_STATE });
+
+  // Re-write ADMIN_STORAGE_STATE after the sign-out test runs. Empirically,
+  // even with scope:"local" the post-signOut JWT is rejected by @supabase/ssr's
+  // getUser() on a fresh context that loads the same cookies — so later specs
+  // (notifications-flow) get bounced to /login. Re-signing in writes a fresh
+  // session to disk so subsequent contexts authenticate cleanly.
+  test.afterAll(async () => {
+    await writeAdminStorageState();
+  });
 
   test("sign-out redirects to /login", async ({ page }) => {
     await page.goto("/admin");

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -3,8 +3,54 @@ import { createClient } from "@supabase/supabase-js";
 import { mkdir } from "fs/promises";
 
 export const TEST_ADMIN_EMAIL = "test-admin@bushel.test";
-const TEST_ADMIN_PASSWORD = "BushelTest1!";
+export const TEST_ADMIN_PASSWORD = "BushelTest1!";
 const MAX_CHUNK_SIZE = 3180;
+
+// Re-export the storage-state path so other tests/helpers can rebuild it.
+export const ADMIN_STORAGE_STATE_PATH = "playwright/.auth/admin.json";
+
+// Sign in the test admin and write a fresh storageState file. Extracted from
+// globalSetup so the admin-shell sign-out test can refresh the shared state
+// after it invalidates the session, keeping later specs (notifications-flow)
+// authenticated. @supabase/ssr's getUser() on subsequent contexts otherwise
+// rejects the post-signOut JWT even with scope:"local" — empirically observed.
+export async function writeAdminStorageState(): Promise<void> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3001";
+
+  const anonClient = createClient(supabaseUrl, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  const { data, error } = await anonClient.auth.signInWithPassword({
+    email: TEST_ADMIN_EMAIL,
+    password: TEST_ADMIN_PASSWORD,
+  });
+  if (error || !data.session) {
+    throw new Error(`writeAdminStorageState sign-in failed: ${error?.message ?? "no session"}`);
+  }
+
+  const sessionCookies = sessionToCookies(data.session, storageKeyFromUrl(supabaseUrl));
+  const hostname = new URL(baseURL).hostname;
+  const secure = baseURL.startsWith("https://");
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ baseURL });
+  await context.addCookies(
+    sessionCookies.map(({ name, value }) => ({
+      name,
+      value,
+      domain: hostname,
+      path: "/",
+      httpOnly: false,
+      secure,
+      sameSite: "Lax" as const,
+    })),
+  );
+  await mkdir("playwright/.auth", { recursive: true });
+  await context.storageState({ path: ADMIN_STORAGE_STATE_PATH });
+  await browser.close();
+}
 
 // @supabase/ssr v0.10+ derives the storage key from the project hostname:
 // sb-<hostname[0]>-auth-token (e.g. sb-nnmfubmlvnkouxxfxxlh-auth-token for remote,

--- a/tests/notifications-flow.spec.ts
+++ b/tests/notifications-flow.spec.ts
@@ -35,7 +35,7 @@ async function testCustomerIds(): Promise<{ farmStand: string; restaurant: strin
 async function resetCustomerState(): Promise<void> {
   const sb = admin();
   for (const token of [TEST_CUSTOMERS.farmStand.token, TEST_CUSTOMERS.restaurant.token]) {
-    await sb
+    const { data, error } = await sb
       .from("customers")
       .update({
         phone: "(216) 555-0100",
@@ -43,7 +43,10 @@ async function resetCustomerState(): Promise<void> {
         send_weekly_link: true,
         is_active: true,
       })
-      .eq("token", token);
+      .eq("token", token)
+      .select("id");
+    if (error) throw new Error(`resetCustomerState(${token}): ${error.message}`);
+    if (!data?.length) throw new Error(`resetCustomerState(${token}): no rows updated — test customer missing`);
   }
 }
 
@@ -52,6 +55,16 @@ async function clearSends(): Promise<void> {
     .from("customer_sends")
     .delete()
     .eq("week_of", weekOfMondayNY());
+}
+
+// admin-settings.spec.ts flips ordering_schedule.is_open without restoring,
+// and the "deep-link → customer page" test below renders the customer order
+// page (which redirects to the closed state when is_open=false).
+async function ensureOrderingOpen(): Promise<void> {
+  await admin()
+    .from("ordering_schedule")
+    .update({ is_open: true, override_closes_at: null })
+    .eq("is_singleton", true);
 }
 
 async function clearOrdersFor(customerId: string): Promise<void> {
@@ -114,6 +127,7 @@ test.describe("notifications cross-task flow", () => {
   test.beforeEach(async () => {
     await resetCustomerState();
     await clearSends();
+    await ensureOrderingOpen();
   });
 
   test("deep-link body contains a working customer URL — operator → customer page", async ({ page }) => {

--- a/tests/orders-flow.spec.ts
+++ b/tests/orders-flow.spec.ts
@@ -1,0 +1,323 @@
+import { test, expect, type Download, type Page } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+
+import {
+  ADMIN_STORAGE_STATE,
+  TEST_CUSTOMERS,
+  TEST_PRODUCTS,
+  customerOrderUrl,
+  resetCustomerOrderState,
+} from "./helpers";
+import { weekOfMondayNY } from "@/lib/week";
+import { EXPORT_COLUMNS } from "@/lib/admin/export-orders";
+
+// Phase 5.3 — cross-task integration tests covering the gaps that 5.1
+// (status UI) and 5.2 (CSV/TSV export) own-specs don't quite hit:
+//   (a) end-to-end customer → admin: place an order, see it, advance it,
+//       export it
+//   (b) reconciliation pin survives sort + week-filter changes together
+//   (c) export respects the active week filter
+
+function admin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+}
+
+async function customerIds(): Promise<{ farmStand: string; restaurant: string }> {
+  const sb = admin();
+  const { data, error } = await sb
+    .from("customers")
+    .select("id, token")
+    .in("token", [TEST_CUSTOMERS.farmStand.token, TEST_CUSTOMERS.restaurant.token]);
+  if (error || !data) throw new Error(`customerIds: ${error?.message ?? "no rows"}`);
+  const map = new Map(data.map((r) => [r.token, r.id]));
+  return {
+    farmStand: map.get(TEST_CUSTOMERS.farmStand.token)!,
+    restaurant: map.get(TEST_CUSTOMERS.restaurant.token)!,
+  };
+}
+
+async function clearOrdersForWeek(weekOf: string): Promise<void> {
+  const sb = admin();
+  const ids = await customerIds();
+  await sb
+    .from("orders")
+    .delete()
+    .in("customer_id", [ids.farmStand, ids.restaurant])
+    .eq("week_of", weekOf);
+}
+
+type SeedOrderInput = {
+  customerId: string;
+  weekOf: string;
+  fulfillmentType: "pickup" | "delivery";
+  needsReconciliation?: boolean;
+  items: Array<{ productId: string; qty: number; unitPriceCents: number }>;
+};
+
+async function seedOrder(input: SeedOrderInput): Promise<string> {
+  const sb = admin();
+  const { data: order, error } = await sb
+    .from("orders")
+    .insert({
+      customer_id: input.customerId,
+      week_of: input.weekOf,
+      fulfillment_type: input.fulfillmentType,
+      delivery_address: input.fulfillmentType === "delivery" ? "123 Test St" : null,
+      status: "new",
+      needs_reconciliation: input.needsReconciliation ?? false,
+    })
+    .select("id")
+    .single();
+  if (error || !order) throw new Error(`seedOrder: ${error?.message}`);
+  await sb.from("order_items").insert(
+    input.items.map((i) => ({
+      order_id: order.id,
+      product_id: i.productId,
+      qty: i.qty,
+      unit_price_cents: i.unitPriceCents,
+    })),
+  );
+  return order.id;
+}
+
+async function stepUp(page: Page, productName: string, qty: number): Promise<void> {
+  const row = page.locator(".item-row", { hasText: productName });
+  for (let i = 0; i < qty; i++) {
+    await row.getByRole("button", { name: "increase" }).click();
+  }
+}
+
+async function readDownloadText(download: Download): Promise<string> {
+  const stream = await download.createReadStream();
+  let text = "";
+  for await (const chunk of stream) text += chunk.toString();
+  return text;
+}
+
+function shiftWeek(weekOf: string, weeks: number): string {
+  const [y, m, d] = weekOf.split("-").map((n) => parseInt(n, 10));
+  const anchor = new Date(Date.UTC(y, m - 1, d));
+  anchor.setUTCDate(anchor.getUTCDate() + weeks * 7);
+  return anchor.toISOString().slice(0, 10);
+}
+
+test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () => {
+  const thisWeek = weekOfMondayNY();
+  const lastWeek = shiftWeek(thisWeek, -1);
+
+  test.beforeEach(async () => {
+    await resetCustomerOrderState();
+  });
+
+  // Clean both weeks we ever touch — test 3 seeds lastWeek and clears it
+  // inline on success, but a mid-test failure would otherwise leak the
+  // last-week order indefinitely.
+  test.afterAll(async () => {
+    await clearOrdersForWeek(thisWeek);
+    await clearOrdersForWeek(lastWeek);
+  });
+
+  test("customer places an order → admin advances status → export contains the row", async ({
+    browser,
+  }) => {
+    // Customer context (no admin cookies)
+    const customerCtx = await browser.newContext();
+    const customerPage = await customerCtx.newPage();
+    await customerPage.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    await stepUp(customerPage, TEST_PRODUCTS.kale.name, 2);
+    await customerPage.locator(".submit-btn").click();
+    await customerPage.waitForURL(/\/c\/[^/]+\/confirmed$/);
+    await customerCtx.close();
+
+    // Pick up the order id the customer just created
+    const sb = admin();
+    const ids = await customerIds();
+    const { data: order } = await sb
+      .from("orders")
+      .select("id")
+      .eq("customer_id", ids.farmStand)
+      .eq("week_of", thisWeek)
+      .single();
+    expect(order?.id).toBeTruthy();
+    const orderId = order!.id;
+
+    // Admin context — separate so admin cookies don't bleed into customerCtx
+    const adminCtx = await browser.newContext({ storageState: ADMIN_STORAGE_STATE });
+    const adminPage = await adminCtx.newPage();
+    await adminPage.goto("/admin/orders");
+
+    const row = adminPage.locator(`tr.ord-row[data-order-id="${orderId}"]`);
+    await expect(row).toHaveAttribute("data-status", "new");
+
+    // new → ready
+    await row.getByRole("button", { name: /mark ready/i }).click();
+    await expect(row).toHaveAttribute("data-status", "ready", { timeout: 5000 });
+    await expect
+      .poll(async () => {
+        const { data } = await sb.from("orders").select("status").eq("id", orderId).single();
+        return data?.status ?? null;
+      }, { timeout: 5000 })
+      .toBe("ready");
+
+    // ready → delivered (farmStand defaults to delivery)
+    const deliveredBtn = row.getByRole("button", { name: /delivered/i });
+    await expect(deliveredBtn).toBeEnabled();
+    await deliveredBtn.click();
+    await expect(row).toHaveAttribute("data-status", "delivered", { timeout: 5000 });
+    await expect
+      .poll(async () => {
+        const { data } = await sb.from("orders").select("status").eq("id", orderId).single();
+        return data?.status ?? null;
+      }, { timeout: 5000 })
+      .toBe("delivered");
+
+    // Export → CSV contains the just-placed order's line item.
+    // No invoice-number column anymore (Wave assigns on import) — match on
+    // customer name + product name; column shape is
+    //   Customer Name, Item Number, Quantity, Unit Price, Description, …
+    await adminPage.getByRole("button", { name: /export to wave/i }).click();
+    const [download] = await Promise.all([
+      adminPage.waitForEvent("download"),
+      adminPage.getByRole("button", { name: /download csv/i }).click(),
+    ]);
+    const text = await readDownloadText(download);
+    const lines = text.split("\r\n");
+    // No header row — first line is the seeded order's data.
+    expect(lines[0]).not.toBe(EXPORT_COLUMNS.join(","));
+    // Customer Name leads each row; Description column carries product name.
+    const kaleLine = lines.find(
+      (l) =>
+        l.startsWith(`${TEST_CUSTOMERS.farmStand.name},`) &&
+        l.includes(TEST_PRODUCTS.kale.name),
+    );
+    expect(kaleLine).toBeTruthy();
+    // Seed product has description = null, so Item Number cell is empty.
+    expect(kaleLine).toBe(`${TEST_CUSTOMERS.farmStand.name},,2,3.00,${TEST_PRODUCTS.kale.name},,`);
+
+    // Reference orderId so the unused-var lint stays happy + documents the
+    // intent that this CSV line corresponds to the order we just created.
+    expect(orderId).toBeTruthy();
+
+    await adminCtx.close();
+  });
+
+  test("reconciliation pin holds across both column sort and week filter changes", async ({
+    browser,
+  }) => {
+    await clearOrdersForWeek(thisWeek);
+    const ids = await customerIds();
+    // Clean order placed later (so newer by created_at) for restaurant
+    const cleanId = await seedOrder({
+      customerId: ids.restaurant,
+      weekOf: thisWeek,
+      fulfillmentType: "delivery",
+      items: [{ productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 }],
+    });
+    // Flagged order — placed AFTER the clean one (still newer by created_at)
+    // to remove the "newest naturally pins to top" confound — the recon pin
+    // is doing the work in both sort orders below.
+    const recId = await seedOrder({
+      customerId: ids.farmStand,
+      weekOf: thisWeek,
+      fulfillmentType: "pickup",
+      needsReconciliation: true,
+      items: [{ productId: TEST_PRODUCTS.honey.id, qty: 1, unitPriceCents: 1200 }],
+    });
+
+    const adminCtx = await browser.newContext({ storageState: ADMIN_STORAGE_STATE });
+    const adminPage = await adminCtx.newPage();
+    await adminPage.goto("/admin/orders");
+
+    async function topOrderId(): Promise<string> {
+      const rowIds = await adminPage
+        .locator("tr.ord-row")
+        .evaluateAll((els) =>
+          (els as HTMLElement[]).map((el) => el.dataset.orderId ?? ""),
+        );
+      return rowIds[0];
+    }
+
+    // Default sort (placed desc): flagged row pinned regardless of which is newer
+    expect(await topOrderId()).toBe(recId);
+
+    // Sort by Customer ascending — Test Farm Stand (F) < Test Restaurant (T)
+    // but even if it were the other way, the recon pin must win.
+    await adminPage.getByRole("button", { name: /^Customer/i }).click();
+    expect(await topOrderId()).toBe(recId);
+
+    // Flip to last week and back — pin must hold after a route change too
+    await adminPage.getByRole("button", { name: /^last week/i }).click();
+    await expect(adminPage).toHaveURL(/week=last/);
+    await adminPage.getByRole("button", { name: /^this week/i }).click();
+    await expect(adminPage).not.toHaveURL(/week=last/);
+    expect(await topOrderId()).toBe(recId);
+    expect(await adminPage.locator("tr.ord-row").count()).toBe(2);
+
+    // Sanity — the clean row is still present, just not first
+    await expect(
+      adminPage.locator(`tr.ord-row[data-order-id="${cleanId}"]`),
+    ).toHaveCount(1);
+
+    await adminCtx.close();
+  });
+
+  test("export respects the active week filter", async ({ browser }) => {
+    await clearOrdersForWeek(thisWeek);
+    await clearOrdersForWeek(lastWeek);
+
+    const ids = await customerIds();
+    // farmStand=delivery this week with Kale; restaurant=pickup last week with
+    // Honey. Customer + product names are the unique markers — no invoice-
+    // number column anymore, so identification has to come from these.
+    await seedOrder({
+      customerId: ids.farmStand,
+      weekOf: thisWeek,
+      fulfillmentType: "delivery",
+      items: [{ productId: TEST_PRODUCTS.kale.id, qty: 3, unitPriceCents: 300 }],
+    });
+    await seedOrder({
+      customerId: ids.restaurant,
+      weekOf: lastWeek,
+      fulfillmentType: "pickup",
+      items: [{ productId: TEST_PRODUCTS.honey.id, qty: 2, unitPriceCents: 1200 }],
+    });
+
+    const adminCtx = await browser.newContext({ storageState: ADMIN_STORAGE_STATE });
+    const adminPage = await adminCtx.newPage();
+
+    // This-week default: export contains only this-week's line items
+    await adminPage.goto("/admin/orders");
+    await adminPage.getByRole("button", { name: /export to wave/i }).click();
+    const [thisDl] = await Promise.all([
+      adminPage.waitForEvent("download"),
+      adminPage.getByRole("button", { name: /download csv/i }).click(),
+    ]);
+    expect(thisDl.suggestedFilename()).toBe(`bushel-orders-${thisWeek}.csv`);
+    const thisText = await readDownloadText(thisDl);
+    expect(thisText).toContain(TEST_CUSTOMERS.farmStand.name);
+    expect(thisText).toContain(TEST_PRODUCTS.kale.name);
+    expect(thisText).not.toContain(TEST_CUSTOMERS.restaurant.name);
+    expect(thisText).not.toContain(TEST_PRODUCTS.honey.name);
+
+    // Switch to Last week — re-export
+    await adminPage.getByRole("button", { name: /^last week/i }).click();
+    await expect(adminPage).toHaveURL(/week=last/);
+    await adminPage.getByRole("button", { name: /export to wave/i }).click();
+    const [lastDl] = await Promise.all([
+      adminPage.waitForEvent("download"),
+      adminPage.getByRole("button", { name: /download csv/i }).click(),
+    ]);
+    expect(lastDl.suggestedFilename()).toBe(`bushel-orders-${lastWeek}.csv`);
+    const lastText = await readDownloadText(lastDl);
+    expect(lastText).toContain(TEST_CUSTOMERS.restaurant.name);
+    expect(lastText).toContain(TEST_PRODUCTS.honey.name);
+    expect(lastText).not.toContain(TEST_CUSTOMERS.farmStand.name);
+    expect(lastText).not.toContain(TEST_PRODUCTS.kale.name);
+
+    await adminCtx.close();
+  });
+});


### PR DESCRIPTION
## Summary

- Restores the 13 code/test files from `origin/task/5.3-orders-spec` that never reached `main` due to a stacked-PR merge order issue last session. See [#114](https://github.com/mobiustripper42/bushel/issues/114) for the root-cause writeup.
- Excludes `package.json` / `CHANGELOG.md` / `docs/PROJECT_PLAN.md` / `docs/RETROSPECTIVES.md` — main's post-retro versions of those are already correct.
- Tags `v0.6.2` → `v0.7.0` stay where they are. The recovery merge makes main contain the work those tags claim; re-tagging is deferred (you can revisit later).

## Restored work

| PR | Files |
|---|---|
| #103 (notifications-flow CI flake fix) | `src/actions/sign-out.ts` (scope:"local"), `tests/global-setup.ts` (extracted `writeAdminStorageState`), `tests/admin-shell.spec.ts` (afterAll storageState refresh), `tests/notifications-flow.spec.ts` (`ensureOrderingOpen` + error-checked reset) |
| #104 (Wave export) | `src/lib/admin/export-orders.ts` (new), `src/components/admin/export-orders-button.tsx` (new), `tests/admin-orders-export.spec.ts` (new), `src/components/admin/orders-page.tsx` (render button), `src/app/(admin)/admin/orders/page.tsx` (pass `weekOf`), `src/lib/admin/orders-queries.ts` (tweaks), `src/styles/app.css` (`.split-btn-*` primitives) |
| #105 (orders-flow cross-task spec) | `tests/orders-flow.spec.ts` (new), `playwright.config.ts` (mobile testIgnore for `orders-flow.spec.ts` + `notifications-flow.spec.ts`) |

## Test plan

- [x] `npm run build` green
- [x] `tests/admin-orders.spec.ts` `tests/admin-orders-export.spec.ts` `tests/orders-flow.spec.ts` `tests/notifications-flow.spec.ts` `tests/admin-shell.spec.ts` — 30/30 green on `--project=desktop` against local Supabase
- [ ] CI full matrix green on this PR

## Notes

After this merges, Phase 6.4's "remove `notifications-flow.spec.ts` entry from `playwright.config.ts` mobile testIgnore once the page renders" AC becomes coherent — that entry will exist on main.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)