### PR TITLE
Phase 6.5b — Per-product Units sub-sheet (#152)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -62,7 +62,16 @@
       "Bash(NOTIFICATIONS_ENABLED=false npx playwright test tests/admin-send.spec.ts:154 --project=mobile)",
       "Bash(sed -n '85,105p' src/styles/app.css)",
       "Bash(sed -n '845,855p' src/styles/app.css)",
-      "Bash(kill -9 1104178)"
+      "Bash(kill -9 1104178)",
+      "Bash(kill -9 382085 387825)",
+      "Bash(PORT=3001 npx next *)",
+      "Bash(PGPASSWORD=postgres psql *)",
+      "Bash(docker exec *)",
+      "Bash(netstat -tlnp)",
+      "Bash(kill -9 306301)",
+      "Bash(vercel env *)",
+      "Bash(awk NR>=170 && NR<=182 *)",
+      "Bash(kill -9 3368201)"
     ]
   }
 }

--- a/design/admin-inventory.css
+++ b/design/admin-inventory.css
@@ -274,6 +274,163 @@
   font-weight: 400;
 }
 
+/* Units chip — sits under the inline unit cell. Opens the Units drawer. */
+.inv-unitsChip {
+  display: inline-flex; align-items: center; gap: 6px;
+  margin-top: 4px;
+  padding: 3px 9px 3px 6px;
+  background: transparent;
+  border: 1px dashed var(--ink-300);
+  border-radius: 999px;
+  font-family: var(--sans);
+  font-size: 0.74rem;
+  font-weight: 500;
+  color: var(--ink-500);
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+.inv-unitsChip:hover {
+  background: var(--leaf-50);
+  color: var(--leaf-700);
+  border-color: var(--leaf-100);
+}
+.inv-unitsChip.is-multi {
+  border-style: solid;
+  border-color: var(--leaf-100);
+  background: var(--leaf-50);
+  color: var(--leaf-700);
+  font-weight: 600;
+}
+.inv-unitsChip-plus {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 14px; height: 14px;
+  border-radius: 50%;
+  background: var(--ink-200);
+  color: var(--ink-700);
+  font-size: 0.78rem;
+  line-height: 1;
+}
+.inv-unitsChip:hover .inv-unitsChip-plus {
+  background: var(--leaf-600);
+  color: var(--paper);
+}
+.inv-unitsChip-count {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 18px; height: 18px; padding: 0 5px;
+  border-radius: 999px;
+  background: var(--leaf-600);
+  color: var(--paper);
+  font-size: 0.72rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Units drawer */
+.units-drawer { width: min(560px, 100vw); }
+.units-drawer-sub {
+  margin-top: 6px;
+  font-size: 0.82rem;
+  color: var(--ink-500);
+  line-height: 1.4;
+}
+
+.units-list {
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-sm);
+  background: var(--paper);
+  overflow: hidden;
+}
+.units-list-head,
+.units-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) 90px 100px 56px 36px;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+}
+.units-list-head {
+  background: var(--cream);
+  border-bottom: 1px solid var(--ink-200);
+  font-size: 0.66rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-500);
+}
+.units-col-hint {
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--ink-300);
+  margin-left: 2px;
+}
+.units-row {
+  border-top: 1px solid var(--ink-200);
+  position: relative;
+}
+.units-row:first-of-type { border-top: 0; }
+.units-row.is-base { background: var(--leaf-50); }
+.units-row.is-inactive { background: var(--ink-100); }
+.units-row.is-inactive .inv-cell { color: var(--ink-500); }
+
+.units-col-label {
+  position: relative;
+  display: flex; align-items: center; gap: 6px;
+}
+.units-col-label .inv-cell { flex: 1; min-width: 0; }
+.units-baseBadge {
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 2px 5px;
+  background: var(--leaf-600);
+  color: var(--paper);
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.units-col-conv .inv-cell:disabled,
+.units-col-conv .inv-cell[disabled] {
+  background: var(--ink-100);
+  color: var(--ink-500);
+  cursor: not-allowed;
+}
+
+.units-col-price .inv-priceWrap { width: 100%; }
+.units-col-price .inv-cell { padding-left: 22px; }
+
+.units-col-active { display: flex; justify-content: center; }
+.units-col-trash  { display: flex; justify-content: flex-end; }
+
+.units-addRow {
+  display: flex; align-items: center; gap: 10px;
+  width: 100%;
+  padding: 10px 14px;
+  background: transparent;
+  border: none;
+  border-top: 1px dashed var(--ink-300);
+  font-family: var(--sans);
+  font-size: 0.86rem;
+  font-weight: 500;
+  color: var(--ink-500);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s, color 0.1s;
+}
+.units-addRow:hover { background: var(--leaf-50); color: var(--leaf-700); }
+
+.units-help {
+  margin-top: 18px;
+  padding: 12px 14px;
+  background: var(--cream);
+  border-radius: var(--r-sm);
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--ink-700);
+}
+.units-help strong { color: var(--ink-900); }
+.units-help em { font-style: italic; color: var(--leaf-700); }
+
 /* Sticky save bar */
 .inv-saveBar {
   position: sticky;

--- a/design/admin-inventory.jsx
+++ b/design/admin-inventory.jsx
@@ -1,21 +1,49 @@
 /* Admin · Inventory editor */
 
-const { useState, useMemo, useRef } = React;
+const { useState, useMemo, useRef, useEffect } = React;
 
 const CATEGORIES = ["Vegetables", "Fruit", "Herbs", "Flowers", "Other"];
 
+/* Seed inventory. Each product carries a `units` array — every product has
+ * at least one row (the base unit, conversion 1.0). Multi-unit products have
+ * additional rows with conversion-to-base != 1.0. The row's top-level
+ * `price` + `unit` mirror the base unit and stay inline-editable for speed;
+ * additional units live behind the Units drawer. */
 const SEED_ROWS = [
-  { id: "p01", name: "Heirloom tomatoes",   category: "Vegetables", price: 5.50, unit: "per lb",     qty: 24, desc: "Mix of Cherokee Purple, Brandywine, and Striped German.", available: true },
-  { id: "p02", name: "Genovese basil",      category: "Herbs",      price: 3.50, unit: "per bunch",  qty: 18, desc: "Big leaves — pesto-ready.", available: true },
-  { id: "p03", name: "Dino kale",           category: "Vegetables", price: 4.50, unit: "per bunch",  qty: 12, desc: "Lacinato. Tender stems this week.", available: true },
-  { id: "p04", name: "Sungold cherry tomatoes", category: "Vegetables", price: 6.00, unit: "per pint", qty: 16, desc: "Picked Tuesday. Honey-sweet.", available: true },
-  { id: "p05", name: "Red beets",           category: "Vegetables", price: 3.25, unit: "per lb",     qty: 9,  desc: "Tops included — good for sautéing.", available: true },
-  { id: "p06", name: "Zucchini",            category: "Vegetables", price: 2.50, unit: "each",       qty: 22, desc: "Medium size, tender skin.", available: true },
-  { id: "p07", name: "Zinnia bouquet",      category: "Flowers",    price: 12.00, unit: "per bunch", qty: 6,  desc: "Mixed colors, ~15 stems.", available: true },
-  { id: "p08", name: "Strawberries",        category: "Fruit",      price: 7.50, unit: "per pint",   qty: 0,  desc: "Last picking — back next week.", available: false },
-  { id: "p09", name: "Garlic scapes",       category: "Herbs",      price: 4.00, unit: "per bunch",  qty: 14, desc: "Curly tops, mild garlic flavor.", available: true },
-  { id: "p10", name: "Rainbow chard",       category: "Vegetables", price: 4.50, unit: "per bunch",  qty: 11, desc: "Beautiful stems — yellow, magenta, white.", available: true },
+  { id: "p01", name: "Heirloom tomatoes",   category: "Vegetables", price: 5.50, unit: "per lb",     qty: 24, desc: "Mix of Cherokee Purple, Brandywine, and Striped German.", available: true,
+    units: [
+      { id: "u01a", label: "per lb", conv: 1.0, price: 5.50, active: true, base: true },
+    ] },
+  { id: "p02", name: "Genovese basil",      category: "Herbs",      price: 3.50, unit: "per bunch",  qty: 18, desc: "Big leaves — pesto-ready.", available: true,
+    units: [
+      { id: "u02a", label: "per bunch", conv: 1.0,  price: 3.50,  active: true, base: true },
+      { id: "u02b", label: "per lb",    conv: 0.25, price: 12.00, active: true, base: false },
+    ] },
+  { id: "p03", name: "Dino kale",           category: "Vegetables", price: 4.50, unit: "per bunch",  qty: 12, desc: "Lacinato. Tender stems this week.", available: true,
+    units: [
+      { id: "u03a", label: "per bunch", conv: 1.0, price: 4.50, active: true, base: true },
+    ] },
+  { id: "p04", name: "Sungold cherry tomatoes", category: "Vegetables", price: 6.00, unit: "per pint", qty: 16, desc: "Picked Tuesday. Honey-sweet.", available: true,
+    units: [
+      { id: "u04a", label: "per pint", conv: 1.0, price: 6.00,  active: true, base: true },
+      { id: "u04b", label: "per qt",   conv: 0.5, price: 11.50, active: true, base: false },
+    ] },
+  { id: "p05", name: "Red beets",           category: "Vegetables", price: 3.25, unit: "per lb",     qty: 9,  desc: "Tops included — good for sautéing.", available: true,
+    units: [ { id: "u05a", label: "per lb", conv: 1.0, price: 3.25, active: true, base: true } ] },
+  { id: "p06", name: "Zucchini",            category: "Vegetables", price: 2.50, unit: "each",       qty: 22, desc: "Medium size, tender skin.", available: true,
+    units: [ { id: "u06a", label: "each", conv: 1.0, price: 2.50, active: true, base: true } ] },
+  { id: "p07", name: "Zinnia bouquet",      category: "Flowers",    price: 12.00, unit: "per bunch", qty: 6,  desc: "Mixed colors, ~15 stems.", available: true,
+    units: [ { id: "u07a", label: "per bunch", conv: 1.0, price: 12.00, active: true, base: true } ] },
+  { id: "p08", name: "Strawberries",        category: "Fruit",      price: 7.50, unit: "per pint",   qty: 0,  desc: "Last picking — back next week.", available: false,
+    units: [ { id: "u08a", label: "per pint", conv: 1.0, price: 7.50, active: true, base: true } ] },
+  { id: "p09", name: "Garlic scapes",       category: "Herbs",      price: 4.00, unit: "per bunch",  qty: 14, desc: "Curly tops, mild garlic flavor.", available: true,
+    units: [ { id: "u09a", label: "per bunch", conv: 1.0, price: 4.00, active: true, base: true } ] },
+  { id: "p10", name: "Rainbow chard",       category: "Vegetables", price: 4.50, unit: "per bunch",  qty: 11, desc: "Beautiful stems — yellow, magenta, white.", available: true,
+    units: [ { id: "u10a", label: "per bunch", conv: 1.0, price: 4.50, active: true, base: true } ] },
 ];
+
+let nextUnitId = 100;
+function newUnitId() { return "u" + String(nextUnitId++); }
 
 let nextId = 11;
 function newRowId() { return "p" + String(nextId++).padStart(2, "0"); }
@@ -23,6 +51,7 @@ function newRowId() { return "p" + String(nextId++).padStart(2, "0"); }
 function InventoryPage() {
   const [rows, setRows] = useState(SEED_ROWS);
   const [originalRows] = useState(SEED_ROWS);
+  const [unitsOpenFor, setUnitsOpenFor] = useState(null); // product id, or null
 
   const dirty = useMemo(
     () => JSON.stringify(rows) !== JSON.stringify(originalRows),
@@ -46,12 +75,27 @@ function InventoryPage() {
   const remove = (id) =>
     setRows(rs => rs.filter(r => r.id !== id));
 
-  const addRow = () =>
+  const addRow = () => {
+    const baseId = newUnitId();
     setRows(rs => [...rs, {
       id: newRowId(),
       name: "", category: "Vegetables", price: 0, unit: "per lb",
-      qty: 0, desc: "", available: true
+      qty: 0, desc: "", available: true,
+      units: [{ id: baseId, label: "per lb", conv: 1.0, price: 0, active: true, base: true }],
     }]);
+  };
+
+  /* When base-unit label/price change inline, mirror onto the product row.
+   * When extra units change in the drawer, they don't touch the inline cells. */
+  const saveUnits = (productId, nextUnits) => {
+    const base = nextUnits.find(u => u.base);
+    setRows(rs => rs.map(r => r.id === productId
+      ? { ...r, unit: base ? base.label : r.unit, price: base ? base.price : r.price, units: nextUnits }
+      : r));
+    setUnitsOpenFor(null);
+  };
+
+  const productForDrawer = unitsOpenFor ? rows.find(r => r.id === unitsOpenFor) : null;
 
   return (
     <div className="inv-page">
@@ -108,6 +152,7 @@ function InventoryPage() {
                 index={i}
                 onUpdate={(patch) => update(row.id, patch)}
                 onRemove={() => remove(row.id)}
+                onOpenUnits={() => setUnitsOpenFor(row.id)}
               />
             ))}
           </tbody>
@@ -118,6 +163,14 @@ function InventoryPage() {
           <span className="inv-addRow-hint mono">↹ Tab moves between cells</span>
         </button>
       </div>
+
+      {productForDrawer && (
+        <UnitsDrawer
+          product={productForDrawer}
+          onClose={() => setUnitsOpenFor(null)}
+          onSave={(nextUnits) => saveUnits(productForDrawer.id, nextUnits)}
+        />
+      )}
 
       {dirty && (
         <div className="inv-saveBar">
@@ -135,8 +188,10 @@ function InventoryPage() {
   );
 }
 
-function InventoryRow({ row, index, onUpdate, onRemove }) {
+function InventoryRow({ row, index, onUpdate, onRemove, onOpenUnits }) {
   const [descOpen, setDescOpen] = useState(false);
+  const extras = (row.units || []).filter(u => !u.base);
+  const inactiveCount = extras.filter(u => !u.active).length;
   return (
     <>
       <tr className={"inv-row" + (!row.available ? " is-unavail" : "")}>
@@ -202,6 +257,18 @@ function InventoryRow({ row, index, onUpdate, onRemove }) {
             onChange={e => onUpdate({ unit: e.target.value })}
             placeholder="per lb"
           />
+          <button
+            type="button"
+            className={"inv-unitsChip" + (extras.length > 0 ? " is-multi" : "")}
+            onClick={onOpenUnits}
+            title={extras.length > 0 ? "Edit units" : "Add another unit"}
+          >
+            {extras.length === 0
+              ? <><span className="inv-unitsChip-plus">+</span><span>Add unit</span></>
+              : <><span className="inv-unitsChip-count">{extras.length + 1}</span>
+                  <span>units{inactiveCount > 0 ? ` · ${inactiveCount} off` : ""}</span></>
+            }
+          </button>
         </td>
         <td className="col-qty">
           <input
@@ -256,6 +323,186 @@ function Switch({ checked, onChange }) {
     >
       <span className="inv-switch-thumb"></span>
     </button>
+  );
+}
+
+/* Units drawer — per-product unit editor.
+ * Base row: BASE badge, label + price editable, conversion locked at 1, no delete.
+ * Extra rows: label, conversion-to-base, price, active toggle, delete.
+ * Validation surfaces inline; server enforces label uniqueness + active >= 1. */
+function UnitsDrawer({ product, onClose, onSave }) {
+  const [units, setUnits] = useState(() => product.units.map(u => ({ ...u })));
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const update = (id, patch) => {
+    setUnits(us => us.map(u => u.id === id ? { ...u, ...patch } : u));
+    setError(null);
+  };
+  const remove = (id) => {
+    setUnits(us => us.filter(u => u.id !== id));
+    setError(null);
+  };
+  const addUnit = () => {
+    setUnits(us => [...us, {
+      id: newUnitId(), label: "", conv: 1, price: 0, active: true, base: false,
+    }]);
+    setError(null);
+  };
+
+  const dirty = useMemo(
+    () => JSON.stringify(units) !== JSON.stringify(product.units),
+    [units, product.units]
+  );
+
+  const handleSave = () => {
+    const labels = units.map(u => u.label.trim().toLowerCase());
+    const dupe = labels.find((l, i) => l && labels.indexOf(l) !== i);
+    if (dupe) { setError(`Two units share the label "${dupe}". Labels must be unique within a product.`); return; }
+    const blank = units.find(u => !u.label.trim());
+    if (blank) { setError("Every unit needs a label."); return; }
+    const badConv = units.find(u => !u.base && (!(u.conv > 0)));
+    if (badConv) { setError(`Conversion-to-base must be greater than zero (check "${badConv.label}").`); return; }
+    if (!units.some(u => u.active)) { setError("At least one unit must stay active."); return; }
+    onSave(units);
+  };
+
+  const baseUnit = units.find(u => u.base);
+  const extras = units.filter(u => !u.base);
+
+  return (
+    <>
+      <div className="drawer-scrim" onClick={onClose} aria-hidden="true" />
+      <aside
+        className="drawer units-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Units for ${product.name}`}
+      >
+        <header className="drawer-head">
+          <div>
+            <div className="eyebrow">edit units</div>
+            <h2 className="drawer-title">{product.name || "Untitled product"}</h2>
+            <div className="units-drawer-sub">
+              Customers pick a unit when ordering. Inventory decrements in the base unit.
+            </div>
+          </div>
+          <button type="button" className="drawer-close" onClick={onClose} aria-label="Close drawer">
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M6 6l12 12 M18 6 6 18"/>
+            </svg>
+          </button>
+        </header>
+
+        <div className="drawer-body">
+          {error && <div role="alert" className="drawer-error">{error}</div>}
+
+          <div className="units-list">
+            <div className="units-list-head">
+              <span className="units-col-label">Label</span>
+              <span className="units-col-conv" title="How many base units this equals. Base unit = 1.">
+                Conversion
+              </span>
+              <span className="units-col-price">Price</span>
+              <span className="units-col-active">Active</span>
+              <span className="units-col-trash" />
+            </div>
+
+            {baseUnit && (
+              <UnitRow
+                unit={baseUnit}
+                onUpdate={(patch) => update(baseUnit.id, patch)}
+              />
+            )}
+            {extras.map(u => (
+              <UnitRow
+                key={u.id}
+                unit={u}
+                onUpdate={(patch) => update(u.id, patch)}
+                onRemove={() => remove(u.id)}
+              />
+            ))}
+
+            <button type="button" className="units-addRow" onClick={addUnit}>
+              <span className="inv-addRow-plus">+</span>
+              <span>Add another unit</span>
+            </button>
+          </div>
+
+          <div className="units-help">
+            <strong>Conversion-to-base</strong> is how much of the base unit one of this unit equals.
+            If the base is <em>per bunch</em> and a pound of basil is roughly four bunches, the pound row's
+            conversion is <span className="mono">4.0</span>. If the base is <em>per pint</em> and a quart is two pints,
+            the quart row is <span className="mono">2.0</span>.
+          </div>
+        </div>
+
+        <footer className="drawer-foot">
+          <div style={{ flex: 1 }} />
+          <button type="button" className="btn btn-ghost" onClick={onClose}>Cancel</button>
+          <button type="button" className={"btn btn-primary" + (dirty ? " is-dirty" : "")} onClick={handleSave} disabled={!dirty}>
+            {dirty ? "Save units" : "Saved"}
+          </button>
+        </footer>
+      </aside>
+    </>
+  );
+}
+
+function UnitRow({ unit, onUpdate, onRemove }) {
+  return (
+    <div className={"units-row" + (unit.base ? " is-base" : "") + (!unit.active ? " is-inactive" : "")}>
+      <div className="units-col-label">
+        <input
+          type="text"
+          className="inv-cell"
+          value={unit.label}
+          onChange={e => onUpdate({ label: e.target.value })}
+          placeholder={unit.base ? "per lb" : "e.g. per pound"}
+        />
+        {unit.base && <span className="units-baseBadge">BASE</span>}
+      </div>
+      <div className="units-col-conv">
+        <input
+          type="number"
+          step="0.1"
+          min="0"
+          className="inv-cell inv-num"
+          value={unit.conv}
+          onChange={e => onUpdate({ conv: parseFloat(e.target.value) || 0 })}
+          disabled={unit.base}
+          title={unit.base ? "Base unit is always 1.0" : ""}
+        />
+      </div>
+      <div className="units-col-price">
+        <div className="inv-priceWrap">
+          <span className="inv-priceSym">$</span>
+          <input
+            type="number"
+            step="0.25"
+            min="0"
+            className="inv-cell inv-num"
+            value={unit.price}
+            onChange={e => onUpdate({ price: parseFloat(e.target.value) || 0 })}
+          />
+        </div>
+      </div>
+      <div className="units-col-active">
+        <Switch checked={unit.active} onChange={v => onUpdate({ active: v })}/>
+      </div>
+      <div className="units-col-trash">
+        {!unit.base && (
+          <button type="button" className="inv-trash" onClick={onRemove} aria-label="Delete unit">
+            <IconTrash/>
+          </button>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/design/preview-inventory.html
+++ b/design/preview-inventory.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Admin · Inventory — design preview</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="tokens.css">
+  <link rel="stylesheet" href="admin-shell.css">
+  <link rel="stylesheet" href="admin-customers.css">
+  <link rel="stylesheet" href="admin-inventory.css">
+  <style>
+    body { margin: 0; background: var(--cream); font-family: var(--sans); color: var(--ink-900); }
+    .preview-shell { max-width: 1180px; margin: 0 auto; padding: 28px 28px 80px; }
+    .preview-banner {
+      margin-bottom: 18px;
+      padding: 10px 14px;
+      background: var(--leaf-50);
+      border: 1px solid var(--leaf-100);
+      border-radius: var(--r-sm);
+      font-size: 0.82rem;
+      color: var(--leaf-700);
+    }
+  </style>
+</head>
+<body>
+  <div class="preview-shell">
+    <div class="preview-banner">
+      <strong>Design preview · admin-inventory.jsx</strong>
+      — open the Units chip under any unit cell to see the drawer.
+      "Genovese basil" and "Sungold cherry tomatoes" have 2 units; everything else is single-unit.
+    </div>
+    <div id="root"></div>
+  </div>
+
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script>
+    (async () => {
+      const src = await fetch("admin-inventory.jsx").then(r => r.text());
+      const out = Babel.transform(src, { presets: ["react"] }).code;
+      // eslint-disable-next-line no-new-func
+      new Function(out)();
+      const root = ReactDOM.createRoot(document.getElementById("root"));
+      root.render(React.createElement(window.InventoryPage));
+    })();
+  </script>
+</body>
+</html>

--- a/src/actions/save-product-units.ts
+++ b/src/actions/save-product-units.ts
@@ -94,7 +94,19 @@ export async function saveProductUnits(
       .from("product_units")
       .delete()
       .in("id", input.deletedUnitIds);
-    if (error) return { error: error.message };
+    if (error) {
+      // 23503 = foreign_key_violation — order_items.product_unit_id is ON
+      // DELETE RESTRICT. Surface a friendly message so Annabel knows the
+      // remedy (deactivate instead of delete) without seeing the raw FK
+      // constraint name.
+      if (error.code === "23503") {
+        return {
+          error:
+            "Can't delete a unit that's already on an existing order. Turn the Active switch off instead — customers won't see it next week.",
+        };
+      }
+      return { error: error.message };
+    }
   }
 
   for (const u of trimmed) {

--- a/src/actions/save-product-units.ts
+++ b/src/actions/save-product-units.ts
@@ -1,0 +1,130 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+
+export type UnitInput = {
+  // null = new unit (insert); non-null = existing (update)
+  id: string | null;
+  label: string;
+  conversion_to_base: number;
+  unit_price_cents: number;
+  is_active: boolean;
+  sort_order: number | null;
+};
+
+export type SaveProductUnitsInput = {
+  productId: string;
+  units: UnitInput[];
+  deletedUnitIds: string[];
+};
+
+export type SaveProductUnitsResult = {
+  error: string | null;
+};
+
+// Slug format matches the 6.5a safety-net trigger:
+//   <product-name-slug>-<unit-label-slug>-<first 8 chars of product_id>
+// The id8 suffix keeps slugs globally unique even when two products share a
+// name. The base unit's slug (created by the trigger) omits the unit-label
+// segment — additional units sit alongside under <name>-<label>-<id8>.
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function unitSlug(productName: string, productId: string, label: string): string {
+  const nameSlug = slugify(productName);
+  const labelSlug = slugify(label);
+  const id8 = productId.slice(0, 8);
+  return `${nameSlug}-${labelSlug}-${id8}`;
+}
+
+export async function saveProductUnits(
+  input: SaveProductUnitsInput,
+): Promise<SaveProductUnitsResult> {
+  if (input.units.length === 0) {
+    return { error: "A product must have at least one unit." };
+  }
+
+  const trimmed = input.units.map((u) => ({ ...u, label: u.label.trim() }));
+
+  for (const u of trimmed) {
+    if (!u.label) return { error: "Every unit needs a label." };
+    if (!(u.conversion_to_base > 0)) {
+      return { error: `Conversion must be greater than zero (check "${u.label}").` };
+    }
+    if (!Number.isInteger(u.unit_price_cents) || u.unit_price_cents < 0) {
+      return { error: `Price must be a non-negative amount (check "${u.label}").` };
+    }
+  }
+
+  const seen = new Map<string, string>();
+  for (const u of trimmed) {
+    const key = u.label.toLowerCase();
+    if (seen.has(key)) {
+      return {
+        error: `Two units share the label "${u.label}". Labels must be unique within a product.`,
+      };
+    }
+    seen.set(key, u.label);
+  }
+
+  if (!trimmed.some((u) => u.is_active)) {
+    return { error: "At least one unit must stay active." };
+  }
+
+  const supabase = await createClient();
+
+  const { data: product, error: prodErr } = await supabase
+    .from("products")
+    .select("id, name")
+    .eq("id", input.productId)
+    .single();
+  if (prodErr || !product) {
+    return { error: prodErr?.message ?? "Product not found." };
+  }
+
+  // Delete first so existing labels can be reassigned within the same save
+  // without colliding on the unique (product_id, label) index.
+  if (input.deletedUnitIds.length > 0) {
+    const { error } = await supabase
+      .from("product_units")
+      .delete()
+      .in("id", input.deletedUnitIds);
+    if (error) return { error: error.message };
+  }
+
+  for (const u of trimmed) {
+    if (u.id === null) {
+      const slug = unitSlug(product.name, product.id, u.label);
+      const { error } = await supabase.from("product_units").insert({
+        product_id: input.productId,
+        label: u.label,
+        conversion_to_base: u.conversion_to_base,
+        unit_price_cents: u.unit_price_cents,
+        is_active: u.is_active,
+        sort_order: u.sort_order,
+        slug,
+      });
+      if (error) return { error: error.message };
+    } else {
+      const { error } = await supabase
+        .from("product_units")
+        .update({
+          label: u.label,
+          conversion_to_base: u.conversion_to_base,
+          unit_price_cents: u.unit_price_cents,
+          is_active: u.is_active,
+          sort_order: u.sort_order,
+        })
+        .eq("id", u.id);
+      if (error) return { error: error.message };
+    }
+  }
+
+  revalidatePath("/admin/inventory");
+  return { error: null };
+}

--- a/src/app/(admin)/admin/inventory/page.tsx
+++ b/src/app/(admin)/admin/inventory/page.tsx
@@ -1,26 +1,48 @@
 import { createClient } from "@/lib/supabase/server";
 import { InventoryEditor } from "@/components/admin/inventory-editor";
 import type { InventoryRowState } from "@/components/admin/inventory-row";
+import type { ProductUnitState } from "@/components/admin/units-drawer";
 import { weekOfLabel } from "@/lib/week";
 
 export default async function InventoryPage() {
   const supabase = await createClient();
-  const { data: products, error } = await supabase
-    .from("products")
-    .select("*")
-    .order("sort_order", { ascending: true, nullsFirst: false })
-    .order("name");
+  const [productsRes, unitsRes] = await Promise.all([
+    supabase
+      .from("products")
+      .select("*")
+      .order("sort_order", { ascending: true, nullsFirst: false })
+      .order("name"),
+    supabase
+      .from("product_units")
+      .select("id, product_id, label, conversion_to_base, unit_price_cents, is_active, sort_order")
+      .order("sort_order", { ascending: true, nullsFirst: false })
+      .order("id"),
+  ]);
 
-  if (error) {
+  if (productsRes.error || unitsRes.error) {
     return (
       <main style={{ padding: "28px 32px", maxWidth: 1200 }}>
         <h1 className="page-title">Inventory</h1>
-        <p style={{ color: "var(--rose-600)", marginTop: 16 }}>{error.message}</p>
+        <p style={{ color: "var(--rose-600)", marginTop: 16 }}>
+          {productsRes.error?.message ?? unitsRes.error?.message}
+        </p>
       </main>
     );
   }
 
-  const initialRows: InventoryRowState[] = (products ?? []).map((p) => ({
+  const unitsByProductId: Record<string, ProductUnitState[]> = {};
+  for (const u of unitsRes.data ?? []) {
+    (unitsByProductId[u.product_id] ??= []).push({
+      id: u.id,
+      label: u.label,
+      conversion_to_base: Number(u.conversion_to_base),
+      unit_price_cents: u.unit_price_cents,
+      is_active: u.is_active,
+      sort_order: u.sort_order,
+    });
+  }
+
+  const initialRows: InventoryRowState[] = (productsRes.data ?? []).map((p) => ({
     id: p.id,
     name: p.name,
     category: p.category,
@@ -34,7 +56,11 @@ export default async function InventoryPage() {
 
   return (
     <main style={{ padding: "28px 32px 60px", maxWidth: 1200, width: "100%" }}>
-      <InventoryEditor initialRows={initialRows} weekLabel={weekOfLabel()} />
+      <InventoryEditor
+        initialRows={initialRows}
+        initialUnits={unitsByProductId}
+        weekLabel={weekOfLabel()}
+      />
     </main>
   );
 }

--- a/src/components/admin/inventory-editor.tsx
+++ b/src/components/admin/inventory-editor.tsx
@@ -9,10 +9,12 @@ import { StatusDot } from "@/components/ui/status-dot";
 import { SaveBar } from "@/components/ui/save-bar";
 import { InventoryRow, type InventoryRowState } from "@/components/admin/inventory-row";
 import { PrepopulateButton } from "@/components/admin/prepopulate-button";
+import { UnitsDrawer, type ProductUnitState } from "@/components/admin/units-drawer";
 import { saveInventory } from "@/actions/save-inventory";
 
 type Props = {
   initialRows: InventoryRowState[];
+  initialUnits: Record<string, ProductUnitState[]>;
   weekLabel: string;
 };
 
@@ -21,13 +23,14 @@ function newLocalId(): string {
   return `new-${Date.now()}-${nextLocalId++}`;
 }
 
-export function InventoryEditor({ initialRows, weekLabel }: Props) {
+export function InventoryEditor({ initialRows, initialUnits, weekLabel }: Props) {
   const router = useRouter();
   const [rows, setRows] = useState<InventoryRowState[]>(initialRows);
   const [baseline, setBaseline] = useState<InventoryRowState[]>(initialRows);
   const [deletedIds, setDeletedIds] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [saving, startSaving] = useTransition();
+  const [unitsOpenFor, setUnitsOpenFor] = useState<string | null>(null);
 
   const baselineMap = useMemo(() => {
     const m = new Map<string, InventoryRowState>();
@@ -204,14 +207,20 @@ export function InventoryEditor({ initialRows, weekLabel }: Props) {
             </tr>
           </thead>
           <tbody>
-            {rows.map((row) => (
-              <InventoryRow
-                key={row.id}
-                row={row}
-                onUpdate={(patch) => update(row.id, patch)}
-                onRemove={() => remove(row.id)}
-              />
-            ))}
+            {rows.map((row) => {
+              const units = initialUnits[row.id] ?? [];
+              return (
+                <InventoryRow
+                  key={row.id}
+                  row={row}
+                  unitsCount={units.length}
+                  inactiveExtrasCount={Math.max(0, units.filter((u) => !u.is_active).length)}
+                  onUpdate={(patch) => update(row.id, patch)}
+                  onRemove={() => remove(row.id)}
+                  onOpenUnits={row.isNew ? undefined : () => setUnitsOpenFor(row.id)}
+                />
+              );
+            })}
           </tbody>
         </table>
         <button type="button" className="add-row" onClick={addRow}>
@@ -227,6 +236,23 @@ export function InventoryEditor({ initialRows, weekLabel }: Props) {
         onSave={handleSave}
         saving={saving}
       />
+
+      {unitsOpenFor && (() => {
+        const product = rows.find((r) => r.id === unitsOpenFor);
+        if (!product) return null;
+        return (
+          <UnitsDrawer
+            productId={unitsOpenFor}
+            productName={product.name}
+            initialUnits={initialUnits[unitsOpenFor] ?? []}
+            onClose={() => setUnitsOpenFor(null)}
+            onSaved={() => {
+              setUnitsOpenFor(null);
+              router.refresh();
+            }}
+          />
+        );
+      })()}
     </>
   );
 }

--- a/src/components/admin/inventory-row.tsx
+++ b/src/components/admin/inventory-row.tsx
@@ -20,18 +20,29 @@ export type InventoryRowState = {
 
 type Props = {
   row: InventoryRowState;
+  unitsCount?: number;
+  inactiveExtrasCount?: number;
   onUpdate: (patch: Partial<InventoryRowState>) => void;
   onRemove: () => void;
+  onOpenUnits?: () => void;
 };
 
 function priceToString(cents: number): string {
   return (cents / 100).toFixed(2);
 }
 
-export function InventoryRow({ row, onUpdate, onRemove }: Props) {
+export function InventoryRow({
+  row,
+  unitsCount = 1,
+  inactiveExtrasCount = 0,
+  onUpdate,
+  onRemove,
+  onOpenUnits,
+}: Props) {
   const [descOpen, setDescOpen] = useState(false);
   const qtyClass =
     row.qty_available === 0 ? " is-zero" : row.qty_available <= 3 ? " is-low" : "";
+  const extras = Math.max(0, unitsCount - 1);
 
   return (
     <>
@@ -115,6 +126,34 @@ export function InventoryRow({ row, onUpdate, onRemove }: Props) {
             placeholder="per lb"
             aria-label="Unit"
           />
+          {onOpenUnits && (
+            <button
+              type="button"
+              className={"units-chip" + (extras > 0 ? " is-multi" : "")}
+              onClick={onOpenUnits}
+              aria-label={
+                extras > 0
+                  ? `Edit units for ${row.name || "row"} (${unitsCount} total)`
+                  : `Add another unit for ${row.name || "row"}`
+              }
+              title={extras > 0 ? "Edit units" : "Add another unit"}
+            >
+              {extras === 0 ? (
+                <>
+                  <span className="units-chip-plus">+</span>
+                  <span>Add unit</span>
+                </>
+              ) : (
+                <>
+                  <span className="units-chip-count">{unitsCount}</span>
+                  <span>
+                    units
+                    {inactiveExtrasCount > 0 ? ` · ${inactiveExtrasCount} off` : ""}
+                  </span>
+                </>
+              )}
+            </button>
+          )}
         </td>
         <td>
           <input

--- a/src/components/admin/units-drawer.tsx
+++ b/src/components/admin/units-drawer.tsx
@@ -57,6 +57,10 @@ function pickBaseId(units: ProductUnitState[]): string | null {
 
 export function UnitsDrawer({ productId, productName, initialUnits, onClose, onSaved }: Props) {
   const [units, setUnits] = useState<ProductUnitState[]>(initialUnits);
+  // Contract: parent unmounts this component on close (inventory-editor
+  // conditional renders on unitsOpenFor). deletedIds therefore lives only
+  // for the current open. If a future refactor keeps the drawer mounted
+  // across opens, this list needs an explicit reset on open.
   const [deletedIds, setDeletedIds] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [saving, startSaving] = useTransition();

--- a/src/components/admin/units-drawer.tsx
+++ b/src/components/admin/units-drawer.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { saveProductUnits, type UnitInput } from "@/actions/save-product-units";
+
+export type ProductUnitState = {
+  id: string;
+  isNew?: boolean;
+  label: string;
+  conversion_to_base: number;
+  unit_price_cents: number;
+  is_active: boolean;
+  sort_order: number | null;
+};
+
+type Props = {
+  productId: string;
+  productName: string;
+  initialUnits: ProductUnitState[];
+  onClose: () => void;
+  onSaved: () => void;
+};
+
+let nextLocalId = 1;
+function newLocalUnitId(): string {
+  return `new-unit-${Date.now()}-${nextLocalId++}`;
+}
+
+function priceToString(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+// Base unit is the row whose conversion_to_base = 1.0 (the canonical 1× unit
+// the others scale against). UI locks its conversion and hides the delete
+// button. Schema has no is_base flag — base-by-convention is enough because
+// the server enforces ≥1 unit + ≥1 active + conversion > 0, and the trigger
+// from 6.5a always seeds a conv=1 row per product.
+//
+// If multiple rows somehow have conv=1, sort_order then id tiebreak — but
+// the 6.5b drawer prevents that path from the UI (base row's conv is
+// disabled), and the server has no migration to introduce it.
+function pickBaseId(units: ProductUnitState[]): string | null {
+  if (units.length === 0) return null;
+  const sorted = [...units].sort((a, b) => {
+    const da = Math.abs(a.conversion_to_base - 1);
+    const db = Math.abs(b.conversion_to_base - 1);
+    if (da !== db) return da - db;
+    const sa = a.sort_order ?? Number.POSITIVE_INFINITY;
+    const sb = b.sort_order ?? Number.POSITIVE_INFINITY;
+    if (sa !== sb) return sa - sb;
+    return a.id.localeCompare(b.id);
+  });
+  return sorted[0].id;
+}
+
+export function UnitsDrawer({ productId, productName, initialUnits, onClose, onSaved }: Props) {
+  const [units, setUnits] = useState<ProductUnitState[]>(initialUnits);
+  const [deletedIds, setDeletedIds] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, startSaving] = useTransition();
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape" && !saving) onClose();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose, saving]);
+
+  const baseId = useMemo(() => pickBaseId(initialUnits), [initialUnits]);
+
+  const dirty = useMemo(() => {
+    if (deletedIds.length > 0) return true;
+    if (units.length !== initialUnits.length) return true;
+    const byId = new Map(initialUnits.map((u) => [u.id, u]));
+    for (const u of units) {
+      const orig = byId.get(u.id);
+      if (!orig) return true;
+      if (
+        orig.label !== u.label ||
+        orig.conversion_to_base !== u.conversion_to_base ||
+        orig.unit_price_cents !== u.unit_price_cents ||
+        orig.is_active !== u.is_active
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }, [units, initialUnits, deletedIds]);
+
+  function update(id: string, patch: Partial<ProductUnitState>) {
+    setUnits((us) => us.map((u) => (u.id === id ? { ...u, ...patch } : u)));
+    setError(null);
+  }
+
+  function remove(id: string) {
+    setUnits((us) => us.filter((u) => u.id !== id));
+    if (!id.startsWith("new-unit-")) {
+      setDeletedIds((ids) => [...ids, id]);
+    }
+    setError(null);
+  }
+
+  function addUnit() {
+    const maxOrder = units.reduce(
+      (max, u) => Math.max(max, u.sort_order ?? 0),
+      0,
+    );
+    setUnits((us) => [
+      ...us,
+      {
+        id: newLocalUnitId(),
+        isNew: true,
+        label: "",
+        conversion_to_base: 1,
+        unit_price_cents: 0,
+        is_active: true,
+        sort_order: maxOrder + 10,
+      },
+    ]);
+    setError(null);
+  }
+
+  function handleSave() {
+    const trimmed = units.map((u) => ({ ...u, label: u.label.trim() }));
+
+    for (const u of trimmed) {
+      if (!u.label) { setError("Every unit needs a label."); return; }
+    }
+    const labels = trimmed.map((u) => u.label.toLowerCase());
+    for (let i = 0; i < labels.length; i++) {
+      if (labels.indexOf(labels[i]) !== i) {
+        setError(`Two units share the label "${trimmed[i].label}". Labels must be unique within a product.`);
+        return;
+      }
+    }
+    for (const u of trimmed) {
+      if (!(u.conversion_to_base > 0)) {
+        setError(`Conversion must be greater than zero (check "${u.label}").`);
+        return;
+      }
+      if (!Number.isInteger(u.unit_price_cents) || u.unit_price_cents < 0) {
+        setError(`Price must be a non-negative amount (check "${u.label}").`);
+        return;
+      }
+    }
+    if (!trimmed.some((u) => u.is_active)) {
+      setError("At least one unit must stay active.");
+      return;
+    }
+
+    const payload: UnitInput[] = trimmed.map((u) => ({
+      id: u.isNew ? null : u.id,
+      label: u.label,
+      conversion_to_base: u.conversion_to_base,
+      unit_price_cents: u.unit_price_cents,
+      is_active: u.is_active,
+      sort_order: u.sort_order,
+    }));
+
+    setError(null);
+    startSaving(async () => {
+      let result;
+      try {
+        result = await saveProductUnits({
+          productId,
+          units: payload,
+          deletedUnitIds: deletedIds,
+        });
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Save failed. Try again.");
+        return;
+      }
+      if (result.error) {
+        setError(result.error);
+        return;
+      }
+      onSaved();
+    });
+  }
+
+  return (
+    <>
+      <div className="drawer-scrim" onClick={() => !saving && onClose()} aria-hidden="true" />
+      <aside
+        className="drawer units-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Units for ${productName}`}
+      >
+        <header className="drawer-head">
+          <div>
+            <div className="eyebrow">edit units</div>
+            <h2 className="drawer-title">{productName || "Untitled product"}</h2>
+            <div className="units-drawer-sub">
+              Customers pick a unit when ordering. Inventory decrements in the base unit.
+            </div>
+          </div>
+          <button
+            type="button"
+            className="drawer-close"
+            onClick={onClose}
+            aria-label="Close drawer"
+            disabled={saving}
+          >
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M6 6l12 12 M18 6 6 18" />
+            </svg>
+          </button>
+        </header>
+
+        <div className="drawer-body">
+          {error && <div role="alert" className="drawer-error" style={{ marginTop: 0, marginBottom: 16 }}>{error}</div>}
+
+          <div className="units-list">
+            <div className="units-list-head">
+              <span className="units-col-label">Label</span>
+              <span className="units-col-conv" title="How many base units this equals. Base unit = 1.">
+                Conversion
+              </span>
+              <span className="units-col-price">Price</span>
+              <span className="units-col-active">Active</span>
+              <span className="units-col-trash" />
+            </div>
+
+            {units.map((u) => {
+              const isBase = u.id === baseId;
+              return (
+                <UnitRow
+                  key={u.id}
+                  unit={u}
+                  isBase={isBase}
+                  onUpdate={(patch) => update(u.id, patch)}
+                  onRemove={() => remove(u.id)}
+                />
+              );
+            })}
+
+            <button type="button" className="units-add-row" onClick={addUnit} disabled={saving}>
+              <span className="add-row-plus">+</span>
+              <span>Add another unit</span>
+            </button>
+          </div>
+
+          <div className="units-help">
+            <strong>Conversion</strong> is how many of the base unit one of this unit equals.
+            If the base is <em>per bunch</em> and a pound of basil is roughly four bunches, the pound row&apos;s
+            conversion is <span className="mono">4</span>.
+            If the base is <em>per pint</em> and a quart is two pints, the quart row is <span className="mono">2</span>.
+          </div>
+        </div>
+
+        <footer className="drawer-foot">
+          <div style={{ flex: 1 }} />
+          <Button variant="ghost" onClick={onClose} disabled={saving}>Cancel</Button>
+          <Button variant="primary" onClick={handleSave} disabled={!dirty || saving} dirty={dirty}>
+            {saving ? "Saving…" : dirty ? "Save units" : "Saved"}
+          </Button>
+        </footer>
+      </aside>
+    </>
+  );
+}
+
+function UnitRow({
+  unit,
+  isBase,
+  onUpdate,
+  onRemove,
+}: {
+  unit: ProductUnitState;
+  isBase: boolean;
+  onUpdate: (patch: Partial<ProductUnitState>) => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div
+      className={
+        "units-row" +
+        (isBase ? " is-base" : "") +
+        (!unit.is_active ? " is-inactive" : "")
+      }
+      data-unit-id={unit.id}
+      data-unit-label={unit.label}
+    >
+      <div className="units-col-label">
+        <input
+          type="text"
+          className="field-input"
+          value={unit.label}
+          onChange={(e) => onUpdate({ label: e.target.value })}
+          placeholder={isBase ? "per lb" : "e.g. per pound"}
+          aria-label={isBase ? "Base unit label" : "Unit label"}
+        />
+        {isBase && <span className="units-base-badge">BASE</span>}
+      </div>
+      <div className="units-col-conv">
+        <input
+          type="number"
+          step="0.1"
+          min="0"
+          className="field-input field-num"
+          value={String(unit.conversion_to_base)}
+          onChange={(e) => onUpdate({ conversion_to_base: parseFloat(e.target.value) || 0 })}
+          disabled={isBase}
+          aria-label="Conversion to base"
+          title={isBase ? "Base unit is always 1.0" : ""}
+        />
+      </div>
+      <div className="units-col-price">
+        <div className="field-price">
+          <span className="field-price-sym">$</span>
+          <input
+            type="number"
+            step="0.25"
+            min="0"
+            className="field-input field-num"
+            value={priceToString(unit.unit_price_cents)}
+            onChange={(e) => {
+              const v = parseFloat(e.target.value);
+              onUpdate({ unit_price_cents: Number.isFinite(v) ? Math.round(v * 100) : 0 });
+            }}
+            aria-label="Unit price"
+          />
+        </div>
+      </div>
+      <div className="units-col-active">
+        <Switch
+          checked={unit.is_active}
+          onChange={(v) => onUpdate({ is_active: v })}
+          ariaLabel={`Active: ${unit.label || "unit"}`}
+        />
+      </div>
+      <div className="units-col-trash">
+        {!isBase && (
+          <button
+            type="button"
+            className="row-trash"
+            onClick={onRemove}
+            aria-label={`Delete unit ${unit.label || "row"}`}
+          >
+            <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M3 6h18" />
+              <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+              <path d="M19 6 17.5 20a2 2 0 0 1-2 2h-7a2 2 0 0 1-2-2L5 6" />
+              <path d="M10 11v6 M14 11v6" />
+            </svg>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -521,6 +521,155 @@
   flex-shrink: 0;
 }
 
+/* ── Units chip (inventory row → opens Units drawer) ─────── */
+.units-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  margin-top: 4px;
+  padding: 3px 9px 3px 6px;
+  background: transparent;
+  border: 1px dashed var(--ink-300);
+  border-radius: 999px;
+  font-family: var(--sans);
+  font-size: 0.74rem;
+  font-weight: 500;
+  color: var(--ink-500);
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+.units-chip:hover {
+  background: var(--leaf-50);
+  color: var(--leaf-700);
+  border-color: var(--leaf-100);
+}
+.units-chip.is-multi {
+  border-style: solid;
+  border-color: var(--leaf-100);
+  background: var(--leaf-50);
+  color: var(--leaf-700);
+  font-weight: 600;
+}
+.units-chip-plus {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 14px; height: 14px;
+  border-radius: 50%;
+  background: var(--ink-200);
+  color: var(--ink-700);
+  font-size: 0.78rem;
+  line-height: 1;
+}
+.units-chip:hover .units-chip-plus {
+  background: var(--leaf-600);
+  color: var(--paper);
+}
+.units-chip-count {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 18px; height: 18px; padding: 0 5px;
+  border-radius: 999px;
+  background: var(--leaf-600);
+  color: var(--paper);
+  font-size: 0.72rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Units drawer (per-product unit editor) ──────────────── */
+.units-drawer { width: min(560px, 100vw); }
+.units-drawer-sub {
+  margin-top: 6px;
+  font-size: 0.82rem;
+  color: var(--ink-500);
+  line-height: 1.4;
+}
+
+.units-list {
+  border: 1px solid var(--ink-200);
+  border-radius: var(--r-sm);
+  background: var(--paper);
+  overflow: hidden;
+}
+.units-list-head,
+.units-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) 90px 100px 56px 36px;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+}
+.units-list-head {
+  background: var(--cream);
+  border-bottom: 1px solid var(--ink-200);
+  font-size: 0.66rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-500);
+}
+.units-row {
+  border-top: 1px solid var(--ink-200);
+  position: relative;
+}
+.units-row:first-of-type { border-top: 0; }
+.units-row.is-base { background: var(--leaf-50); }
+.units-row.is-inactive { background: var(--ink-100); }
+.units-row.is-inactive .field-input { color: var(--ink-500); }
+
+.units-col-label {
+  position: relative;
+  display: flex; align-items: center; gap: 6px;
+}
+.units-col-label .field-input { flex: 1; min-width: 0; }
+.units-base-badge {
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 2px 5px;
+  background: var(--leaf-600);
+  color: var(--paper);
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.units-col-conv .field-input:disabled,
+.units-col-conv .field-input[disabled] {
+  background: var(--ink-100);
+  color: var(--ink-500);
+  cursor: not-allowed;
+}
+
+.units-col-price .field-price { width: 100%; }
+.units-col-active { display: flex; justify-content: center; }
+.units-col-trash  { display: flex; justify-content: flex-end; }
+
+.units-add-row {
+  display: flex; align-items: center; gap: 10px;
+  width: 100%;
+  padding: 10px 14px;
+  background: transparent;
+  border: none;
+  border-top: 1px dashed var(--ink-300);
+  font-family: var(--sans);
+  font-size: 0.86rem;
+  font-weight: 500;
+  color: var(--ink-500);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s, color 0.1s;
+}
+.units-add-row:hover { background: var(--leaf-50); color: var(--leaf-700); }
+.units-add-row:disabled { cursor: not-allowed; opacity: 0.5; }
+
+.units-help {
+  margin-top: 18px;
+  padding: 12px 14px;
+  background: var(--cream);
+  border-radius: var(--r-sm);
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--ink-700);
+}
+.units-help strong { color: var(--ink-900); }
+.units-help em { font-style: italic; color: var(--leaf-700); }
+
 /* ── Customer table (admin/customers) ────────────────────── */
 /* Row-style table variant: clickable rows that open a drawer. Distinct
    from .data-table (inline-edit) — different padding, vertical rhythm,

--- a/tests/admin-inventory-units.spec.ts
+++ b/tests/admin-inventory-units.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect, type Page } from "@playwright/test";
+import { ADMIN_STORAGE_STATE, TEST_PRODUCTS, admin, resetProductUnits } from "./helpers";
+
+// Per-product Units drawer (#152). The drawer opens from the units chip in
+// each row's unit cell. The 6.5a safety-net trigger gives every product a
+// single base unit; the drawer's job is to let admins add/edit additional
+// units and toggle activity per-unit.
+
+const KALE = TEST_PRODUCTS.kale;
+const EGGS = TEST_PRODUCTS.eggs;
+
+function row(page: Page, name: string) {
+  return page.locator(`tr[data-row-name="${name}"]`);
+}
+function chip(page: Page, name: string) {
+  return row(page, name).locator(".units-chip");
+}
+function drawer(page: Page) {
+  return page.getByRole("dialog");
+}
+function drawerSave(page: Page) {
+  return drawer(page).getByRole("button", { name: /^(Save units|Saved|Saving…)$/ });
+}
+
+test.describe("admin inventory · units drawer", () => {
+  test.use({ storageState: ADMIN_STORAGE_STATE });
+
+  test.beforeEach(async () => {
+    await resetProductUnits(KALE.id, KALE.price_cents);
+    await resetProductUnits(EGGS.id, EGGS.price_cents);
+  });
+
+  test.afterEach(async () => {
+    await resetProductUnits(KALE.id, KALE.price_cents);
+    await resetProductUnits(EGGS.id, EGGS.price_cents);
+  });
+
+  test("single-unit product shows '+ Add unit' chip and opens drawer", async ({ page }) => {
+    await page.goto("/admin/inventory");
+    const c = chip(page, KALE.name);
+    await expect(c).toContainText(/add unit/i);
+    await expect(c).not.toHaveClass(/is-multi/);
+
+    await c.click();
+    await expect(drawer(page)).toBeVisible();
+    await expect(drawer(page).getByRole("heading", { name: KALE.name })).toBeVisible();
+
+    // base row visible, conversion locked, no delete button
+    const baseInput = drawer(page).getByLabel("Base unit label");
+    await expect(baseInput).toHaveValue(KALE.unit);
+    await expect(drawer(page).getByLabel("Conversion to base").first()).toBeDisabled();
+    await expect(drawer(page).getByRole("button", { name: /^Delete unit/ })).toHaveCount(0);
+  });
+
+  test("add a second unit, save, chip updates", async ({ page }) => {
+    await page.goto("/admin/inventory");
+    await chip(page, KALE.name).click();
+    await expect(drawer(page)).toBeVisible();
+
+    await drawer(page).getByRole("button", { name: /add another unit/i }).click();
+    const newRow = drawer(page).locator(".units-row").nth(1);
+    await newRow.getByRole("textbox", { name: "Unit label" }).fill("per lb");
+    await newRow.getByRole("spinbutton", { name: "Conversion to base" }).fill("0.5");
+    await newRow.getByRole("spinbutton", { name: "Unit price" }).fill("8.00");
+
+    await drawerSave(page).click();
+    await expect(drawer(page)).toBeHidden();
+
+    const c = chip(page, KALE.name);
+    await expect(c).toContainText(/2\s*units/);
+    await expect(c).toHaveClass(/is-multi/);
+
+    // verify persisted via DB
+    const sb = admin();
+    const { data } = await sb.from("product_units").select("label, unit_price_cents, conversion_to_base, is_active").eq("product_id", KALE.id);
+    const extra = data?.find((u) => u.label === "per lb");
+    expect(extra).toBeTruthy();
+    expect(extra?.unit_price_cents).toBe(800);
+    expect(Number(extra?.conversion_to_base)).toBe(0.5);
+    expect(extra?.is_active).toBe(true);
+  });
+
+  test("inactive unit is reflected in chip subtext", async ({ page }) => {
+    // seed an extra unit, then deactivate it via the drawer
+    const sb = admin();
+    await sb.from("product_units").insert({
+      product_id: EGGS.id,
+      label: "per half-dozen",
+      conversion_to_base: 0.5,
+      unit_price_cents: 350,
+      is_active: true,
+      slug: `eggs-per-half-dozen-${EGGS.id.slice(0, 8)}`,
+    });
+
+    await page.goto("/admin/inventory");
+    await expect(chip(page, EGGS.name)).toContainText(/2\s*units/);
+
+    await chip(page, EGGS.name).click();
+    const switches = drawer(page).getByRole("switch");
+    await expect(switches).toHaveCount(2);
+    await switches.nth(1).click(); // turn off the extra
+    await drawerSave(page).click();
+    await expect(drawer(page)).toBeHidden();
+
+    const c = chip(page, EGGS.name);
+    await expect(c).toContainText(/2\s*units\s*·\s*1\s*off/);
+  });
+
+  test("remove a non-base unit", async ({ page }) => {
+    const sb = admin();
+    await sb.from("product_units").insert({
+      product_id: KALE.id,
+      label: "per lb",
+      conversion_to_base: 0.25,
+      unit_price_cents: 1200,
+      is_active: true,
+      slug: `kale-per-lb-${KALE.id.slice(0, 8)}`,
+    });
+
+    await page.goto("/admin/inventory");
+    await chip(page, KALE.name).click();
+    await expect(drawer(page).locator(".units-row")).toHaveCount(2);
+
+    await drawer(page).getByRole("button", { name: /^Delete unit/ }).click();
+    await expect(drawer(page).locator(".units-row")).toHaveCount(1);
+    await drawerSave(page).click();
+    await expect(drawer(page)).toBeHidden();
+
+    await expect(chip(page, KALE.name)).toContainText(/add unit/i);
+  });
+
+  test("validation: blank label, duplicate label, zero conversion, all inactive", async ({ page }) => {
+    await page.goto("/admin/inventory");
+    await chip(page, KALE.name).click();
+
+    // blank label
+    await drawer(page).getByRole("button", { name: /add another unit/i }).click();
+    await drawerSave(page).click();
+    await expect(drawer(page).getByRole("alert")).toContainText(/every unit needs a label/i);
+
+    // duplicate label (same as base)
+    const newRow = drawer(page).locator(".units-row").nth(1);
+    await newRow.getByRole("textbox", { name: "Unit label" }).fill(KALE.unit);
+    await drawerSave(page).click();
+    await expect(drawer(page).getByRole("alert")).toContainText(/labels must be unique/i);
+
+    // zero conversion
+    await newRow.getByRole("textbox", { name: "Unit label" }).fill("per lb");
+    await newRow.getByRole("spinbutton", { name: "Conversion to base" }).fill("0");
+    await drawerSave(page).click();
+    await expect(drawer(page).getByRole("alert")).toContainText(/conversion must be greater than zero/i);
+
+    // all inactive
+    await newRow.getByRole("spinbutton", { name: "Conversion to base" }).fill("0.5");
+    const switches = drawer(page).getByRole("switch");
+    await switches.nth(0).click();
+    await switches.nth(1).click();
+    await drawerSave(page).click();
+    await expect(drawer(page).getByRole("alert")).toContainText(/at least one unit must stay active/i);
+  });
+
+  test("new (unsaved) row hides the units chip", async ({ page }) => {
+    await page.goto("/admin/inventory");
+    await page.getByRole("button", { name: /add row/i }).click();
+    const newRow = page.locator(`tr[data-row-id^="new-"]`);
+    await expect(newRow.locator(".units-chip")).toHaveCount(0);
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -208,3 +208,36 @@ export async function setProductQty(id: string, qty: number): Promise<void> {
   const sb = admin();
   await sb.from("products").update({ qty_available: qty }).eq("id", id);
 }
+
+// Resets a product's units to the single base row the 6.5a safety-net
+// trigger originally seeded: label = product.unit, conv = 1, price =
+// basePriceCents, active = true, slug = "<name-slug>-<id8>" (trigger's
+// format). Deletes every existing product_units row first to clear any
+// leaked slug/label drift from a prior failed test run, then re-inserts
+// a fresh base row. Used by beforeEach/afterEach in units-drawer specs.
+export async function resetProductUnits(productId: string, basePriceCents: number): Promise<void> {
+  const sb = admin();
+  const { data: product } = await sb
+    .from("products")
+    .select("name, unit")
+    .eq("id", productId)
+    .single();
+  if (!product) return;
+
+  await sb.from("product_units").delete().eq("product_id", productId);
+
+  const nameSlug = product.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const id8 = productId.slice(0, 8);
+
+  await sb.from("product_units").insert({
+    product_id: productId,
+    label: product.unit,
+    conversion_to_base: 1,
+    unit_price_cents: basePriceCents,
+    is_active: true,
+    slug: `${nameSlug}-${id8}`,
+  });
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -224,6 +224,8 @@ export async function resetProductUnits(productId: string, basePriceCents: numbe
     .single();
   if (!product) return;
 
+  // Non-atomic: a concurrent reader between delete + insert would observe
+  // zero units for this product. Relies on Playwright's workers=1 config.
   await sb.from("product_units").delete().eq("product_id", productId);
 
   const nameSlug = product.name


### PR DESCRIPTION
## Summary
Adds a per-product Units drawer to `/admin/inventory`. Click the chip under any unit cell to open it; add/edit/remove additional units beyond the trigger-created base. Base unit is identified by `conversion_to_base = 1.0` and protected from deletion + conv-edits. Inline price/unit cells keep working for the single-unit 80% case.

Closes #152.

## Files changed
- `src/app/(admin)/admin/inventory/page.tsx` — joined `product_units` into the page query, keyed by product_id.
- `src/components/admin/inventory-editor.tsx` — drawer open/close state, refresh after save.
- `src/components/admin/inventory-row.tsx` — `.units-chip` affordance under the unit cell (count badge when multi; `+ Add unit` when single).
- `src/components/admin/units-drawer.tsx` — new drawer + UnitRow. Mirrors the customer-drawer shell.
- `src/actions/save-product-units.ts` — new server action: upsert/delete units, ≥1 active, conversion > 0, unique labels, non-negative price, label non-blank. Slug computed in the 6.5a trigger's format (`name-label-id8`). FK-violation on delete returns Annabel-facing copy ("Turn the Active switch off instead").
- `src/styles/app.css` — `.units-chip`, `.units-drawer`, `.units-row`, `.units-base-badge`, `.units-add-row`, `.units-help` (one-file CSS rule).
- `tests/admin-inventory-units.spec.ts` — 6 cases: chip states (single + multi), open drawer, add unit, edit (inactive subtext), remove non-base, validation chain, new-row chip suppression. Green on desktop + mobile webkit.
- `tests/helpers.ts` — `resetProductUnits` (delete-all + reinsert base with canonical slug) so specs can't leak slug drift.
- `design/admin-inventory.{jsx,css}` + `design/preview-inventory.html` — design mockup mirror (Babel-standalone harness so the JSX is live-renderable).
- `.claude/settings.local.json` — session permission additions.

## Code review
@code-review pass surfaced two real fixes (now in commit `4ea7ced`):
- FK-violation message on delete — Postgres 23503 now returns "Can't delete a unit that's already on an existing order. Turn the Active switch off instead — customers won't see it next week."
- `deletedIds` invariant comment in the drawer (depends on parent unmounting on close).

Latent/flagged for awareness (not fixed in this PR):
- Slug format divergence: the 6.5a trigger writes base slugs as `name-id8` (no label segment), while new units written here use `name-label-id8`. Diverges only if base is ever renamed; not load-bearing until 6.5c uses slugs in customer URLs. Worth unifying in a follow-up migration.
- Validation order differs between client and server (same checks, different sequence). Cheap to align if a non-browser client ever calls `saveProductUnits` directly.

## Test plan
- [ ] **/admin/inventory loads.** Three test products (Kale, Eggs, Honey) each show `+ Add unit` chip. No regression in price/unit inline edits.
- [ ] **Add a second unit.** Click `+ Add unit` on Kale → drawer opens. Click `+ Add another unit`. Fill label "per lb", conv 0.25, price 12.00. Save → drawer closes, chip flips to solid green `2 units`. Reload — persisted.
- [ ] **Edit existing unit.** Reopen Kale's drawer. Change "per lb" price to 14.00. Save. Reload — persisted.
- [ ] **Deactivate a unit.** Toggle the "per lb" Active switch off. Save → chip subtext shows `· 1 off`.
- [ ] **Delete a non-base unit.** Reactivate "per lb", then trash it. Save → drawer closes, chip back to `+ Add unit`.
- [ ] **Base protection.** With a multi-unit product, base row has BASE badge, no trash, conversion disabled. Trying to delete via dev tools surfaces the FK message if the unit has order history (manual: seed an order_item against it first).
- [ ] **Validation chain.** Open drawer. Add unit, leave blank → "Every unit needs a label." Fill label same as base → "Labels must be unique within a product." Conversion 0 → "Conversion must be greater than zero." Toggle all units inactive → "At least one unit must stay active."
- [ ] **375px mobile.** Drawer collapses to full-width, scrolls, all inputs reachable.
- [ ] **Customer order flow unchanged.** Place a test order via `/c/<token>` against Kale — places against the base unit (the 6.5a safety-net trigger fills `order_items.product_unit_id`).
- [ ] `npx playwright test tests/admin-inventory-units.spec.ts --project=desktop` — 6 pass.
- [ ] `npx playwright test tests/admin-inventory.spec.ts --project=desktop` — 5 pass (1 skipped, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)