### PR TITLE
Phase 6.6 — /admin/inventory + /admin/customers mobile-responsive (#111)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,8 +41,6 @@ export default defineConfig({
       testIgnore: [
         "**/admin-alert-template.spec.ts",
         "**/admin-auth.spec.ts",
-        "**/admin-customers.spec.ts",
-        "**/admin-inventory.spec.ts",
         "**/admin-orders.spec.ts",
         "**/admin-orders-export.spec.ts",
         "**/admin-prepopulate.spec.ts",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2405,3 +2405,153 @@
   font-size: 0.82rem;
   color: var(--ink-700);
 }
+
+/* ── /admin/inventory + /admin/customers mobile (Phase 6.6 / DEC-034) ── */
+/* Card-stack reflow at ≤640px. Goal is "usable on a phone," not pixel-perfect.
+   Annabel will mainly work from desktop; mobile is the back-pocket case. */
+@media (max-width: 640px) {
+  /* /admin/inventory */
+  main:has(.data-table) { padding: 16px !important; }
+  main:has(.data-table) .page-head {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+  main:has(.data-table) .page-actions {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+  main:has(.data-table) .page-actions button {
+    flex: 1;
+    min-width: 0;
+    min-height: 44px;
+  }
+  main:has(.data-table) .meta-row { flex-wrap: wrap; }
+  .data-card { overflow: visible; }
+  .data-table { border: none; }
+  .data-table thead { display: none; }
+  .data-table,
+  .data-table tbody,
+  .data-table tbody tr.data-row,
+  .data-table tbody tr.data-row > td {
+    display: block;
+    width: 100%;
+  }
+  .data-table tbody tr.data-row {
+    background: var(--paper);
+    border: 1px solid var(--ink-200);
+    border-radius: var(--r-md);
+    margin-bottom: 12px;
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .data-table tbody tr.data-row > td {
+    display: block;
+    width: 100% !important;
+    padding: 0 !important;
+    border: 0 !important;
+    min-width: 0;
+    text-align: left !important;
+  }
+  /* Hide drag handle on mobile — no useful interaction there yet. */
+  .data-table tbody tr.data-row > td:nth-child(1) { display: none; }
+  /* Switch + trash side-by-side at the bottom of the card. */
+  .data-table tbody tr.data-row > td:nth-child(7) {
+    display: inline-flex !important;
+    width: auto !important;
+    align-self: flex-start;
+  }
+  .data-table tbody tr.data-row > td:nth-child(8) {
+    display: inline-flex !important;
+    width: auto !important;
+    align-self: flex-end;
+    margin-top: -36px; /* hug the switch row */
+  }
+
+  .data-table tbody tr.data-row.data-row-sub {
+    margin-top: -10px;
+    padding-top: 0 !important;
+    border-top: 0 !important;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+  .data-table tbody tr.data-row.data-row-sub > td:nth-child(1) { display: none; }
+  .data-table tbody tr.data-row.data-row-sub > td:nth-child(2) {
+    display: block !important;
+    padding: 0 !important;
+  }
+
+  .data-table .field-input,
+  .data-table .field-select { min-height: 40px; width: 100%; }
+  .data-table .field-num { text-align: left; }
+  .data-table .field-price .field-input { padding-left: 24px; }
+
+  .add-row { min-height: 48px; font-size: 0.95rem; }
+
+  /* /admin/customers */
+  main:has(.cust-table) { padding: 16px !important; }
+  .cust-tableCard { background: transparent; border: none; border-radius: 0; overflow: visible; }
+  .cust-table { border: none; }
+  .cust-table thead { display: none; }
+  .cust-table,
+  .cust-table tbody,
+  .cust-table tbody tr.cust-row,
+  .cust-table tbody tr.cust-row > td {
+    display: block;
+    width: 100%;
+  }
+  .cust-table tbody tr.cust-row {
+    background: var(--paper);
+    border: 1px solid var(--ink-200);
+    border-radius: var(--r-md);
+    margin-bottom: 12px;
+    padding: 14px;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      "name     sub"
+      "contact  contact"
+      "addr     addr"
+      "priority priority"
+      "link     link";
+    column-gap: 10px;
+    row-gap: 10px;
+  }
+  .cust-table tbody tr.cust-row > td {
+    padding: 0;
+    border: 0;
+    width: auto;
+    min-width: 0;
+    text-align: left;
+  }
+  .cust-table tbody tr.cust-row > td.col-c-name     { grid-area: name; }
+  .cust-table tbody tr.cust-row > td.col-c-contact  { grid-area: contact; }
+  .cust-table tbody tr.cust-row > td.col-c-addr     { grid-area: addr; }
+  .cust-table tbody tr.cust-row > td.col-c-priority {
+    grid-area: priority;
+    font-size: 0.85rem;
+    color: var(--ink-500);
+  }
+  .cust-table tbody tr.cust-row > td.col-c-priority::before {
+    content: "Priority: ";
+    color: var(--ink-500);
+  }
+  .cust-table tbody tr.cust-row > td.col-c-link {
+    grid-area: link;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+  }
+  .cust-table tbody tr.cust-row > td.col-c-sub      { grid-area: sub; justify-self: end; }
+  .cust-table tbody tr.cust-row > td.col-c-actions  { display: none; }
+
+  .cust-copy { min-height: 40px; padding: 0 14px; }
+  .cust-regen { min-height: 40px; padding: 0 10px; }
+  .cust-addr { white-space: normal; overflow: visible; text-overflow: clip; }
+
+  main:has(.cust-table) .page-head { flex-wrap: wrap; gap: 12px; }
+  main:has(.cust-table) .page-actions { width: 100%; flex-wrap: wrap; }
+  main:has(.cust-table) .page-actions button { flex: 1; min-height: 44px; }
+}

--- a/tests/admin-customers.spec.ts
+++ b/tests/admin-customers.spec.ts
@@ -145,6 +145,29 @@ test.describe("admin customers", () => {
     }
   });
 
+  test("mobile (375px): page fits viewport; row renders as a card; copy-link is tappable", async ({ page, viewport }, testInfo) => {
+    test.skip(testInfo.project.name !== "mobile", "Mobile-only assertions; covered on the mobile project.");
+    await page.goto("/admin/customers");
+
+    // No horizontal overflow at iPhone-13 width — the cust-table reflows to
+    // a card stack (Phase 6.6 / DEC-034).
+    const vw = viewport!.width;
+    const docWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    expect(docWidth).toBeLessThanOrEqual(vw + 1);
+
+    // Seed row still locatable by data-row-name, with copy-link in reach.
+    const row = rowByName(page, TEST_CUSTOMERS.farmStand.name);
+    await expect(row).toBeVisible();
+    await expect(row.locator(".cust-name")).toHaveText(TEST_CUSTOMERS.farmStand.name);
+
+    const copy = row.getByRole("button", {
+      name: new RegExp(`copy order link for ${TEST_CUSTOMERS.farmStand.name}`, "i"),
+    });
+    const box = await copy.boundingBox();
+    expect(box, "Copy-link button should be visible").not.toBeNull();
+    expect(box!.height).toBeGreaterThanOrEqual(36);
+  });
+
   test("subscribed switch toggles inline without opening the drawer", async ({ page }) => {
     await page.goto("/admin/customers");
     const row = rowByName(page, TEST_CUSTOMERS.farmStand.name);
@@ -154,6 +177,25 @@ test.describe("admin customers", () => {
     await sw.click();
     // Drawer must NOT open from the switch
     await expect(drawer(page)).toHaveCount(0);
+
+    // Wait for the server action's round-trip to persist before reloading —
+    // otherwise on slow projects (mobile WebKit) the reload can race and read
+    // the pre-toggle DB row.
+    const supabase = adminClient();
+    const expectedFlipped = initial === "true" ? false : true;
+    await expect
+      .poll(
+        async () => {
+          const { data } = await supabase
+            .from("customers")
+            .select("send_weekly_link")
+            .eq("token", TEST_CUSTOMERS.farmStand.token)
+            .single();
+          return data?.send_weekly_link ?? null;
+        },
+        { timeout: 5000 },
+      )
+      .toBe(expectedFlipped);
 
     await page.reload();
     const flipped = await rowByName(page, TEST_CUSTOMERS.farmStand.name)

--- a/tests/admin-inventory.spec.ts
+++ b/tests/admin-inventory.spec.ts
@@ -94,6 +94,27 @@ test.describe("admin inventory", () => {
     );
   });
 
+  test("mobile (375px): page fits viewport; rows render as cards; qty input is editable", async ({ page, viewport }, testInfo) => {
+    test.skip(testInfo.project.name !== "mobile", "Mobile-only assertions; covered on the mobile project.");
+    await page.goto("/admin/inventory");
+
+    // No horizontal overflow at iPhone-13 width — the data-table reflows to
+    // a card stack (Phase 6.6 / DEC-034).
+    const vw = viewport!.width;
+    const docWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    expect(docWidth).toBeLessThanOrEqual(vw + 1);
+
+    // Seed row still reachable through the same data-row-name attribute.
+    const kale = rowByName(page, TEST_PRODUCTS.kale.name);
+    await expect(kale).toBeVisible();
+
+    // Qty input is still wired up — Annabel can edit from a phone in a pinch.
+    const qtyInput = kale.getByRole("spinbutton", { name: /quantity/i });
+    await expect(qtyInput).toBeVisible();
+    await qtyInput.fill("17");
+    await expect(saveButton(page, 1)).toBeEnabled();
+  });
+
   test("add row, save, then delete the added row", async ({ page }) => {
     await page.goto("/admin/inventory");
 


### PR DESCRIPTION
## Summary
Card-stack reflow of `/admin/inventory` and `/admin/customers` at ≤640px. Closes #111 — the shell drawer chrome already shipped in 6.4; this finishes the remaining per-page work. Goal is "phone-usable," not pixel-perfect.

## Files changed
- `src/styles/app.css` — new `@media (max-width: 640px)` block at end of file with `.data-table`/`.data-row` (flex-column) + `.cust-table`/`.cust-row` (grid-areas) card-stack rules.
- `playwright.config.ts` — drops `admin-inventory.spec.ts` + `admin-customers.spec.ts` from mobile testIgnore.
- `tests/admin-inventory.spec.ts` — new mobile fit-to-viewport + qty-edit assertion.
- `tests/admin-customers.spec.ts` — new mobile fit-to-viewport + copy-link assertion. Pre-existing "subscribed switch toggles" test got a DB poll before reload (mobile WebKit's server-action round-trip races with `page.reload()` otherwise).

## Merge order note
This PR overlaps with **#117** (Phase 6.5 — /admin/orders mobile) on `playwright.config.ts` and `src/styles/app.css`. The overlap is trivial (both append rules at the end of disjoint sections), but merge #117 first and this branch will need a trivial fast-forward or auto-merge to pick it up.

## Code review
Ships clean for the stated bar (per `@code-review`). Two non-blocking cleanups flagged for the next inventory touch:
1. Inventory row uses `nth-child(7)`/`nth-child(8)` to target the switch + trash cells — positionally fragile. A `.col-i-*` class on those tds would mirror the customers approach. Skipped this PR.
2. Eight `!important` rules to defeat inline `style={{ width: 90 }}` on inventory row tds. Lifting the inline widths to a class would remove the `!important` chain.

## Test plan
- `npx playwright test tests/admin-inventory.spec.ts --project=mobile` — 6 pass (header, save persistence, switch toggle, discard, mobile-only fit-viewport, add/delete row).
- `npx playwright test tests/admin-inventory.spec.ts --project=desktop` — 5 pass, 1 skipped (the new mobile-only test).
- `npx playwright test tests/admin-customers.spec.ts --project=mobile` — 8 pass (full suite running on mobile for the first time, including the previously-skipped subscribed-switch test).
- `npx playwright test tests/admin-customers.spec.ts --project=desktop` — 7 pass, 1 skipped.
- Mobile screenshots verified at 375×812: inventory cards stack with name → category → price → unit → qty → switch/trash; customers cards stack with name + subscribed switch on top, then token + priority + Copy link / Regenerate.

## Acceptance criteria (#111)
- [x] Admin shell collapses to drawer at ≤768px (shipped in 6.4).
- [x] Remaining /admin/* pages mobile-responsive: `/admin/orders` (#117 / 6.5), `/admin/inventory` + `/admin/customers` (this PR).
- [x] All targeted tests green on desktop + mobile projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)