### PR TITLE
Fix flake: customer-place-order leaves order that breaks notifications-flow (#123)

### DIFF
--- a/tests/customer-place-order.spec.ts
+++ b/tests/customer-place-order.spec.ts
@@ -32,6 +32,16 @@ test.describe("/c/[token] place order", () => {
     await resetCustomerOrderState();
   });
 
+  // Without this, the last "happy path" test leaves a freshly-placed order
+  // for the seeded farmStand customer in the current week. The next spec to
+  // alphabetically follow (notifications-flow.spec.ts) opens /c/<token> and
+  // expects to see the "What's available" heading — but the /c page redirects
+  // to /confirmed whenever an order exists for the current week, so the
+  // assertion times out. resetCustomerOrderState clears it.
+  test.afterAll(async () => {
+    await resetCustomerOrderState();
+  });
+
   test("happy path: submit creates an order + decrements inventory, lands on confirmed", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
`tests/customer-place-order.spec.ts` has `resetCustomerOrderState` in `beforeEach` but never `afterAll`. The "happy path" test submits an order; when the spec finishes, that order sits in the DB. The next alphabetical spec (`notifications-flow.spec.ts:121`) then opens `/c/<token>`, the route redirects to `/confirmed` because an order already exists, and the "What's available" assertion times out. Add `afterAll(resetCustomerOrderState)` so the spec cleans up after itself. Closes #123.

## Files changed
- `tests/customer-place-order.spec.ts` — `afterAll(resetCustomerOrderState)` after the existing `beforeEach`, with a comment pointing at the symptom this prevents.

## Code review
Trivial — one defensive cleanup hook. No behavior change to the existing tests; only affects what state the DB is in when the spec set finishes.

## Test plan
```
npx playwright test tests/customer-place-order.spec.ts tests/notifications-flow.spec.ts --project=desktop
```
Pre-fix: 6/7 pass (notifications-flow:121 times out).
Post-fix: 7/7 pass. ✅ Verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)