### PR TITLE
Sticky-bar button: Review → scroll to fulfillment

### DIFF
--- a/design/order-page.jsx
+++ b/design/order-page.jsx
@@ -2,7 +2,7 @@
  * Mobile-first responsive. State driven by tweaks.
  */
 
-const { useState, useMemo, useEffect } = React;
+const { useState, useMemo, useEffect, useRef } = React;
 
 // ───── Data ──────────────────────────────────────────────────────────
 const INVENTORY = [
@@ -147,6 +147,11 @@ function OrderPage({ tweaks }) {
     setTimeout(() => setSubmitted(false), 2400);
   };
 
+  const fulfillRef = useRef(null);
+  const scrollToFulfill = () => {
+    fulfillRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
   return (
     <div className={"order-page vp-" + (tweaks.viewport || "mobile")}>
       {/* Top brand strip */}
@@ -208,7 +213,7 @@ function OrderPage({ tweaks }) {
             </section>
 
             {/* Fulfillment ──────────────────────────────── */}
-            <section className="fulfill">
+            <section className="fulfill" ref={fulfillRef}>
               <Eyebrow>fulfillment</Eyebrow>
               <h2 className="section-title">How would you like it?</h2>
               <div className="fulfill-tabs">
@@ -391,10 +396,9 @@ function OrderPage({ tweaks }) {
         </div>
         <button
           className="btn btn-primary sticky-btn"
-          onClick={submit}
+          onClick={scrollToFulfill}
           disabled={lineCount === 0}>
-          
-          {submitted ? "✓ Placed" : "Review & submit"}
+          Review
         </button>
       </div>
     </div>);

--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -214,6 +214,11 @@ export function OrderForm({
   // latch; the server action is idempotent on the second call but the second
   // request still hits the network unnecessarily.
   const submittingRef = useRef(false);
+  const fulfillRef = useRef<HTMLElement>(null);
+
+  const scrollToFulfill = () => {
+    fulfillRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
 
   const itemsWithQty = useMemo(
     () => products.filter((p) => (qty[p.id] ?? 0) > 0),
@@ -350,7 +355,7 @@ export function OrderForm({
               </div>
             </section>
 
-            <section className="fulfill">
+            <section className="fulfill" ref={fulfillRef}>
               <div className="eyebrow">fulfillment</div>
               <h2 className="section-title">How would you like it?</h2>
               <div className="fulfill-tabs" role="tablist">
@@ -538,15 +543,10 @@ export function OrderForm({
         <button
           type="button"
           className="btn btn-primary sticky-btn"
-          onClick={handleSubmit}
-          disabled={submitDisabled}
-          aria-busy={isPending}
+          onClick={scrollToFulfill}
+          disabled={lineCount === 0}
         >
-          {isPending ? (
-            <span className="btn-spinner" aria-hidden="true" />
-          ) : (
-            "Review & submit"
-          )}
+          Review
         </button>
       </div>
     </div>

--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -544,7 +544,7 @@ export function OrderForm({
           type="button"
           className="btn btn-primary sticky-btn"
           onClick={scrollToFulfill}
-          disabled={lineCount === 0}
+          disabled={submitDisabled}
         >
           Review
         </button>

--- a/tests/customer-order-form.spec.ts
+++ b/tests/customer-order-form.spec.ts
@@ -105,4 +105,29 @@ test.describe("/c/[token] order form", () => {
     await page.goto(customerOrderUrl(TEST_CUSTOMERS.restaurant.token));
     await expect(page.locator("#delivery-pref")).toHaveValue("");
   });
+
+  test("sticky-bar Review scrolls to fulfillment without submitting", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "mobile", "Sticky bar is mobile-only (CSS @media >= 880px hides it).");
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+
+    const kaleRow = page.locator(".item-row", { hasText: TEST_PRODUCTS.kale.name });
+    await kaleRow.getByRole("button", { name: "increase" }).click();
+
+    const stickyBtn = page.locator(".sticky-btn");
+    await expect(stickyBtn).toHaveText("Review");
+
+    // Scroll back to top so the click has somewhere to scroll to (test fixture
+    // is short enough that fulfill can already be in view).
+    await page.evaluate(() => window.scrollTo(0, 0));
+    const beforeY = await page.evaluate(() => window.scrollY);
+
+    await stickyBtn.click();
+
+    // Fulfill section is in viewport after click, scroll position moved down,
+    // and we did NOT navigate to /confirmed.
+    await expect(page.locator(".fulfill")).toBeInViewport();
+    const afterY = await page.evaluate(() => window.scrollY);
+    expect(afterY).toBeGreaterThan(beforeY);
+    expect(page.url()).not.toContain("/confirmed");
+  });
 });


### PR DESCRIPTION
## Summary
Closes #145. Renames the customer order sticky-bar button from "Review & submit" to "Review", and changes its behavior from immediate-submit to `scrollIntoView` on the fulfillment `<section>`. The real "Submit order" buttons (inline summary block + desktop rail card) are untouched — they remain the commit path. Mirrored in `design/order-page.jsx` per CLAUDE.md's design-authoritative rule.

## Files changed
- `src/components/customer/OrderForm.tsx`
- `design/order-page.jsx`
- `tests/customer-order-form.spec.ts`

## Code review
One finding, fixed in a follow-up commit (`37e3979`): sticky button now uses the shared `submitDisabled` predicate (`lineCount === 0 || isPending`) instead of `lineCount === 0`, matching the other two submit buttons. This prevents the sticky from being interactive while an in-flight submit is pending. Otherwise clean — design mockup synced, a11y unchanged (`<button type="button">` with clear label), real commit paths untouched.

## Test plan
- Open `/c/[token]` on a 375px viewport (mobile project).
- Confirm sticky bar reads "Review" (not "Review & submit") once an item is in the cart.
- Tap "Review" → fulfillment section scrolls into view. No `/confirmed` navigation; no `place_order` server action fires.
- Scroll further to the inline summary section → "Submit order" still places the order normally.
- Desktop ≥880px: sticky bar still hidden (CSS `@media`), rail-card "Submit order" unchanged.
- Playwright: `npx playwright test tests/customer-order-form.spec.ts --project=mobile` — 9 passed, including the new `sticky-bar Review scrolls to fulfillment without submitting` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)