### PR TITLE
Redirect root URL to /admin; move VersionTag to login footer

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,4 +1,5 @@
 import { signInWithGoogle } from "./actions";
+import { VersionTag } from "@/components/VersionTag";
 
 export default async function LoginPage({
   searchParams,
@@ -19,6 +20,9 @@ export default async function LoginPage({
           Sign in with Google
         </button>
       </form>
+      <footer className="fixed bottom-2 right-3">
+        <VersionTag className="text-xs text-muted-foreground" />
+      </footer>
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,9 @@
-import { VersionTag } from "@/components/VersionTag";
+import { redirect } from "next/navigation";
 
+// The bare domain has no customer-facing purpose — customers arrive at
+// /c/<token> via the weekly SMS link, never at /. Anyone hitting the root
+// is Annabel (or a curious clicker on a bookmark); send them to admin.
+// The proxy will bounce unauthenticated traffic to /login?next=/admin.
 export default function Home() {
-  return (
-    <main className="min-h-screen flex items-center justify-center px-6">
-      <div className="max-w-md text-center space-y-3">
-        <h1 className="text-2xl font-semibold tracking-tight">
-          Bay Branch Farm
-        </h1>
-        <p className="text-muted-foreground">
-          Wholesale ordering — coming soon.
-        </p>
-      </div>
-      <footer className="fixed bottom-2 right-3">
-        <VersionTag className="text-xs text-muted-foreground" />
-      </footer>
-    </main>
-  );
+  redirect("/admin");
 }


### PR DESCRIPTION
## Summary
`order.baybranchfarm.com` (bare domain) currently renders a "coming soon" splash. In production that misleads — customers arrive at `/c/<token>`, never at `/`. Anyone hitting `/` is Annabel or a bookmark click. Redirect root → `/admin`, and let the proxy bounce unauthenticated traffic to `/login?next=/admin` as it already does.

Also moves `<VersionTag />` off the (now-redirecting) home page to the `/login` footer — CLAUDE.md flagged this as a 6.1 polish task.

## Files changed
- `src/app/page.tsx` — replaces splash with `redirect("/admin")`.
- `src/app/login/page.tsx` — adds VersionTag in a fixed-bottom-right footer.

## Code review
Trivial — two small Next.js page edits, no logic changes.

## Test plan
- `npm run build` — green.
- Local: `curl -i http://localhost:3001/` → expect 307 → `Location: /admin`. ✅ Verified.
- Local: navigate to `/` in a fresh browser tab → lands at `/login` (proxy intercepts `/admin` without a session) → sign in → end up at `/admin`. (Verify post-deploy on preview.)
- Local: `/login` page shows the VersionTag in the bottom-right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)