### PR TITLE
Phase 6.7 — Desktop SMS relay via clipboard + Messages for Web (#112)

### DIFF
--- a/src/components/admin/send-row.tsx
+++ b/src/components/admin/send-row.tsx
@@ -16,13 +16,13 @@ type SendRowProps = {
   initialSentAt: string | null;
 };
 
-// Phase 6.7: when the operator is on desktop, `sms:` deep links either no-op
-// or open iMessage on macOS — neither is what Annabel wants when working from
-// her laptop. Detect desktop via the pointer-precision media query (touch
-// primary devices report "coarse"; trackpad/mouse report "fine") and fall back
-// to copy-body-to-clipboard + open messages.google.com in a new tab.
 const MESSAGES_WEB_URL = "https://messages.google.com/web/conversations";
 
+// Phase 6.7: when the operator is on desktop, `sms:` deep links either no-op
+// or open iMessage on macOS — neither is what Annabel wants when working from
+// her laptop. Detect desktop via the pointer-precision media query (touch-
+// primary devices report "coarse"; trackpad/mouse report "fine") and fall back
+// to copy-body-to-clipboard + open messages.google.com in a new tab.
 function isDesktopOperator(): boolean {
   if (typeof window === "undefined") return false;
   return window.matchMedia("(pointer: fine)").matches;
@@ -76,17 +76,25 @@ export function SendRow({
       // Messages for Web in a new tab. Messages for Web doesn't accept a
       // prefill query-param — operator pastes after picking the conversation.
       e.preventDefault();
+      // Open the tab synchronously inside the click handler; Safari and
+      // some Chromium variants pop-up-block window.open if it runs after
+      // an await.
+      window.open(MESSAGES_WEB_URL, "_blank", "noopener,noreferrer");
       try {
         await navigator.clipboard.writeText(body);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2400);
       } catch {
-        // Clipboard blocked — surface the body so operator can copy by hand.
-        setError("Clipboard blocked. Copy the message manually.");
+        // Clipboard blocked — surface the failure and do NOT record the send.
+        // The operator sees a single coherent state (error, still Unsent) and
+        // can retry after granting clipboard access, instead of an optimistic
+        // Sent pill that lies about delivery.
+        setError("Clipboard blocked. Copy the message manually, then click Send again.");
+        return;
       }
-      window.open(MESSAGES_WEB_URL, "_blank", "noopener,noreferrer");
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2400);
     }
-    // Mobile path: let the <a href="sms:..."> navigation proceed naturally.
+    // Mobile path falls through: the <a href="sms:..."> navigation proceeds
+    // naturally (no preventDefault), and recordOptimistic() runs below.
     recordOptimistic();
   }
 

--- a/src/components/admin/send-row.tsx
+++ b/src/components/admin/send-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, type MouseEvent } from "react";
 
 import { recordSend } from "@/actions/record-send";
 import { buildSmsUrl } from "@/lib/notifications/sms-deep-link";
@@ -15,6 +15,18 @@ type SendRowProps = {
   mode: SendMode;
   initialSentAt: string | null;
 };
+
+// Phase 6.7: when the operator is on desktop, `sms:` deep links either no-op
+// or open iMessage on macOS — neither is what Annabel wants when working from
+// her laptop. Detect desktop via the pointer-precision media query (touch
+// primary devices report "coarse"; trackpad/mouse report "fine") and fall back
+// to copy-body-to-clipboard + open messages.google.com in a new tab.
+const MESSAGES_WEB_URL = "https://messages.google.com/web/conversations";
+
+function isDesktopOperator(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(pointer: fine)").matches;
+}
 
 function formatSentAt(iso: string): string {
   const d = new Date(iso);
@@ -38,12 +50,12 @@ export function SendRow({
   const [sentAt, setSentAt] = useState<string | null>(initialSentAt);
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   const smsHref = phone ? buildSmsUrl({ phone, body }) : null;
   const isSent = sentAt !== null;
 
-  function handleClick() {
-    if (!phone) return;
+  function recordOptimistic() {
     setError(null);
     const optimisticTimestamp = new Date().toISOString();
     setSentAt(optimisticTimestamp);
@@ -56,6 +68,28 @@ export function SendRow({
     });
   }
 
+  async function handleClick(e: MouseEvent<HTMLAnchorElement>) {
+    if (!phone) return;
+
+    if (isDesktopOperator()) {
+      // Desktop path: intercept the sms: nav, copy body to clipboard, open
+      // Messages for Web in a new tab. Messages for Web doesn't accept a
+      // prefill query-param — operator pastes after picking the conversation.
+      e.preventDefault();
+      try {
+        await navigator.clipboard.writeText(body);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2400);
+      } catch {
+        // Clipboard blocked — surface the body so operator can copy by hand.
+        setError("Clipboard blocked. Copy the message manually.");
+      }
+      window.open(MESSAGES_WEB_URL, "_blank", "noopener,noreferrer");
+    }
+    // Mobile path: let the <a href="sms:..."> navigation proceed naturally.
+    recordOptimistic();
+  }
+
   return (
     <li className="send-row" data-customer-id={customerId} data-sent={isSent ? "true" : "false"}>
       <div className="send-row-name">
@@ -66,6 +100,11 @@ export function SendRow({
         <span className={"send-status" + (isSent ? " is-sent" : "")}>
           {isSent ? `Sent · ${formatSentAt(sentAt!)}` : "Unsent"}
         </span>
+        {copied && (
+          <span className="send-row-copied" role="status">
+            Copied — paste in Messages
+          </span>
+        )}
         {error && (
           <span className="send-row-error" role="alert">
             {error}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2006,6 +2006,11 @@
   font-size: 0.74rem;
   color: var(--rose-600);
 }
+.send-row-copied {
+  font-size: 0.74rem;
+  color: var(--leaf-700);
+  font-weight: 500;
+}
 .send-row-disabled {
   font-size: 0.82rem;
   color: var(--ink-500);

--- a/tests/admin-send.spec.ts
+++ b/tests/admin-send.spec.ts
@@ -111,7 +111,19 @@ async function ensureTestCustomerState(): Promise<void> {
 test.describe("admin send-queue", () => {
   test.use({ storageState: ADMIN_STORAGE_STATE });
 
-  test.beforeEach(async () => {
+  test.beforeEach(async ({ context, browserName }) => {
+    // Phase 6.7 — on desktop the Send button writes the SMS body to the
+    // clipboard before recording the send. Without these permissions the
+    // clipboard write throws and the send is intentionally NOT recorded
+    // (the operator sees an error and retries), which breaks every test
+    // here that asserts the Sent pill flip after clicking Send.
+    //
+    // WebKit doesn't support the clipboard-write permission name, but the
+    // mobile project's tests go down the sms: deep-link path anyway, so
+    // clipboard isn't needed there.
+    if (browserName === "chromium") {
+      await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    }
     await ensureTestCustomerState();
     await clearSends();
     await clearIntroNote();

--- a/tests/admin-send.spec.ts
+++ b/tests/admin-send.spec.ts
@@ -192,6 +192,63 @@ test.describe("admin send-queue", () => {
       .toBe(1);
   });
 
+  test("desktop: clicking Send copies the body to clipboard and opens Messages for Web", async ({ page, context }, testInfo) => {
+    test.skip(testInfo.project.name === "mobile", "Desktop-only path (Phase 6.7). Mobile uses the sms: deep link directly.");
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    const ids = await testCustomerIds();
+    await page.goto("/admin/send");
+
+    const list = page.getByRole("list", { name: /weekly update queue/i });
+    const farmStandRow = list.locator(`li.send-row[data-customer-id="${ids.farmStand}"]`);
+    await expect(farmStandRow.locator(".send-status")).toHaveText("Unsent");
+
+    // Pull the body the row will copy by decoding it out of the sms: href.
+    const href = (await farmStandRow.getByRole("link", { name: /^send$/i }).getAttribute("href")) ?? "";
+    const bodyEncoded = href.split("?body=")[1] ?? "";
+    const expectedBody = decodeURIComponent(bodyEncoded);
+    expect(expectedBody).toContain("Bay Branch Farm");
+
+    // Click Send — desktop project ("(pointer: fine)") triggers the desktop
+    // path: preventDefault + clipboard.writeText + window.open in a new tab.
+    const [popup] = await Promise.all([
+      context.waitForEvent("page"),
+      farmStandRow.getByRole("link", { name: /^send$/i }).click(),
+    ]);
+
+    // Popup is the Messages-for-Web tab.
+    await popup.waitForLoadState("domcontentloaded").catch(() => {
+      // Real google.com may be unreachable in CI; URL alone is enough.
+    });
+    expect(popup.url()).toContain("messages.google.com");
+    await popup.close();
+
+    // Clipboard contains the body the operator will paste.
+    const clip = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clip).toBe(expectedBody);
+
+    // Copied indicator + Sent pill flip.
+    await expect(farmStandRow.locator(".send-row-copied")).toBeVisible();
+    await expect(farmStandRow.locator(".send-status")).toContainText("Sent", { timeout: 5000 });
+    await expect(farmStandRow).toHaveAttribute("data-sent", "true");
+
+    // DB confirmation.
+    const sb = admin();
+    await expect
+      .poll(
+        async () => {
+          const { data } = await sb
+            .from("customer_sends")
+            .select("customer_id")
+            .eq("customer_id", ids.farmStand)
+            .eq("week_of", weekOfMondayNY())
+            .eq("mode", "weekly_update");
+          return data?.length ?? 0;
+        },
+        { timeout: 5000 },
+      )
+      .toBe(1);
+  });
+
   test("intro note saves and is injected into the weekly_update body", async ({ page }) => {
     const ids = await testCustomerIds();
     await page.goto("/admin/send");

--- a/tests/notifications-flow.spec.ts
+++ b/tests/notifications-flow.spec.ts
@@ -124,7 +124,13 @@ async function ensureDeliveryOrder(token: string): Promise<void> {
 test.describe("notifications cross-task flow", () => {
   test.use({ storageState: ADMIN_STORAGE_STATE });
 
-  test.beforeEach(async () => {
+  test.beforeEach(async ({ context, browserName }) => {
+    // Phase 6.7 — desktop Send path writes to clipboard before recording.
+    // WebKit doesn't accept the clipboard-write permission; mobile project
+    // hits the sms: deep-link branch which never touches the clipboard.
+    if (browserName === "chromium") {
+      await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    }
     await resetCustomerState();
     await clearSends();
     await ensureOrderingOpen();


### PR DESCRIPTION
## Summary
Desktop fallback for the `sms:` deep link. On desktop, clicking Send copies the SMS body to the clipboard, opens `https://messages.google.com/web/conversations` in a new tab, and shows a "Copied — paste in Messages" indicator. Mobile path unchanged. Closes #112.

## Files changed
- `src/components/admin/send-row.tsx` — `isDesktopOperator()` via `matchMedia("(pointer: fine)")`. Desktop click handler: `preventDefault` → `window.open` (synchronous, to dodge popup-blockers after `await`) → `navigator.clipboard.writeText(body)` → set Copied → `recordOptimistic()`. Clipboard failure returns early without recording the send.
- `src/styles/app.css` — `.send-row-copied` (small green text).
- `tests/admin-send.spec.ts` — new desktop test asserting clipboard content + popup URL + Copied indicator + Sent pill + DB row. `beforeEach` grants clipboard permissions on chromium only.
- `tests/notifications-flow.spec.ts` — same `beforeEach` clipboard grant on chromium (existing tests click Send and now hit the desktop branch).

## Merge order note
Overlaps with **#118** on `src/styles/app.css` (different rules — disjoint sections). PR #117 already merged. Either order works; trivial cascade either way.

## Code review
Two real fixes applied from `@code-review` before opening this PR:
1. Clipboard failure used to record the send anyway — operator saw contradictory error+Sent state. Now returns early on clipboard error.
2. `window.open` after `await` was at risk of popup-blocker on Safari. Moved synchronous call before the await.

Plus two minor: comment placement above `isDesktopOperator`, and a clarifying note in the test skip.

## Test plan
- `npx playwright test tests/admin-send.spec.ts --project=desktop` — 6 pass, 1 skipped (mobile-only test from 6.4).
- `npx playwright test tests/admin-send.spec.ts --project=mobile` — 5 pass, 2 skipped (the existing sms: nav skip + the new desktop-only test).
- `npx playwright test tests/notifications-flow.spec.ts --project=desktop` — 4 pass.
- `npx playwright test tests/notifications-flow.spec.ts --project=mobile` — 1 pass, 3 skipped (existing sms: nav skips).
- Manual check on `preview.baybranchfarm.com` post-deploy: on a laptop (trackpad → pointer: fine), click Send — verify a new Messages-for-Web tab opens and the clipboard contains the SMS body ready to paste.

## Acceptance criteria (#112)
- [x] When operator is on desktop, the Send button copies the sms body to clipboard AND opens messages.google.com in a new tab.
- [x] Detect desktop via user-agent / viewport. *(Used `(pointer: fine)` media query — standard primary-input signal, no UA sniffing required.)*
- [x] sms: deep link stays the default on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)