### PR TITLE
6.5a — product_units migration + backfill + safety-net triggers

### DIFF
--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -138,6 +138,7 @@ export type Database = {
           id: string
           order_id: string
           product_id: string
+          product_unit_id: string
           qty: number
           unit_price_cents: number
         }
@@ -146,6 +147,7 @@ export type Database = {
           id?: string
           order_id: string
           product_id: string
+          product_unit_id: string
           qty: number
           unit_price_cents: number
         }
@@ -154,6 +156,7 @@ export type Database = {
           id?: string
           order_id?: string
           product_id?: string
+          product_unit_id?: string
           qty?: number
           unit_price_cents?: number
         }
@@ -170,6 +173,13 @@ export type Database = {
             columns: ["product_id"]
             isOneToOne: false
             referencedRelation: "products"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "order_items_product_unit_id_fkey"
+            columns: ["product_unit_id"]
+            isOneToOne: false
+            referencedRelation: "product_units"
             referencedColumns: ["id"]
           },
         ]
@@ -265,6 +275,53 @@ export type Database = {
             columns: ["customer_id"]
             isOneToOne: false
             referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      product_units: {
+        Row: {
+          conversion_to_base: number
+          created_at: string
+          id: string
+          is_active: boolean
+          label: string
+          product_id: string
+          slug: string
+          sort_order: number | null
+          unit_price_cents: number
+          updated_at: string
+        }
+        Insert: {
+          conversion_to_base?: number
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          label: string
+          product_id: string
+          slug: string
+          sort_order?: number | null
+          unit_price_cents: number
+          updated_at?: string
+        }
+        Update: {
+          conversion_to_base?: number
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          label?: string
+          product_id?: string
+          slug?: string
+          sort_order?: number | null
+          unit_price_cents?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "product_units_product_id_fkey"
+            columns: ["product_id"]
+            isOneToOne: false
+            referencedRelation: "products"
             referencedColumns: ["id"]
           },
         ]

--- a/supabase/migrations/20260522175735_multi_unit_products.sql
+++ b/supabase/migrations/20260522175735_multi_unit_products.sql
@@ -100,7 +100,11 @@ alter table public.products
 --     is guaranteed unique even if two products share a name (which happens
 --     in test fixtures and isn't otherwise prevented). The 6.5b admin UI will
 --     offer human-curated slugs; this trigger is the safety net.
-create function public.products_spawn_default_unit() returns trigger as $$
+create function public.products_spawn_default_unit() returns trigger
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
 begin
   insert into public.product_units (
     product_id, label, conversion_to_base, unit_price_cents, is_active, slug
@@ -116,7 +120,7 @@ begin
   on conflict (product_id, label) do nothing;
   return new;
 end;
-$$ language plpgsql security definer;
+$$;
 
 create trigger products_spawn_default_unit_trigger
   after insert on public.products
@@ -124,7 +128,11 @@ create trigger products_spawn_default_unit_trigger
 
 -- 5b. order_items inserts without product_unit_id inherit from the product's
 --     first active unit (the default, until callers wise up to multi-unit).
-create function public.order_items_default_unit() returns trigger as $$
+create function public.order_items_default_unit() returns trigger
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
 begin
   if new.product_unit_id is null then
     select id into new.product_unit_id
@@ -135,7 +143,7 @@ begin
   end if;
   return new;
 end;
-$$ language plpgsql;
+$$;
 
 create trigger order_items_default_unit_trigger
   before insert on public.order_items

--- a/supabase/migrations/20260522175735_multi_unit_products.sql
+++ b/supabase/migrations/20260522175735_multi_unit_products.sql
@@ -1,0 +1,142 @@
+-- Multi-unit products (DEC-032, issue #151, parent #135).
+--
+-- Adds product_units as the source of truth for unit/label/price; each existing
+-- product gets one product_units row backfilled (single-unit equivalent).
+-- order_items grows a product_unit_id FK so a line can reference the specific
+-- unit ordered. products.qty_available widens to numeric(10,2) for fractional
+-- decrement (e.g., 0.5 lb of basil).
+--
+-- products.unit and products.price_cents are intentionally left in place this
+-- migration — they continue to function as a fallback until 6.5b–e (admin UI,
+-- customer picker, order placement) land, after which a follow-up migration
+-- removes them.
+--
+-- Two safety-net triggers keep callers that don't yet know about product_units
+-- working unchanged: products auto-spawn a default unit row, and order_items
+-- inherit product_unit_id from that default if omitted. Both become no-ops
+-- once 6.5b and 6.5d ship; they can be removed in the cleanup migration.
+
+-- ------------------------------------------------------------
+-- 1. product_units table
+-- ------------------------------------------------------------
+create table public.product_units (
+  id                  uuid          not null primary key default gen_random_uuid(),
+  product_id          uuid          not null references public.products(id) on delete cascade,
+  label               text          not null,
+  conversion_to_base  numeric(10,4) not null default 1.0 check (conversion_to_base > 0),
+  unit_price_cents    integer       not null check (unit_price_cents > 0),
+  is_active           boolean       not null default true,
+  slug                text          not null,
+  sort_order          integer,
+  created_at          timestamptz   not null default now(),
+  updated_at          timestamptz   not null default now(),
+  unique (product_id, label),
+  unique (slug)
+);
+
+create index product_units_product_id_idx on public.product_units (product_id);
+create index product_units_active_idx     on public.product_units (product_id) where is_active;
+
+alter table public.product_units enable row level security;
+
+create policy "public_read_product_units" on public.product_units
+  for select to anon using (is_active = true);
+
+create policy "admin_all_product_units" on public.product_units
+  for all to authenticated using (true) with check (true);
+
+
+-- ------------------------------------------------------------
+-- 2. Backfill: one product_units row per existing product
+-- ------------------------------------------------------------
+-- Slug = lowercased name with non-alphanumerics collapsed to '-' and trimmed,
+-- plus the first 8 chars of the product id. The id suffix guarantees
+-- uniqueness even if two products share a name (which has happened in V1 —
+-- e.g., "Basil (bunch)" vs "Basil (lb)" before multi-unit lands). Wave item
+-- slugs land here so this is the format Wave will see.
+insert into public.product_units (product_id, label, conversion_to_base, unit_price_cents, is_active, slug)
+select
+  id,
+  unit,
+  1.0,
+  price_cents,
+  true,
+  trim(both '-' from regexp_replace(lower(name), '[^a-z0-9]+', '-', 'g'))
+    || '-' || left(id::text, 8)
+from public.products;
+
+
+-- ------------------------------------------------------------
+-- 3. order_items.product_unit_id (nullable → backfill → not null)
+-- ------------------------------------------------------------
+alter table public.order_items
+  add column product_unit_id uuid references public.product_units(id) on delete restrict;
+
+update public.order_items oi
+   set product_unit_id = pu.id
+  from public.product_units pu
+ where pu.product_id = oi.product_id;
+
+alter table public.order_items
+  alter column product_unit_id set not null;
+
+create index order_items_product_unit_id_idx on public.order_items (product_unit_id);
+
+
+-- ------------------------------------------------------------
+-- 4. products.qty_available → numeric(10,2)
+-- ------------------------------------------------------------
+-- Tracked in base units for fractional decrement (DEC-032).
+alter table public.products
+  alter column qty_available type numeric(10,2) using qty_available::numeric(10,2);
+
+
+-- ------------------------------------------------------------
+-- 5. Safety-net triggers (removable after 6.5b + 6.5d ship)
+-- ------------------------------------------------------------
+
+-- 5a. New products get a default product_units row (mirroring the backfill).
+--     Slug appends the first 8 chars of product_id so the auto-generated slug
+--     is guaranteed unique even if two products share a name (which happens
+--     in test fixtures and isn't otherwise prevented). The 6.5b admin UI will
+--     offer human-curated slugs; this trigger is the safety net.
+create function public.products_spawn_default_unit() returns trigger as $$
+begin
+  insert into public.product_units (
+    product_id, label, conversion_to_base, unit_price_cents, is_active, slug
+  ) values (
+    new.id,
+    new.unit,
+    1.0,
+    new.price_cents,
+    true,
+    trim(both '-' from regexp_replace(lower(new.name), '[^a-z0-9]+', '-', 'g'))
+      || '-' || left(new.id::text, 8)
+  )
+  on conflict (product_id, label) do nothing;
+  return new;
+end;
+$$ language plpgsql security definer;
+
+create trigger products_spawn_default_unit_trigger
+  after insert on public.products
+  for each row execute function public.products_spawn_default_unit();
+
+-- 5b. order_items inserts without product_unit_id inherit from the product's
+--     first active unit (the default, until callers wise up to multi-unit).
+create function public.order_items_default_unit() returns trigger as $$
+begin
+  if new.product_unit_id is null then
+    select id into new.product_unit_id
+      from public.product_units
+     where product_id = new.product_id and is_active = true
+     order by sort_order nulls last, created_at
+     limit 1;
+  end if;
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger order_items_default_unit_trigger
+  before insert on public.order_items
+  for each row execute function public.order_items_default_unit();

--- a/supabase/tests/product_units.sql
+++ b/supabase/tests/product_units.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(24);
+select plan(28);
 
 -- ============================================================
 -- Schema sanity (migration 20260522175735_multi_unit_products)
@@ -18,6 +18,44 @@ select has_column('public', 'product_units', 'slug',               'product_unit
 select has_column('public', 'order_items',   'product_unit_id',    'order_items.product_unit_id exists (DEC-032)');
 select col_not_null('public', 'order_items', 'product_unit_id',    'order_items.product_unit_id is NOT NULL');
 select col_type_is('public', 'products', 'qty_available', 'numeric(10,2)', 'products.qty_available widened to numeric(10,2)');
+
+-- ============================================================
+-- Backfill: every pre-existing product got exactly one product_units row
+-- ============================================================
+select is(
+  (select count(*)::int from public.products),
+  (select count(distinct product_id)::int from public.product_units),
+  'backfill produced one product_units row per existing product'
+);
+
+-- ============================================================
+-- FK enforcement on order_items.product_unit_id
+-- ============================================================
+insert into public.customers (id, name, token)
+values ('cccccccc-aaaa-0000-0000-000000000001'::uuid, 'FK Customer', 'token-fk');
+
+insert into public.orders (id, customer_id, week_of, fulfillment_type, status)
+values ('cccccccc-bbbb-0000-0000-000000000001'::uuid,
+        'cccccccc-aaaa-0000-0000-000000000001'::uuid,
+        '2026-05-11', 'delivery', 'new');
+
+select throws_ok(
+  $$ insert into public.order_items (order_id, product_id, qty, unit_price_cents, product_unit_id)
+     values ('cccccccc-bbbb-0000-0000-000000000001'::uuid,
+             (select id from public.products limit 1),
+             1, 100,
+             '99999999-9999-9999-9999-999999999999'::uuid) $$,
+  '23503', null, 'order_items.product_unit_id FK rejects unknown unit id'
+);
+
+-- ============================================================
+-- conversion_to_base > 0 check
+-- ============================================================
+select throws_ok(
+  $$ insert into public.product_units (product_id, label, conversion_to_base, unit_price_cents, slug)
+     values ((select id from public.products limit 1), 'bad', 0, 100, 'bad-zero') $$,
+  '23514', null, 'product_units.conversion_to_base must be > 0'
+);
 
 -- ============================================================
 -- Safety-net trigger: new product spawns a default unit row
@@ -140,6 +178,18 @@ select lives_ok(
   'authenticated can insert product_units'
 );
 reset role;
+
+-- ============================================================
+-- Cascade: deleting a product wipes its product_units rows
+-- ============================================================
+delete from public.order_items where product_id = 'eeeeeeee-0000-0000-0000-000000000001'::uuid;
+delete from public.products where id = 'eeeeeeee-0000-0000-0000-000000000001'::uuid;
+select is(
+  (select count(*)::int from public.product_units
+    where product_id = 'eeeeeeee-0000-0000-0000-000000000001'::uuid),
+  0,
+  'deleting a product cascades to its product_units rows'
+);
 
 select * from finish();
 rollback;

--- a/supabase/tests/product_units.sql
+++ b/supabase/tests/product_units.sql
@@ -1,0 +1,145 @@
+begin;
+select plan(24);
+
+-- ============================================================
+-- Schema sanity (migration 20260522175735_multi_unit_products)
+-- ============================================================
+select has_table('public', 'product_units', 'product_units table exists');
+select is(
+  (select relrowsecurity from pg_class where oid = 'public.product_units'::regclass),
+  true, 'RLS enabled on product_units'
+);
+select has_column('public', 'product_units', 'product_id',         'product_units.product_id exists');
+select has_column('public', 'product_units', 'label',              'product_units.label exists');
+select has_column('public', 'product_units', 'conversion_to_base', 'product_units.conversion_to_base exists');
+select has_column('public', 'product_units', 'unit_price_cents',   'product_units.unit_price_cents exists');
+select has_column('public', 'product_units', 'is_active',          'product_units.is_active exists');
+select has_column('public', 'product_units', 'slug',               'product_units.slug exists');
+select has_column('public', 'order_items',   'product_unit_id',    'order_items.product_unit_id exists (DEC-032)');
+select col_not_null('public', 'order_items', 'product_unit_id',    'order_items.product_unit_id is NOT NULL');
+select col_type_is('public', 'products', 'qty_available', 'numeric(10,2)', 'products.qty_available widened to numeric(10,2)');
+
+-- ============================================================
+-- Safety-net trigger: new product spawns a default unit row
+-- ============================================================
+insert into public.products (id, name, unit, price_cents, qty_available, is_available)
+values ('eeeeeeee-0000-0000-0000-000000000001'::uuid, 'Test Multi Unit Item', 'each', 250, 7, true);
+
+select is(
+  (select count(*)::int from public.product_units
+    where product_id = 'eeeeeeee-0000-0000-0000-000000000001'::uuid),
+  1,
+  'product_units auto-spawned for newly inserted product'
+);
+
+select is(
+  (select label from public.product_units
+    where product_id = 'eeeeeeee-0000-0000-0000-000000000001'::uuid),
+  'each',
+  'auto-spawned unit copies products.unit'
+);
+
+select is(
+  (select unit_price_cents from public.product_units
+    where product_id = 'eeeeeeee-0000-0000-0000-000000000001'::uuid),
+  250,
+  'auto-spawned unit copies products.price_cents'
+);
+
+select is(
+  (select conversion_to_base from public.product_units
+    where product_id = 'eeeeeeee-0000-0000-0000-000000000001'::uuid),
+  1.0::numeric(10,4),
+  'auto-spawned unit has conversion_to_base = 1.0'
+);
+
+select is(
+  (select slug from public.product_units
+    where product_id = 'eeeeeeee-0000-0000-0000-000000000001'::uuid),
+  'test-multi-unit-item-eeeeeeee',
+  'auto-spawned unit slug = name-slug + product-id prefix'
+);
+
+-- ============================================================
+-- Safety-net trigger: order_items inherits product_unit_id
+-- ============================================================
+insert into public.customers (id, name, token)
+values ('ffffffff-0000-0000-0000-000000000001'::uuid, 'Multi Unit Customer', 'token-mu');
+
+insert into public.orders (id, customer_id, week_of, fulfillment_type, status)
+values ('eeeeeeee-1111-0000-0000-000000000001'::uuid,
+        'ffffffff-0000-0000-0000-000000000001'::uuid,
+        '2026-05-11', 'delivery', 'new');
+
+-- Insert WITHOUT product_unit_id; trigger should inherit from default unit.
+insert into public.order_items (order_id, product_id, qty, unit_price_cents)
+values ('eeeeeeee-1111-0000-0000-000000000001'::uuid,
+        'eeeeeeee-0000-0000-0000-000000000001'::uuid,
+        2, 250);
+
+select isnt(
+  (select product_unit_id from public.order_items
+    where order_id = 'eeeeeeee-1111-0000-0000-000000000001'::uuid),
+  null,
+  'order_items.product_unit_id auto-filled by trigger'
+);
+
+select is(
+  (select pu.product_id from public.order_items oi
+     join public.product_units pu on pu.id = oi.product_unit_id
+    where oi.order_id = 'eeeeeeee-1111-0000-0000-000000000001'::uuid),
+  'eeeeeeee-0000-0000-0000-000000000001'::uuid,
+  'auto-filled product_unit_id belongs to the right product'
+);
+
+-- ============================================================
+-- products.qty_available accepts fractional values
+-- ============================================================
+update public.products
+   set qty_available = 3.5
+ where id = 'eeeeeeee-0000-0000-0000-000000000001'::uuid;
+
+select is(
+  (select qty_available from public.products
+    where id = 'eeeeeeee-0000-0000-0000-000000000001'::uuid),
+  3.5::numeric(10,2),
+  'products.qty_available stores fractional values (3.5)'
+);
+
+-- ============================================================
+-- RLS — anon
+-- ============================================================
+-- Mark one unit inactive so we can verify the active-only filter.
+insert into public.product_units (product_id, label, conversion_to_base, unit_price_cents, is_active, slug)
+values ('eeeeeeee-0000-0000-0000-000000000001'::uuid, 'inactive-unit', 0.5, 500, false, 'test-multi-unit-item-inactive');
+
+set local role anon;
+select isnt_empty(
+  $$ select * from public.product_units where is_active = true $$,
+  'anon can read active product_units'
+);
+select is_empty(
+  $$ select * from public.product_units where is_active = false $$,
+  'anon cannot read inactive product_units'
+);
+select throws_ok(
+  $$ insert into public.product_units (product_id, label, unit_price_cents, slug)
+     values ('eeeeeeee-0000-0000-0000-000000000001', 'x', 100, 'x-x') $$,
+  '42501', null, 'anon cannot insert product_units'
+);
+reset role;
+
+set local role authenticated;
+select isnt_empty(
+  $$ select * from public.product_units $$,
+  'authenticated can read all product_units (active + inactive)'
+);
+select lives_ok(
+  $$ insert into public.product_units (product_id, label, unit_price_cents, slug)
+     values ('eeeeeeee-0000-0000-0000-000000000001', 'pound', 600, 'test-multi-unit-item-pound') $$,
+  'authenticated can insert product_units'
+);
+reset role;
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
Closes #151, closes #133. Part of [#135](https://github.com/mobiustripper42/bushel/issues/135) (multi-unit products epic, DEC-032). Lays the schema groundwork for multi-unit products: `product_units` table, `order_items.product_unit_id` FK, `products.qty_available` widened to `numeric(10,2)`. Two safety-net triggers keep the existing `place_order` flow + `seedOrder` helper working unmodified until 6.5d ships.

## Files changed
- `supabase/migrations/20260522175735_multi_unit_products.sql`
- `supabase/tests/product_units.sql`
- `src/lib/supabase/types.ts`

## Key design decisions
- **Slugs include first 8 chars of `product_id`** so two products with the same name (V1 has had this — basil bunch vs basil lb) don't collide on the global slug unique constraint. Wave item slugs land here.
- **Safety-net triggers** (AFTER INSERT on products spawns a default unit; BEFORE INSERT on order_items defaults `product_unit_id` from the product's first active unit) keep the unmodified `place_order` DB function working. Both are explicitly removable in the cleanup migration after 6.5d ships.
- **`products.unit` and `products.price_cents` are NOT removed in this migration.** They keep functioning alongside `product_units` until 6.5b–e land, then a follow-up migration drops them.

## Code review
Two follow-ups applied in `e34ea58`:
- Both new functions now use `security invoker` + `set search_path = public, pg_temp`, matching the `place_order` precedent. The original `security definer` widened attack surface unnecessarily (triggers only fire on inserts already gated by table RLS).
- pgTAP coverage extended: backfill row count, order_items FK rejection, `conversion_to_base > 0` check, product cascade-delete. 24 → 28 plan; full suite 90 → 94 assertions.

Otherwise clean. Migration applies cleanly on local; Playwright customer-place-order + admin-orders specs pass against the new schema (the safety-net triggers do their job — `place_order` keeps working unmodified).

## Migration deployment status
- **dev/preview** (`nnmfubmlvnkouxxfxxlh`): migration already pushed pre-review. Function bodies on that environment carry the pre-`e34ea58` shape (with `security definer`) until next `supabase db reset`. Functionally identical; the hardening is defense in depth, not a fix.
- **prod** (`piaobrnrmoxnfrpnpixw`): not pushed yet. Will get the cleaned version on first push after merge.

## Test plan
- `supabase db reset` against local — applies migration clean, all prior migrations still pass.
- `supabase test db` — all 94 pgTAP assertions pass:
  - Schema: 11 columns/types/RLS/NOT NULL assertions.
  - Triggers: 8 assertions covering spawn-default-unit + inherit-product-unit-id.
  - Fractional `qty_available`: 1 assertion.
  - RLS anon/authenticated: 5 assertions.
  - Backfill: 1 assertion (one row per pre-existing product).
  - FK rejection: 1 assertion.
  - Check constraint: 1 assertion.
  - Cascade-delete: 1 assertion.
- `npm run build` — green, types regenerated.
- `npx playwright test tests/customer-place-order.spec.ts tests/customer-order-form.spec.ts --project=mobile` — 12 passed, 1 skipped (desktop variant).
- `npx playwright test tests/orders-flow.spec.ts tests/admin-orders.spec.ts tests/admin-orders-export.spec.ts --project=desktop` — 17 passed, 1 skipped.
- Manual: `/c/[testtoken-farmstand-0001]` on the dev/preview deploy — adding items, placing an order, and confirming the resulting `order_items.product_unit_id` is non-null (filled by the safety-net trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)