### PR TITLE
auto-sync downstream — 2026-05-24

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,7 @@ npx supabase gen types typescript --local > src/lib/supabase/types.ts
 
 - Main session: Sonnet by default. Switch to Opus when stuck.
 - Agents: model in agent frontmatter. Don't override unless task warrants.
+- **New agents:** default to Sonnet. Add `model: opus` frontmatter only for architecture-level agents.
 
 ## PR Workflow
 
@@ -349,6 +350,8 @@ Bushel carries a SemVer version in `package.json`, mirrored to a git tag (`vX.Y.
 
 **Tag rule:** tags only ever applied on `main`. In staging-flow projects (which bushel currently isn't — see above), bumps on `staging` are untagged; the tag lands when `/promote-staging` ff-merges.
 
+**Detection:** these skills check `package.json` exists at the repo root before bumping. If it doesn't (template/markdown-only project), they no-op silently.
+
 ### `<VersionTag />` component
 
 Build-time version display at `src/components/VersionTag.tsx`. Reads `process.env.NEXT_PUBLIC_APP_VERSION` + `process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA`. Renders e.g. `v1.2.3 (a1b2c3)`.
@@ -366,6 +369,17 @@ import { VersionTag } from "@/components/VersionTag";
 ### CHANGELOG.md
 
 Auto-maintained by `/retro` and `/bump-major` (DEC-013 — `/its-dead` no longer touches it). Don't edit by hand mid-flow — the skills always prepend after the `# Changelog` header. The first bump creates the file if absent.
+
+Format (Keep-a-Changelog inspired but simpler):
+```
+# Changelog
+
+## [1.2.3] - 2026-05-05
+- PR #42: Add login form
+
+## [1.2.2] - 2026-05-04
+- PR #41: Fix dashboard query
+```
 
 ## Workflow Notes
 - **Diagnostic commands** (build, lint, type, test): run directly.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -192,7 +192,7 @@ Slash commands manage session lifecycle. Time tracking is automatic.
 ## Agent Summary
 
 | Agent/Skill | Model | When | Purpose |
-|-------------|-------|------|-------|
+|-------------|-------|------|---------|
 | @architect | Opus | Before design decisions | Keep architecture coherent |
 | @code-review | Sonnet | After commits, optional | Catch issues early |
 | @pm | Sonnet | Start/end of sessions | Track progress, flag risks |


### PR DESCRIPTION
Base: main

## Classification table

| File | Hunk | Provenance | Classification | Action |
|------|------|------------|----------------|--------|
| `docs/AGENTS.md` | Agent Summary table last-column separator `-------|` → `---------|` | Template-only | Forward-port | Forward-ported |
| `CLAUDE.md` | "New agents: default to Sonnet..." bullet under Model Selection | Template-only | Forward-port | Forward-ported |
| `CLAUDE.md` | "Detection: these skills check `package.json`..." paragraph under Versioning | Template-only | Forward-port | Forward-ported |
| `CLAUDE.md` | CHANGELOG format example block (Keep-a-Changelog inspired) | Template-only | Forward-port | Forward-ported |

## Files changed

- `docs/AGENTS.md`
- `CLAUDE.md`

## Pattern flags

None.

## Skipped hunks

- Skipped (logic, hash-equal, 15 files): all 13 skills + sync-config.md + tape-reader.md
- `agents/ui-reviewer.md`: 3 Project-only hunks skipped (`[Project]` → `bushel` substitutions)
- `agents/architect.md`, `code-review.md`: hash-equal
- `CLAUDE.md`: ~30+ Both-modified hunks skipped (mode:auto default) — project has heavily customized nearly every section (Two Supabase projects, Design folder READ FIRST, Next.js 16 routing note, bushel-specific data model, etc.)
- Skipped (class:context, 6 files): `docs/SPEC.md`, `docs/BRAND.md`, `docs/DECISIONS.md`, `docs/PROJECT_PLAN.md`, `docs/RETROSPECTIVES.md`, `docs/USER_STORIES.md`
- `docs/CHEATSHEET.md`, `docs/VELOCITY_AND_POKER_GUIDE.md`: hash-equal

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsVFtUD1XBbMtbuFd3z1hh)_