### PR TITLE
Phase 6.1 — Customer-side responsive polish (#106)

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -872,6 +872,19 @@
   justify-self: end;
   font-size: 1rem; color: var(--ink-700); margin: 0;
 }
+
+/* Narrow phones: eyebrow + greet on opposite edges of a 1fr 1fr grid get
+   crowded near each other (visible chasm on iPhone 13 @ 375px). Stack them
+   vertically below 480px and left-align both. 6.1 review. */
+@media (max-width: 480px) {
+  .order-page .page-head {
+    grid-template-columns: 1fr;
+  }
+  .order-page .page-head .page-head-week,
+  .order-page .page-head .page-greet {
+    justify-self: start;
+  }
+}
 .customer-name { font-weight: 600; color: var(--ink-900); }
 
 .section-title {
@@ -942,8 +955,12 @@
 .item-name {
   font-weight: 600; color: var(--ink-900);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  /* min-width: 0 lets the ellipsis actually trigger inside the .item-line1
+     flex container — without it the name fights the price for space and
+     crowds the stepper at 375px. 6.1 review. */
+  min-width: 0;
 }
-.item-price { font-size: 0.92rem; white-space: nowrap; }
+.item-price { font-size: 0.92rem; white-space: nowrap; flex-shrink: 0; }
 .item-price .mono { font-weight: 600; color: var(--ink-900); }
 .item-per { color: var(--ink-500); }
 .item-line2 { font-size: 0.82rem; }
@@ -1165,6 +1182,13 @@
   .page-rail { display: block; position: sticky; top: 20px; }
   .sticky-bar { display: none; }
   .order-page { padding-bottom: 0; }
+  /* Desktop: sticky rail is the sole order-summary affordance. Hide the
+     in-flow .submit-summary block — duplicates the rail and creates a tall
+     empty void next to the sticky column on long pages. 6.1 review. */
+  .submit-summary { display: none; }
+  /* Desktop: drop the centered headline — everything below is left-aligned
+     to the column, so a centered h1 reads as a mismatch. 6.1 review. */
+  .order-page .page-head .page-title { text-align: left; }
 }
 
 /* ============================================================


### PR DESCRIPTION
## Summary
Light ui-reviewer-driven pass on the customer order page at 375px + 1440px. Fixed 2 must-fix layout issues + 2 small polish nits; deferred the confirmed-page parity work (needs a real placed order to design against) and seed-data copy issues (separate concerns). Closes #106.

## Files changed
- `src/styles/app.css` — four targeted rule additions in the existing customer-page sections.

## What changed (per ui-reviewer findings)

**MUST-FIX:**
1. **Desktop empty rail-void** — `.submit-summary` was rendering in-flow below the sticky rail on ≥880px and duplicating its content, leaving a tall void next to the rail on long pages. Hidden at desktop; the rail is the sole order-summary affordance there.
2. **Centered desktop headline** — \"What's available\" was centered while everything below was left-aligned to the column. Dropped `text-align: center` at ≥880px.

**POLISH:**
3. **Page-head chasm at ≤480px** — the 1fr 1fr grid put the eyebrow (left) and the greet (right) on opposite edges of a narrow viewport with a visible gap. Stack vertically below 480px.
4. **Item-row crowding at 375px** — `.item-name` was missing `min-width: 0`, so the flex ellipsis didn't trigger and the name fought the price for space, crowding the stepper on longer names. Added `min-width: 0` on `.item-name` + `flex-shrink: 0` on `.item-price`.

## Deferred (will be triaged at retro or post-go-live)
- Seed data: \"bunchs\" → \"bunches\". Pluralization in product seed, not CSS.
- Eyebrow letter-spacing tightening at mobile (`.eyebrow`). Minor; survives without it.
- Confirmed page eyebrow + status art parity. Page renders the empty-state shell when no order exists; reviewer couldn't grade the real confirmed state. Revisit after Annabel places a test order during UAT (6.3).

## Out of scope
- `/admin/*` ui-reviewer pass (V2 per session decision).
- `/login` (admin).

## Code review
Skipped — small, targeted CSS additions in existing media-query blocks. Easy to revert per-rule.

## Test plan
- `npm run build` — green.
- `npx playwright test tests/customer-place-order.spec.ts --project=desktop` — 3/3 pass (no regression on submit / oversold / revisit-redirect flows).
- Visual: screenshots captured at 375px and 1440px showing the chasm gone, the headline left-aligned at desktop, no empty rail-void on long pages, and item-row breathing room at 375px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)