### PR TITLE
DEC-016 — extract Bay Branch Farm design system to .claude/ui-context.md

### DIFF
--- a/.claude/agents/sync-config.md
+++ b/.claude/agents/sync-config.md
@@ -31,7 +31,7 @@ The invoking caller passes `mode: interactive` (default) or `mode: auto`.
   - Stage commits with one of these literal message formats (no placeholders — substitute the actual values):
     - **PUSH:** `sync-config: push backport from <repo>` (e.g. `sync-config: push backport from bushel`)
     - **PULL:** `sync-config: pull propagate from seeds` (no `<repo>` — pull always sources from seeds)
-  One commit per source repo per direction. No empty commits.
+    One commit per source repo per direction. No empty commits.
   - Do NOT push, do NOT open a PR. The calling Routine handles git operations.
 
 If `mode` is missing, default to `interactive`. If `mode: auto` is requested but `direction` is also missing or ambiguous, STOP — auto mode requires both parameters resolved upfront.

--- a/.claude/agents/ui-reviewer.md
+++ b/.claude/agents/ui-reviewer.md
@@ -3,159 +3,22 @@ name: ui-reviewer
 description: Reviews visual design quality for bushel pages against the Bay Branch Farm design system. Covers brand adherence (leaf greens, cream bg, Source Sans 3), mobile responsiveness for customer pages (375px), admin desktop layout, typography, shadcn component usage, and accessibility basics. Use after completing a page or significant component, at phase boundaries, or when something looks off.
 ---
 
-You are @ui-reviewer for bushel — Bay Branch Farm's ordering system.
+You are @ui-reviewer for bushel.
 
-Two surfaces. Different rules for each.
+## Project Design System
 
-**Customer** — mobile-first, 375px primary. The farmer texted you a link. Big tap targets, plain chrome, one column.
-**Admin** — desktop-only, 1440px primary. Annabel's working tool. Dense, table-driven, ink-900 sidebar.
+Read `.claude/ui-context.md`. It contains bushel's brand tokens, surfaces, typography scale, component rules, and the project-specific review checklist. Treat it as authoritative for all design decisions below.
 
----
-
-## Brand Tokens
-
-All bushel colors are defined as CSS custom properties in `globals.css`. Source of truth: `design/tokens.css`.
-
-| Token | Hex | Tailwind semantic |
-|---|---|---|
-| `--leaf-600` | `#3B6D11` | `bg-primary` / `text-primary` |
-| `--leaf-700` | `#2C5310` | hover states, focus rings |
-| `--leaf-500` | `#4F8A1B` | badge-ready fill |
-| `--leaf-100` | `#EDF5E5` | badge-new bg, subtle highlight |
-| `--leaf-50` | `#F4F8EE` | `bg-secondary`, `bg-muted`, panel wash |
-| `--cream` | `#FBFAF5` | `bg-background` — page background |
-| `--paper` | `#FFFFFF` | `bg-card` — cards and inputs |
-| `--ink-900` | `#1A1A1A` | `text-foreground`, admin sidebar bg |
-| `--ink-700` | `#3A3A38` | secondary text |
-| `--ink-500` | `#6E6E6A` | `text-muted-foreground` |
-| `--ink-200` | `#E4E2DA` | `border-border`, row dividers |
-| `--amber-600` | `#E6A817` | `--warning` — needs_reconciliation, caution |
-| `--amber-50` | `#FFF7E0` | callout-warn background |
-| `--rose-600` | `#B23B2E` | `bg-destructive` — destructive only |
-
-**Never:** pure white or black. Never above leaf-500 saturation. No gradients. Card shadows: `0 1px 0 rgba(0,0,0,0.04)` only.
-
----
-
-## Typography
-
-- **Body / UI:** Source Sans 3 (loaded via `--font-sans`). 16px base, 1.55 leading. Weights: 300, 400, 600.
-- **Customer hero h1 only:** Playfair Display (loaded via `--font-display`). Only on the order page "What's available" title. Nowhere else.
-- **Eyebrows / labels:** Source Sans 3 600, uppercase, `letter-spacing: 0.08em`, `0.72rem`, leaf-600.
-- **Mono:** JetBrains Mono (loaded via `--font-mono`). Tokens, IDs, prices, tabular numbers.
-
-**Scale:**
-- h1 status/admin: `1.85rem` (Source Sans)
-- h1 customer hero: `2rem` mobile / `2.5rem` desktop (Playfair)
-- body: `1rem`
-- small: `0.85rem` — minimum on customer pages
-- eyebrow: `0.72rem` — absolute minimum
-
-**Flags:**
-- Playfair anywhere except customer order page h1 → High
-- Font size below 0.82rem on customer → High
-- `font-bold` anywhere → Medium (use `font-semibold`)
-
----
-
-## Spacing
-
-- 4px scale only. No arbitrary values (`p-[13px]`, `gap-[22px]`, etc.).
-- Page padding in layout.tsx only — not on individual pages.
-- Section spacing: `space-y-6` between major sections.
-
----
-
-## Border Radius
-
-`rounded-lg` (6px = `--r-sm`) everywhere. Customer CSS uses `--r-md` (10px) for cards — that's the design-defined exception. No other mixing.
-
-**Never:** `rounded-none`, `rounded-full` on non-pill/badge elements, oversized overrides.
-
----
-
-## Shadows
-
-- Cards: `var(--hairline)` = `0 1px 0 rgba(0,0,0,0.04)` only.
-- Modals/overlays: `shadow-lg`.
-- Nothing else.
-
----
-
-## Components (shadcn — admin/auth pages)
-
-- **Button** variants → semantics:
-  - `default`: leaf-600 primary action (one per screen)
-  - `secondary`: secondary action
-  - `outline`: tertiary
-  - `ghost`: nav items, icon-only
-  - `destructive`: irreversible, rose-600
-- **Badge** variants:
-  - New state: leaf-100 bg, leaf-700 text (use `secondary` variant or custom class)
-  - Ready state: leaf-500 bg, white text
-  - Picked Up / Delivered: ink-200 bg, ink-700 text
-  - Needs reconciliation: amber-50 bg + amber-600 left rule (custom — not a standard badge variant)
-- **Tables:** `w-full text-sm`, `text-muted-foreground` headers, `border-b` rows, no striping. Reconciliation rows: amber-50 bg, pinned top.
-- **Sidebar:** must use `bg-sidebar` token (ink-900) — never `bg-gray-*` or hardcoded dark colors.
-
----
-
-## Customer pages (plain CSS — no shadcn)
-
-Customer routes (`/c/[token]/*`) use `src/styles/customer.css` with the design prototype classes. Do not apply Tailwind utilities or shadcn components to customer pages.
-
-| Check | Rule |
-|---|---|
-| Touch targets | All interactive elements ≥ 44px height |
-| Single column | No multi-column layout on mobile |
-| Status art | SVG illustrations only (no generated images) |
-| Brand strip | Leaf mark + "Bay Branch Farm" in leaf-700, white background |
-| Footer | "Bay Branch Farm · 3612 W 114th St, Cleveland" in ink-500 |
-| Phone links | `sms:2162025718` (tap-to-text) — not `tel:` |
-
----
-
-## Admin layout (desktop-only)
-
-- Sidebar: ink-900 bg (`bg-sidebar`), white text, leaf-600 active accent bar left edge.
-- Top bar: cream bg, week label right-aligned, sign-out button outlined.
-- Content: fills viewport, 24px padding, no max-width constraint.
-- Mobile: no mobile fallback required in V1 (DEC-019).
-
----
-
-## Accessibility (baseline)
-
-- All interactive elements: visible focus rings (leaf-700, 2px, 2px offset). Never override with bare `outline-none`.
-- Color is not the sole state indicator — always pair with icon or text label.
-- Form fields: visible `<label>`, not placeholder-only.
-- Decorative icons and SVGs: `aria-hidden="true"`.
-- Customer status art: `aria-hidden="true"` on the SVG wrapper.
-
----
-
-## What to Check
-
-For each page or component:
-
-1. **Color / tokens** — raw hex in shadcn pages → flag. Customer pages: leaf/ink/cream vars only.
-2. **Typography** — Playfair only on customer hero h1; no font-bold; nothing below 0.82rem customer / 0.78rem admin.
-3. **Spacing** — 4px scale; no arbitrary values; page padding in layout.
-4. **Radius** — `rounded-lg` (shadcn pages); `--r-sm`/`--r-md` (customer pages); no mixing.
-5. **Shadows** — hairline on cards only; shadow-lg on modals.
-6. **Buttons/badges** — variant semantics correct; one primary per screen.
-7. **Customer 375px** — single column; 44px+ targets; no horizontal scroll.
-8. **Admin sidebar** — `bg-sidebar` token; not hardcoded.
-9. **Reconciliation rows** — amber-50 bg + amber-600 rule; pinned to top.
-10. **Accessibility** — focus rings intact; labels visible; aria-hidden on decorative SVGs.
+If the file does not exist, stop: "`.claude/ui-context.md` is missing. Create it with the project's design system before running a UI review. See `dev/claude/agents/ui-reviewer.md` in seeds for the expected format — brand tokens, surfaces, typography, component rules, and a What to Check checklist."
 
 ---
 
 ## How to Review
 
 1. Read the component/page source file(s).
-2. Take Playwright screenshots at 375px (customer) or 1440px (admin).
-3. Check each item above against source and screenshots.
+2. Read `.claude/ui-context.md` for bushel's design system and checklist.
+3. Take Playwright screenshots at the viewports listed in `ui-context.md` (default: 375px and 1440px).
+4. Work through the project-specific checklist in `ui-context.md` against the source and screenshots.
 
 ---
 
@@ -170,19 +33,27 @@ Score: X/10
 
 | Priority | Issue | Location | Fix |
 |----------|-------|----------|-----|
-| High | [description] | [file:line] | [exact change] |
+| High | [description] | [file:line or selector] | [exact change] |
 | Medium | ... | ... | ... |
 | Low | ... | ... | ... |
 
 ### Notes
-[Patterns to watch, things that are right and should be preserved.]
+[Broader observations — patterns to watch, things that are right and should be preserved, etc.]
 ```
 
 **Priority definitions:**
-- **High** — breaks functionality, fails WCAG AA contrast, or creates confusing UX
-- **Medium** — visible inconsistency with the design system; accumulates if uncaught
-- **Low** — minor polish; address at a polish phase unless trivial
+- **High** — breaks functionality, fails WCAG AA contrast, or creates a confusing UX
+- **Medium** — visible inconsistency with the design system; will accumulate if not caught
+- **Low** — minor polish; address at a polish phase unless trivial to fix now
 
-Score: start at 10, subtract 1 per High, 0.5 per Medium, 0.25 per Low (round to nearest 0.5).
+Score rubric: start at 10, subtract 1 per High, 0.5 per Medium, 0.25 per Low (round to nearest 0.5).
 
-If there are no findings, say so explicitly.
+If there are no findings, say so explicitly — "No issues found" is a valid result.
+
+## Behavior
+
+- Be specific. File paths and line numbers for every finding.
+- If everything passes, output exactly: **Clean Bill of Health.** Don't manufacture findings.
+- If a change reveals a missing primitive (e.g., a shadcn component that the project doesn't have yet), flag it as a follow-up — don't try to design the primitive yourself.
+- If a change is architecturally wrong (data shape, route boundary), say "escalate to @architect" rather than redesigning it.
+- Respect the project deadline. Don't gold-plate surfaces that are not yet in scope for the current phase.

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -68,27 +68,44 @@ If `gh` is unavailable, try `mcp__github__pull_request_read` with `owner`, `repo
 
 If both unavailable: skip PR-derived math for this session; note `inference: github-unavailable`. The user can rerun retro later.
 
-### Step 2.5 — dev_time and review_time
+### Step 2.5 — dev_time and review_time (per-PR windows, DEC-015)
 
-The session has a dev phase (work happens, possibly across multiple tasks via N `/kill-this` calls) and review phases (user reviews each PR and merges). Under DEC-013, multi-task sessions are the norm — `min(pr.createdAt)` is just the first `/kill-this`, after which dev work continues on Task 2..N. The dev window therefore runs to the **last** `/kill-this`, not the first.
+Each PR gets its own dev window (time building it) and its own review window (time reviewing it). Sum across all PRs. Replaces the prior single-boundary model — which collapsed an N-PR session to one seam and structurally under-reported dev_time when PRs > 1.
 
-**`dev_time`** = `(max(all pr.createdAt) − started) − breaks_in_dev_window`
-- Window: `started` to the latest PR opening of the session. (If no PRs, dev window = `started` to `ended`.)
-- Breaks: count only break gaps whose start timestamp falls inside this window.
-- In-session review of earlier PRs (reading the diff at `/kill-this` time) is overlapped with dev and counted as dev, not subtracted out — the user isn't review-blocked between tasks.
+Sort `pr_numbers` by `createdAt` ascending. For each `PR_i` (i = 0..N-1):
 
-**`review_time`** = sum across all PRs of the post-dev-window portion of `(merged_at − created_at)`, capped at `ended − max(pr.createdAt)` if the user merged before `/its-dead`. Post-dev-window = `[max(pr.createdAt), ended]`.
-- If a PR was opened mid-session and merged after `/its-dead`, count only the in-session portion from `max(pr.createdAt)` to `ended`.
-- If a PR was opened and merged in-session, count `max(0, merged_at − max(pr.createdAt))`. The clamp is load-bearing, not a clock-skew guard: if a PR merged *before* `max(pr.createdAt)` (Task 1's PR reviewed while Task 2 was being built), that review is overlapped with dev per the dev_time rule above and intentionally absorbed into dev_time — contributing 0 here is the correct behavior, not a missing case.
-- Subtract any break gaps inside the review window.
+**dev_window_i** = `anchor_i → PR_i.createdAt`
+- `anchor_i = started` if i = 0; otherwise `anchor_i = PR_{i-1}.mergedAt`.
+- If `PR_{i-1}.mergedAt` is null (previous PR not yet merged at retro time): use `PR_{i-1}.createdAt` as the anchor — conservative under-count of dev time for PR_i; the cost is absorbed into PR_{i-1}'s review window.
+- If `anchor_i > PR_i.createdAt` (next PR opened before previous merged — concurrent work): `dev_window_i = 0`. The time is real dev work but it overlapped review of PR_{i-1} and is counted there.
 
-Edge cases:
-- No PRs at all: `dev_time = wall_clock - breaks`, `review_time = 0`.
-- Single-PR session: `max(pr.createdAt) = min(pr.createdAt)`, the formula collapses to the pre-fix shape — no behavior change for the one-task case.
-- All PRs merged after `/its-dead`: `review_time = max(0, ended − max(pr.createdAt) − breaks_in_review_window)`.
-- A PR was closed without merging: do not count it in `review_time`.
+**review_window_i** = `PR_i.createdAt → effective_merge_i`
+- `effective_merge_i = min(PR_i.mergedAt, ended)` if `mergedAt` is non-null. If merged after `/its-dead`, cap at `ended` — post-session review is uncountable.
+- If `PR_i` is still OPEN at retro time: `effective_merge_i = ended`.
+- If `PR_i` was CLOSED-without-merge in-session: still count `PR_i.createdAt → closed_at` as review (the time was spent on it). Skip if closed after `ended`.
 
-Round all times to nearest 0.083h (5 min). If any number comes out negative due to clock skew, clamp to 0.
+**Trailing review window** — after the last in-session activity:
+- `last_in_session = max over i of (effective_merge_i)`
+- If `last_in_session < ended`: add a trailing review window `last_in_session → ended` covering session close-out (final review reads, `/its-dead`, etc.).
+
+**Subtract breaks per window:** for each window above, sum break gaps > 15 min whose start timestamp falls inside the window. Subtract from that window's contribution.
+
+**Sum and clamp:**
+```
+dev_time     = Σ max(0, dev_window_i − dev_breaks_i)
+review_time  = Σ max(0, review_window_i − review_breaks_i)
+              + max(0, trailing_window − trailing_breaks)
+```
+
+Round each to nearest 0.083 h (5 min).
+
+**Sanity check:** `dev_time + review_time + Σ breaks_in_all_windows ≈ wall_clock`. If off by more than 0.1 h after rounding, surface in Notes — likely a missed break or a merge timestamp outside the session window.
+
+**Edge cases:**
+- **N=0 (no PRs):** `dev_time = wall_clock − all_breaks`, `review_time = 0`. Pure dev session.
+- **N=1:** collapses cleanly. dev_window = `started → PR.createdAt`. review_window = `PR.createdAt → effective_merge`. Trailing = `effective_merge → ended`.
+- **N≥2 with concurrent work:** dev_window_i clamps at 0 when the next PR opened before the previous merged; that overlap time is implicitly inside PR_{i-1}'s review_window. Honest accounting — you were context-switching, not pure-deving.
+- **All PRs merged post-`/its-dead`:** every review_window caps at `ended`. dev_time and review_time still split correctly; the post-session merge time is just invisible to the metric.
 
 ### Step 2.6 — Per-session line for the retro
 
@@ -127,7 +144,7 @@ Reconcile drift: issues with `phase:<N>` labels that don't appear in PROJECT_PLA
 Update the velocity table at the top:
 ```
 | Phase | Sessions | Points | Wall (h) | Dev (h) | Review (h) | hrs/pt (dev) |
-|-------|----------|--------|----------|---------|------------|______________|
+|-------|----------|--------|----------|---------|------------|--------------|
 | N     | <count>  | <pts>  | <wall>   | <dev>   | <review>   | <hrs_pt_dev> |
 ```
 
@@ -295,4 +312,5 @@ Version: v<NEW_VERSION>  (dev projects only; skipped if no package.json)
 - **Session files are read-only here.** Retro reads them; never writes. DEC-013 atomicity.
 - **GitHub queries can fail.** If `gh` and MCP are both unavailable, skip the PR-derived numbers, mark them `inference: github-unavailable` in the retro, and tell the user they can rerun retro later. Don't guess.
 - **The headline velocity is `dev_time / point`.** Wall-clock velocity is inflated by review-and-merge wait. Review-time velocity is interesting but secondary. Forecast against dev_time.
-- **The dev/review boundary is the LAST `/kill-this` of the session, not the first** (Step 2.5). Pre-fix, the formula used `min(pr.createdAt)`, which dropped Tasks 2..N out of `dev_time` and into `review_time`. Bushel Phase 3 retro surfaced the artifact: 0.15 h/pt dev vs 0.35 h/pt active. Any historical retro run before this fix that included multi-task sessions has under-reported `dev_time` and over-reported `review_time` — treat those numbers as method artifacts and forecast against `wall_clock − breaks` (active time) instead.
+- **Each PR has its own dev + review window** (Step 2.5, DEC-015). Replaces both the original `min(pr.createdAt)` single-boundary model AND its `max(pr.createdAt)` follow-up — both collapsed multi-PR sessions to one seam and structurally mis-attributed dev vs review time. Per-PR windows make `dev_time + review_time + breaks ≈ wall_clock` honestly hold for any N.
+- **Historical retros run under the single-boundary model are method artifacts.** Sessions where N>1 will have under-reported `dev_time` and over-reported `review_time` (or vice versa, depending on which seam version). Forecast against `wall_clock − breaks` (active time) when comparing to pre-DEC-015 numbers. Going forward (post-DEC-015), `dev_time / point` and `review_time / point` are both meaningful headlines.

--- a/.claude/ui-context.md
+++ b/.claude/ui-context.md
@@ -1,0 +1,149 @@
+# bushel — UI Design System Context
+
+Used by @ui-reviewer. Contains the authoritative design system for bushel (Bay Branch Farm ordering system).
+
+## Surfaces
+
+Two surfaces. Different rules for each.
+
+**Customer** — mobile-first, 375px primary. The farmer texted you a link. Big tap targets, plain chrome, one column.
+**Admin** — desktop-only, 1440px primary. Annabel's working tool. Dense, table-driven, ink-900 sidebar.
+
+Viewports for screenshots: **375px** (customer pages), **1440px** (admin pages).
+
+---
+
+## Brand Tokens
+
+All bushel colors are defined as CSS custom properties in `src/styles/app.css`. Source of truth: `design/tokens.css`.
+
+| Token | Hex | Tailwind semantic |
+|---|---|---|
+| `--leaf-600` | `#3B6D11` | `bg-primary` / `text-primary` |
+| `--leaf-700` | `#2C5310` | hover states, focus rings |
+| `--leaf-500` | `#4F8A1B` | badge-ready fill |
+| `--leaf-100` | `#EDF5E5` | badge-new bg, subtle highlight |
+| `--leaf-50` | `#F4F8EE` | `bg-secondary`, `bg-muted`, panel wash |
+| `--cream` | `#FBFAF5` | `bg-background` — page background |
+| `--paper` | `#FFFFFF` | `bg-card` — cards and inputs |
+| `--ink-900` | `#1A1A1A` | `text-foreground`, admin sidebar bg |
+| `--ink-700` | `#3A3A38` | secondary text |
+| `--ink-500` | `#6E6E6A` | `text-muted-foreground` |
+| `--ink-200` | `#E4E2DA` | `border-border`, row dividers |
+| `--amber-600` | `#E6A817` | `--warning` — needs_reconciliation, caution |
+| `--amber-50` | `#FFF7E0` | callout-warn background |
+| `--rose-600` | `#B23B2E` | `bg-destructive` — destructive only |
+
+**Never:** pure white or black. Never above leaf-500 saturation. No gradients. Card shadows: `0 1px 0 rgba(0,0,0,0.04)` only.
+
+---
+
+## Typography
+
+- **Body / UI:** Source Sans 3 (loaded via `--font-sans`). 16px base, 1.55 leading. Weights: 300, 400, 600.
+- **Customer hero h1 only:** Playfair Display (loaded via `--font-display`). Only on the order page "What's available" title. Nowhere else.
+- **Eyebrows / labels:** Source Sans 3 600, uppercase, `letter-spacing: 0.08em`, `0.72rem`, leaf-600.
+- **Mono:** JetBrains Mono (loaded via `--font-mono`). Tokens, IDs, prices, tabular numbers.
+
+**Scale:**
+- h1 status/admin: `1.85rem` (Source Sans)
+- h1 customer hero: `2rem` mobile / `2.5rem` desktop (Playfair)
+- body: `1rem`
+- small: `0.85rem` — minimum on customer pages
+- eyebrow: `0.72rem` — absolute minimum
+
+**Flags:**
+- Playfair anywhere except customer order page h1 → High
+- Font size below 0.82rem on customer → High
+- `font-bold` anywhere → Medium (use `font-semibold`)
+
+---
+
+## Spacing
+
+- 4px scale only. No arbitrary values (`p-[13px]`, `gap-[22px]`, etc.).
+- Page padding in layout.tsx only — not on individual pages.
+- Section spacing: `space-y-6` between major sections.
+
+---
+
+## Border Radius
+
+`rounded-lg` (6px = `--r-sm`) everywhere. Customer CSS uses `--r-md` (10px) for cards — that's the design-defined exception. No other mixing.
+
+**Never:** `rounded-none`, `rounded-full` on non-pill/badge elements, oversized overrides.
+
+---
+
+## Shadows
+
+- Cards: `var(--hairline)` = `0 1px 0 rgba(0,0,0,0.04)` only.
+- Modals/overlays: `shadow-lg`.
+- Nothing else.
+
+---
+
+## Components (shadcn — admin/auth pages)
+
+- **Button** variants → semantics:
+  - `default`: leaf-600 primary action (one per screen)
+  - `secondary`: secondary action
+  - `outline`: tertiary
+  - `ghost`: nav items, icon-only
+  - `destructive`: irreversible, rose-600
+- **Badge** variants:
+  - New state: leaf-100 bg, leaf-700 text (use `secondary` variant or custom class)
+  - Ready state: leaf-500 bg, white text
+  - Picked Up / Delivered: ink-200 bg, ink-700 text
+  - Needs reconciliation: amber-50 bg + amber-600 left rule (custom — not a standard badge variant)
+- **Tables:** `w-full text-sm`, `text-muted-foreground` headers, `border-b` rows, no striping. Reconciliation rows: amber-50 bg, pinned top.
+- **Sidebar:** must use `bg-sidebar` token (ink-900) — never `bg-gray-*` or hardcoded dark colors.
+
+---
+
+## Customer pages (plain CSS — no shadcn)
+
+Customer routes (`/c/[token]/*`) use `src/styles/app.css` with the design prototype classes. Do not apply Tailwind utilities or shadcn components to customer pages.
+
+| Check | Rule |
+|---|---|
+| Touch targets | All interactive elements ≥ 44px height |
+| Single column | No multi-column layout on mobile |
+| Status art | SVG illustrations only (no generated images) |
+| Brand strip | Leaf mark + "Bay Branch Farm" in leaf-700, white background |
+| Footer | "Bay Branch Farm · 3612 W 114th St, Cleveland" in ink-500 |
+| Phone links | `sms:2162025718` (tap-to-text) — not `tel:` |
+
+---
+
+## Admin layout (desktop-only)
+
+- Sidebar: ink-900 bg (`bg-sidebar`), white text, leaf-600 active accent bar left edge.
+- Top bar: cream bg, week label right-aligned, sign-out button outlined.
+- Content: fills viewport, 24px padding, no max-width constraint.
+- Mobile: no mobile fallback required in V1 (DEC-019).
+
+---
+
+## Accessibility (baseline)
+
+- All interactive elements: visible focus rings (leaf-700, 2px, 2px offset). Never override with bare `outline-none`.
+- Color is not the sole state indicator — always pair with icon or text label.
+- Form fields: visible `<label>`, not placeholder-only.
+- Decorative icons and SVGs: `aria-hidden="true"`.
+- Customer status art: `aria-hidden="true"` on the SVG wrapper.
+
+---
+
+## What to Check
+
+1. **Color / tokens** — raw hex in shadcn pages → flag. Customer pages: leaf/ink/cream vars only.
+2. **Typography** — Playfair only on customer hero h1; no font-bold; nothing below 0.82rem customer / 0.78rem admin.
+3. **Spacing** — 4px scale; no arbitrary values; page padding in layout.
+4. **Radius** — `rounded-lg` (shadcn pages); `--r-sm`/`--r-md` (customer pages); no mixing.
+5. **Shadows** — hairline on cards only; shadow-lg on modals.
+6. **Buttons/badges** — variant semantics correct; one primary per screen.
+7. **Customer 375px** — single column; 44px+ targets; no horizontal scroll.
+8. **Admin sidebar** — `bg-sidebar` token; not hardcoded.
+9. **Reconciliation rows** — amber-50 bg + amber-600 rule; pinned to top.
+10. **Accessibility** — focus rings intact; labels visible; aria-hidden on decorative SVGs.


### PR DESCRIPTION
## Summary

- Creates `.claude/ui-context.md` with all bushel-specific design system content: brand tokens (leaf/ink/cream/amber), customer vs admin surface rules, typography (Source Sans 3, Playfair hero h1), component semantics, and the What to Check checklist
- Slims `.claude/agents/ui-reviewer.md` to match the new generic seeds shell (DEC-016, seeds PR #51): read-context step, How to Review, output format, behavior rules — no project content

## Why

`ui-reviewer.md` was Both-modified vs the seeds template on every nightly sync run because it contained both generic structure and Bay Branch Farm brand content. After this PR, the agent shell is structurally identical to seeds (with "bushel" filled in where the template has "[Project]"), so structural improvements propagate automatically. The design system lives in one readable place.

## What to verify

After merge, a `diff` of `seeds/dev/claude/agents/ui-reviewer.md` vs `.claude/agents/ui-reviewer.md` should show only the `[Project]` → `bushel` substitutions and the description line — nothing structural.

🤖 Generated with [Claude Code](https://claude.com/claude-code)