### PR TITLE
auto-sync downstream — 2026-05-17

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -53,7 +53,7 @@ For every decision brought to you:
 - Default to the simpler option. "We can always add that later" is usually the right answer for V1.
 - If a decision is clearly fine, say "proceed" in one line. Don't over-analyze straightforward choices.
 - If recommending "modify" or "reject", always suggest a concrete alternative.
-- Reference specific decision IDs from `docs/DECISIONS.md` when relevant.
+- Reference specific decision IDs from `docs/DECISIONS.md` when relevant (e.g., "this contradicts DEC-007").
 - The launch deadline is real — scope discipline is your primary value.
 
 ## On Dependencies

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -70,20 +70,22 @@ If both unavailable: skip PR-derived math for this session; note `inference: git
 
 ### Step 2.5 — dev_time and review_time
 
-The session has a dev phase (work happens, possibly across multiple tasks) and review phases (user reviews each PR and merges). Compute:
+The session has a dev phase (work happens, possibly across multiple tasks via N `/kill-this` calls) and review phases (user reviews each PR and merges). Under DEC-013, multi-task sessions are the norm — `min(pr.createdAt)` is just the first `/kill-this`, after which dev work continues on Task 2..N. The dev window therefore runs to the **last** `/kill-this`, not the first.
 
-**`dev_time`** = `(min(all pr.createdAt) − started) − breaks_in_dev_window`
-- Window: `started` to the earliest PR opening of the session. (If no PRs, dev window = `started` to `ended`.)
+**`dev_time`** = `(max(all pr.createdAt) − started) − breaks_in_dev_window`
+- Window: `started` to the latest PR opening of the session. (If no PRs, dev window = `started` to `ended`.)
 - Breaks: count only break gaps whose start timestamp falls inside this window.
+- In-session review of earlier PRs (reading the diff at `/kill-this` time) is overlapped with dev and counted as dev, not subtracted out — the user isn't review-blocked between tasks.
 
-**`review_time`** = sum across all PRs of `(merged_at − created_at) − overlap_with_dev` for each merged PR, capped at `ended − earliest_pr.created_at` if user merged before `/its-dead`.
-- If a PR was opened mid-session and merged after `/its-dead`, count only the in-session portion (up to `ended`).
-- If a PR was opened and merged in-session, count the full open→merged span.
+**`review_time`** = sum across all PRs of the post-dev-window portion of `(merged_at − created_at)`, capped at `ended − max(pr.createdAt)` if the user merged before `/its-dead`. Post-dev-window = `[max(pr.createdAt), ended]`.
+- If a PR was opened mid-session and merged after `/its-dead`, count only the in-session portion from `max(pr.createdAt)` to `ended`.
+- If a PR was opened and merged in-session, count `max(0, merged_at − max(pr.createdAt))`. The clamp is load-bearing, not a clock-skew guard: if a PR merged *before* `max(pr.createdAt)` (Task 1's PR reviewed while Task 2 was being built), that review is overlapped with dev per the dev_time rule above and intentionally absorbed into dev_time — contributing 0 here is the correct behavior, not a missing case.
 - Subtract any break gaps inside the review window.
 
 Edge cases:
 - No PRs at all: `dev_time = wall_clock - breaks`, `review_time = 0`.
-- All PRs merged after `/its-dead`: `review_time = max(0, ended - earliest_pr.created_at - breaks_in_review_window)`.
+- Single-PR session: `max(pr.createdAt) = min(pr.createdAt)`, the formula collapses to the pre-fix shape — no behavior change for the one-task case.
+- All PRs merged after `/its-dead`: `review_time = max(0, ended − max(pr.createdAt) − breaks_in_review_window)`.
 - A PR was closed without merging: do not count it in `review_time`.
 
 Round all times to nearest 0.083h (5 min). If any number comes out negative due to clock skew, clamp to 0.
@@ -125,7 +127,7 @@ Reconcile drift: issues with `phase:<N>` labels that don't appear in PROJECT_PLA
 Update the velocity table at the top:
 ```
 | Phase | Sessions | Points | Wall (h) | Dev (h) | Review (h) | hrs/pt (dev) |
-|-------|----------|--------|----------|---------|------------|--------------|
+|-------|----------|--------|----------|---------|------------|______________|
 | N     | <count>  | <pts>  | <wall>   | <dev>   | <review>   | <hrs_pt_dev> |
 ```
 
@@ -293,3 +295,4 @@ Version: v<NEW_VERSION>  (dev projects only; skipped if no package.json)
 - **Session files are read-only here.** Retro reads them; never writes. DEC-013 atomicity.
 - **GitHub queries can fail.** If `gh` and MCP are both unavailable, skip the PR-derived numbers, mark them `inference: github-unavailable` in the retro, and tell the user they can rerun retro later. Don't guess.
 - **The headline velocity is `dev_time / point`.** Wall-clock velocity is inflated by review-and-merge wait. Review-time velocity is interesting but secondary. Forecast against dev_time.
+- **The dev/review boundary is the LAST `/kill-this` of the session, not the first** (Step 2.5). Pre-fix, the formula used `min(pr.createdAt)`, which dropped Tasks 2..N out of `dev_time` and into `review_time`. Bushel Phase 3 retro surfaced the artifact: 0.15 h/pt dev vs 0.35 h/pt active. Any historical retro run before this fix that included multi-task sessions has under-reported `dev_time` and over-reported `review_time` — treat those numbers as method artifacts and forecast against `wall_clock − breaks` (active time) instead.


### PR DESCRIPTION
Base: main

## Classification table

| File | Hunk | Provenance | Classification | Action |
|------|------|------------|----------------|--------|
| `agents/architect.md` | `(e.g., "this contradicts DEC-007")` example reference in Behavior section | Template-only | Forward-port | Forward-ported |
| `skills/retro/SKILL.md` | Step 2.5 dev_time formula: `min(pr.createdAt)` → `max(pr.createdAt)` | Template-only | Forward-port | Forward-ported |
| `skills/retro/SKILL.md` | Step 2.5 multi-task explanation paragraph ("Under DEC-013, multi-task sessions are the norm…") | Template-only | Forward-port | Forward-ported |
| `skills/retro/SKILL.md` | Step 2.5 review_time: post-dev-window definition, clamp explanation, Single-PR edge case | Template-only | Forward-port | Forward-ported |
| `skills/retro/SKILL.md` | Step 2.5 edge case: `Single-PR session: max = min, formula collapses` | Template-only | Forward-port | Forward-ported |
| `skills/retro/SKILL.md` | Notes: "dev/review boundary is LAST /kill-this" paragraph | Template-only | Forward-port | Forward-ported |
| `skills/retro/SKILL.md` | Step 6 read-before-edit guard + prepend-at-top logic | Both-modified | Skip | Skipped — bushel already has the correct version of Step 6 (read-before-edit + prepend); applying seeds Step 6 would regress it |
| `agents/sync-config.md` | 2-byte whitespace diff in Step 2 commit-message block | Both-modified | Skip | Skipped — trivial whitespace, Both-modified |
| `agents/ui-reviewer.md` | Entire file is project-specific (bushel has Bay Branch Farm design system; template has [Project] placeholders) | Both-modified | Skip | Skipped — project-specific design system; applying template would erase Bushel brand content |
| `agents/tape-reader.md` | Bushel is larger (has P17); template doesn't yet | Both-modified | Skip | Skipped — upstream PR backports P17 to seeds; no downstream action needed |

## Files changed

- `.claude/agents/architect.md`
- `.claude/skills/retro/SKILL.md`

## Pattern flags

None in this run.

## Skipped hunks

- `agents/sync-config.md` — 2-byte whitespace difference only; Both-modified (each side has diverged slightly); no structural change to apply.
- `agents/ui-reviewer.md` — Both-modified. Bushel version has fully filled-in Bay Branch Farm brand system; template has [Project] placeholders. Applying template would destroy the project-specific content. Correct direction is skip.
- `agents/tape-reader.md` — Bushel is larger (P17 already present). Seeds template still at P1–P16. Upstream PR handles the backport; no downstream needed.
- `skills/retro/SKILL.md` Step 6 — Bushel already has the improved read-before-edit + prepend version; seeds template still has the older append-only version. Applying seeds here would be a regression. Upstream PR backports the bushel improvement to seeds.

## Bug fix surfaced

`skills/retro/SKILL.md` Step 2.5: bushel had the old `min(pr.createdAt)` dev_time formula. The seeds template already has the corrected `max(pr.createdAt)` formula (multi-task fix). This forward-port corrects the formula in bushel. Historical retro numbers from multi-task sessions using the old formula had under-reported dev_time and over-reported review_time — the Notes section explains how to handle those.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrroTVNsTN71bkV6jkWnU8)_