### PR TITLE
Tidy: collapse test-helper aliases to one canonical name (#122)

### DIFF
--- a/tests/admin-customers.spec.ts
+++ b/tests/admin-customers.spec.ts
@@ -2,11 +2,11 @@ import { test, expect, type Page } from "@playwright/test";
 import {
   ADMIN_STORAGE_STATE,
   TEST_CUSTOMERS,
-  adminClient,
+  admin,
 } from "./helpers";
 
 async function resetTestCustomers() {
-  const supabase = adminClient();
+  const supabase = admin();
   for (const token of [TEST_CUSTOMERS.farmStand.token, TEST_CUSTOMERS.restaurant.token]) {
     await supabase
       .from("customers")
@@ -81,7 +81,7 @@ test.describe("admin customers", () => {
 
   test("Delete customer deactivates and drops the row from the list", async ({ page }) => {
     // Seed phone so beforeEach-cleaned customer can be edited
-    const supabase = adminClient();
+    const supabase = admin();
     await supabase.from("customers").update({ phone: "216-555-0100" }).eq("token", TEST_CUSTOMERS.restaurant.token);
 
     await page.goto("/admin/customers");
@@ -108,7 +108,7 @@ test.describe("admin customers", () => {
   });
 
   test("Regenerate rotates the customer token and refreshes the row", async ({ page }) => {
-    const supabase = adminClient();
+    const supabase = admin();
     const seedToken = TEST_CUSTOMERS.restaurant.token;
 
     try {
@@ -176,7 +176,7 @@ test.describe("admin customers", () => {
     // Wait for the server action's round-trip to persist before reloading —
     // otherwise on slow projects (mobile WebKit) the reload can race and read
     // the pre-toggle DB row.
-    const supabase = adminClient();
+    const supabase = admin();
     const expectedFlipped = initial === "true" ? false : true;
     await expect
       .poll(

--- a/tests/admin-orders-export.spec.ts
+++ b/tests/admin-orders-export.spec.ts
@@ -6,7 +6,7 @@ import {
   TEST_PRODUCTS,
   admin,
   customerIds,
-  clearWeek,
+  clearOrdersForWeek,
   seedOrder,
 } from "./helpers";
 import { weekOfMondayNY } from "@/lib/week";
@@ -181,11 +181,11 @@ test.describe("admin orders export — UI", () => {
   const thisWeek = weekOfMondayNY();
 
   test.beforeEach(async () => {
-    await clearWeek(thisWeek);
+    await clearOrdersForWeek(thisWeek);
   });
 
   test.afterAll(async () => {
-    await clearWeek(thisWeek);
+    await clearOrdersForWeek(thisWeek);
   });
 
   // Set a product slug for the download test so we exercise the non-empty

--- a/tests/admin-orders.spec.ts
+++ b/tests/admin-orders.spec.ts
@@ -6,7 +6,7 @@ import {
   TEST_PRODUCTS,
   admin,
   customerIds,
-  clearWeek,
+  clearOrdersForWeek,
   seedOrder,
 } from "./helpers";
 import { weekOfMondayNY } from "@/lib/week";
@@ -17,11 +17,11 @@ test.describe("admin orders list", () => {
   const thisWeek = weekOfMondayNY();
 
   test.beforeEach(async () => {
-    await clearWeek(thisWeek);
+    await clearOrdersForWeek(thisWeek);
   });
 
   test.afterAll(async () => {
-    await clearWeek(thisWeek);
+    await clearOrdersForWeek(thisWeek);
   });
 
   test("renders current-week orders with totals and item counts", async ({ page }) => {

--- a/tests/admin-prepopulate.spec.ts
+++ b/tests/admin-prepopulate.spec.ts
@@ -3,7 +3,7 @@ import {
   ADMIN_STORAGE_STATE,
   TEST_CUSTOMERS,
   TEST_PRODUCTS,
-  adminClient,
+  admin,
 } from "./helpers";
 
 function rowByName(page: Page, name: string) {
@@ -25,7 +25,7 @@ test.describe("admin inventory — pre-populate from last week", () => {
   test.use({ storageState: ADMIN_STORAGE_STATE });
 
   test.beforeEach(async () => {
-    const supabase = adminClient();
+    const supabase = admin();
 
     // Resolve the test farm-stand customer id (seed.sql doesn't fix the UUID)
     const { data: customer, error: customerError } = await supabase
@@ -66,7 +66,7 @@ test.describe("admin inventory — pre-populate from last week", () => {
   });
 
   test.afterEach(async () => {
-    const supabase = adminClient();
+    const supabase = admin();
     await supabase.from("orders").delete().eq("id", LAST_WEEK_ORDER_ID);
     // Reset Kale qty back to the canonical seed value
     await supabase

--- a/tests/admin-send.spec.ts
+++ b/tests/admin-send.spec.ts
@@ -4,7 +4,7 @@ import {
   ADMIN_STORAGE_STATE,
   TEST_CUSTOMERS,
   admin,
-  testCustomerIds,
+  customerIds,
 } from "./helpers";
 import { weekOfMondayNY } from "@/lib/week";
 
@@ -115,7 +115,7 @@ test.describe("admin send-queue", () => {
   });
 
   test("weekly_update: lists subscribers in priority order with sms: deep links", async ({ page }) => {
-    const ids = await testCustomerIds();
+    const ids = await customerIds();
     await page.goto("/admin/send");
 
     const list = page.getByRole("list", { name: /weekly update queue/i });
@@ -147,7 +147,7 @@ test.describe("admin send-queue", () => {
       testInfo.project.name === "mobile",
       "WebKit navigates to sms:... on click and clears the page; onClick fires (server action runs) but the DOM is gone before the optimistic Sent pill can be asserted. Headless Chromium ignores the sms: navigation, so desktop covers this code path.",
     );
-    const ids = await testCustomerIds();
+    const ids = await customerIds();
     await page.goto("/admin/send");
 
     const list = page.getByRole("list", { name: /weekly update queue/i });
@@ -186,7 +186,7 @@ test.describe("admin send-queue", () => {
   test("desktop: clicking Send copies the body to clipboard and opens Messages for Web", async ({ page, context }, testInfo) => {
     test.skip(testInfo.project.name === "mobile", "Desktop-only path (Phase 6.7). Mobile uses the sms: deep link directly.");
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-    const ids = await testCustomerIds();
+    const ids = await customerIds();
     await page.goto("/admin/send");
 
     const list = page.getByRole("list", { name: /weekly update queue/i });
@@ -241,7 +241,7 @@ test.describe("admin send-queue", () => {
   });
 
   test("intro note saves and is injected into the weekly_update body", async ({ page }) => {
-    const ids = await testCustomerIds();
+    const ids = await customerIds();
     await page.goto("/admin/send");
 
     const textarea = page.getByLabel(/this week.+intro note/i);
@@ -266,7 +266,7 @@ test.describe("admin send-queue", () => {
   });
 
   test("order_confirmation mode: only customers with current-week orders appear", async ({ page }) => {
-    const ids = await testCustomerIds();
+    const ids = await customerIds();
     await clearCurrentWeekOrders();
     await ensureOrderForCustomer(TEST_CUSTOMERS.farmStand.token);
 
@@ -292,7 +292,7 @@ test.describe("admin send-queue", () => {
 
   test("mobile (375px): page fits viewport; Send button is touch-sized; drawer opens and closes", async ({ page, viewport }, testInfo) => {
     test.skip(testInfo.project.name !== "mobile", "Mobile-only assertions; covered on the mobile project.");
-    await testCustomerIds();
+    await customerIds();
     await page.goto("/admin/send");
 
     // (a) No horizontal overflow at the iPhone-13 width — shell + page combined
@@ -320,7 +320,7 @@ test.describe("admin send-queue", () => {
   });
 
   test("pickup_reminder mode: same order-bound customer set, different body", async ({ page }, testInfo) => {
-    const ids = await testCustomerIds();
+    const ids = await customerIds();
     await clearCurrentWeekOrders();
     await ensureOrderForCustomer(TEST_CUSTOMERS.farmStand.token);
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -30,9 +30,6 @@ export const TEST_PRODUCTS = {
 } as const;
 
 // Lazy admin Supabase client — only constructed when a test calls it.
-// Exported as both `admin` (the common shorthand used in admin-side specs)
-// and `adminClient` (the name customer-side specs picked up). Same function;
-// two names so the Phase 6.8 consolidation didn't churn every existing call.
 export function admin() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
@@ -40,7 +37,6 @@ export function admin() {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 }
-export { admin as adminClient };
 
 // Resolves the two seeded test customers' UUIDs by token. Used by every spec
 // that needs to query orders/sends/etc. scoped to the test fixtures.
@@ -57,14 +53,9 @@ export async function customerIds(): Promise<{ farmStand: string; restaurant: st
     restaurant: map.get(TEST_CUSTOMERS.restaurant.token)!,
   };
 }
-// admin-send + notifications-flow specs settled on `testCustomerIds`; alias
-// rather than churn every call site.
-export { customerIds as testCustomerIds };
-
 // Deletes orders for the two seeded test customers in a given NY-week-Monday.
 // Caller passes the week explicitly (use `weekOfMondayNY()` from @/lib/week
-// for the current week). admin-orders + admin-orders-export specs called
-// this `clearWeek`; alias preserved for the same reason.
+// for the current week).
 export async function clearOrdersForWeek(weekOf: string): Promise<void> {
   const sb = admin();
   const ids = await customerIds();
@@ -74,7 +65,6 @@ export async function clearOrdersForWeek(weekOf: string): Promise<void> {
     .in("customer_id", [ids.farmStand, ids.restaurant])
     .eq("week_of", weekOf);
 }
-export { clearOrdersForWeek as clearWeek };
 
 // Inserts an order + its line items for a seeded test customer. Union of the
 // shapes used across admin-orders, admin-orders-export, and orders-flow specs

--- a/tests/notifications-flow.spec.ts
+++ b/tests/notifications-flow.spec.ts
@@ -4,7 +4,7 @@ import {
   ADMIN_STORAGE_STATE,
   TEST_CUSTOMERS,
   admin,
-  testCustomerIds,
+  customerIds,
 } from "./helpers";
 import { weekOfMondayNY } from "@/lib/week";
 
@@ -119,7 +119,7 @@ test.describe("notifications cross-task flow", () => {
   });
 
   test("deep-link body contains a working customer URL — operator → customer page", async ({ page }) => {
-    const ids = await testCustomerIds();
+    const ids = await customerIds();
     await page.goto("/admin/send");
 
     // Extract the sms: href for our test customer
@@ -154,7 +154,7 @@ test.describe("notifications cross-task flow", () => {
 
   test("reload preserves Sent state — admin returns later and the pill persists", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name === "mobile", "WebKit navigates to sms:... on click and clears the page; covered on desktop");
-    const ids = await testCustomerIds();
+    const ids = await customerIds();
     await page.goto("/admin/send");
 
     const list = page.getByRole("list", { name: /weekly update queue/i });
@@ -189,7 +189,7 @@ test.describe("notifications cross-task flow", () => {
 
   test("re-send is idempotent — second click does not duplicate the row", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name === "mobile", "WebKit navigates to sms:... on click and clears the page; covered on desktop");
-    const ids = await testCustomerIds();
+    const ids = await customerIds();
     await page.goto("/admin/send");
 
     const list = page.getByRole("list", { name: /weekly update queue/i });
@@ -228,7 +228,7 @@ test.describe("notifications cross-task flow", () => {
 
   test("mode independence — sent in weekly_update does not bleed into order_confirmation", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name === "mobile", "WebKit navigates to sms:... on click and clears the page; covered on desktop");
-    const ids = await testCustomerIds();
+    const ids = await customerIds();
 
     // Seed an order so the customer appears in order_confirmation mode too.
     // try/finally so a mid-test failure doesn't leak the order into the


### PR DESCRIPTION
## Summary
Phase 6.8 preserved three alias pairs to avoid renaming call sites: `adminClient`/`admin`, `testCustomerIds`/`customerIds`, `clearWeek`/`clearOrdersForWeek`. This PR collapses each to the canonical name and removes the alias exports. Closes #122.

## Files changed
- `tests/helpers.ts` — drops three alias exports.
- 6 spec files renamed mechanically (one canonical name per call site).

## Code review
Pure mechanical rename. No behavior change.

## Test plan
- `npm run build` — green.
- `npx playwright test tests/admin-orders.spec.ts tests/admin-orders-export.spec.ts tests/admin-send.spec.ts tests/notifications-flow.spec.ts tests/admin-customers.spec.ts tests/admin-prepopulate.spec.ts --project=desktop` — 33 pass, 3 mobile-only skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)