### PR TITLE
Phase 6.5c — Customer order form: per-product unit picker (#153)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -71,7 +71,10 @@
       "Bash(kill -9 306301)",
       "Bash(vercel env *)",
       "Bash(awk NR>=170 && NR<=182 *)",
-      "Bash(kill -9 3368201)"
+      "Bash(kill -9 3368201)",
+      "Bash(awk '/^## Phase 6.5/,/^## Phase 7/' docs/PROJECT_PLAN.md)",
+      "Bash(kill 2777394 2777433)",
+      "Bash(pkill -f \"next-server\")"
     ]
   }
 }

--- a/design/order-page.css
+++ b/design/order-page.css
@@ -75,7 +75,9 @@
   display: grid;
   grid-template-columns: 44px minmax(0, 1fr) auto;
   gap: 12px;
-  align-items: center;
+  /* Top-align so the name + meta + picker stack grows downward and the
+     stepper stays paired with the price. 6.5c restructure (#144). */
+  align-items: start;
   padding: 12px 14px;
   border-top: 1px solid var(--ink-200);
 }
@@ -103,31 +105,76 @@
 }
 .item-row.is-sold-out .item-thumb { opacity: 0.55; }
 
-.item-body { min-width: 0; }
-.item-line1 {
-  display: flex; justify-content: space-between; align-items: baseline;
-  gap: 8px;
-  margin-bottom: 2px;
-  flex-wrap: wrap;
+.item-body {
+  min-width: 0;
+  display: flex; flex-direction: column; gap: 4px;
 }
 .item-name {
   font-weight: 600; font-size: 1rem; color: var(--ink-900);
-  min-width: 0;
+  line-height: 1.25;
+  /* Wraps freely now that price has moved below — closes #144. */
+  overflow-wrap: anywhere;
+}
+.item-meta-row {
+  display: flex; align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 0.82rem;
+  flex-wrap: wrap;
 }
 .item-price {
-  font-size: 0.88rem; color: var(--ink-700);
+  color: var(--ink-700);
   white-space: nowrap; flex-shrink: 0;
 }
 .item-price .mono { font-weight: 600; color: var(--ink-900); }
 .item-per { color: var(--ink-500); }
 
-.item-line2 { font-size: 0.82rem; }
 .item-meta { color: var(--ink-500); }
 .meta-low { color: var(--amber-600); font-weight: 600; }
 .meta-sold-out {
   color: var(--ink-500); font-weight: 600;
   text-transform: uppercase; letter-spacing: 0.06em; font-size: 0.72rem;
 }
+
+/* Per-product unit picker (6.5c). Native radio in-DOM for a11y; the
+   label is the visual pill and the click target. */
+.unit-picker {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+.unit-option {
+  position: relative;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
+  padding: 5px 9px;
+  background: var(--paper);
+  border: 1px solid var(--ink-300);
+  border-radius: var(--r-sm);
+  font-size: 0.82rem;
+  color: var(--ink-700);
+  cursor: pointer;
+  user-select: none;
+  transition: border-color 0.12s, background 0.12s, color 0.12s;
+}
+.unit-option input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+.unit-option:hover:not(.is-disabled) { border-color: var(--leaf-600); }
+.unit-option.is-selected {
+  border-color: var(--leaf-600);
+  background: var(--leaf-50);
+  color: var(--leaf-700);
+}
+.unit-option.is-disabled { opacity: 0.45; cursor: not-allowed; }
+.unit-option-label { font-weight: 600; }
+.unit-option-price { font-weight: 600; color: var(--ink-900); font-variant-numeric: tabular-nums; }
+.unit-option.is-selected .unit-option-price { color: var(--leaf-700); }
+.unit-option.is-disabled .unit-option-price { color: var(--ink-500); }
 
 /* Stepper */
 .stepper {

--- a/design/order-page.css
+++ b/design/order-page.css
@@ -170,6 +170,10 @@
   background: var(--leaf-50);
   color: var(--leaf-700);
 }
+.unit-option:has(input:focus-visible) {
+  outline: 2px solid var(--leaf-600);
+  outline-offset: 2px;
+}
 .unit-option.is-disabled { opacity: 0.45; cursor: not-allowed; }
 .unit-option-label { font-weight: 600; }
 .unit-option-price { font-weight: 600; color: var(--ink-900); font-variant-numeric: tabular-nums; }

--- a/design/order-page.jsx
+++ b/design/order-page.jsx
@@ -5,6 +5,10 @@
 const { useState, useMemo, useEffect, useRef } = React;
 
 // ───── Data ──────────────────────────────────────────────────────────
+// `units` is optional: when present and length ≥ 2 the row renders a
+// per-product unit picker (6.5c). Each unit declares its own price and a
+// conversion to the base unit (the first entry — conv=1). Inventory is
+// tracked in base units; per-unit availability is floor(avail / conv).
 const INVENTORY = [
 { id: "tomato", name: "Heirloom tomatoes", unit: "lb", price: 5.50, avail: 24 },
 { id: "kale", name: "Dino kale", unit: "bunch", price: 4.50, avail: 18 },
@@ -12,7 +16,12 @@ const INVENTORY = [
 { id: "beets", name: "Red beets", unit: "lb", price: 3.25, avail: 22 },
 { id: "carrots", name: "Rainbow carrots", unit: "bunch", price: 4.75, avail: 11 },
 { id: "shallots", name: "Shallots", unit: "lb", price: 6.00, avail: 8 },
-{ id: "basil", name: "Genovese basil", unit: "bunch", price: 3.50, avail: 6 },
+{ id: "basil", name: "Genovese basil", unit: "bunch", price: 3.50, avail: 6,
+  units: [
+    { id: "bunch", label: "bunch", price: 3.50, conv: 1 },
+    { id: "lb",    label: "lb",    price: 9.00, conv: 4 }
+  ]
+},
 { id: "flowers", name: "Mixed bouquet", unit: "stem", price: 12.00, avail: 7 },
 { id: "garlic", name: "Music garlic", unit: "head", price: 2.50, avail: 0 }];
 
@@ -59,39 +68,68 @@ function Stepper({ value, onChange, max, disabled }) {
 
 }
 
-function ItemRow({ item, qty, onQty, soldOut }) {
+function ItemRow({ item, qty, onQty, soldOut, selectedUnitId, onUnitChange }) {
   const out = soldOut || item.avail === 0;
-  const remaining = out ? 0 : item.avail - qty;
+  const hasPicker = Array.isArray(item.units) && item.units.length >= 2;
+  const selected = hasPicker
+    ? item.units.find((u) => u.id === selectedUnitId) || item.units[0]
+    : { label: item.unit, price: item.price, conv: 1 };
+  const perUnitMax = Math.floor(item.avail / selected.conv);
+  const remaining = out ? 0 : perUnitMax - qty;
   return (
-    <div className={"item-row" + (out ? " is-sold-out" : "")}>
+    <div className={"item-row" + (out ? " is-sold-out" : "") + (hasPicker ? " has-picker" : "")}>
       <div className="item-thumb" aria-hidden="true">
         <div className="item-thumb-inner"></div>
       </div>
       <div className="item-body">
-        <div className="item-line1">
-          <div className="item-name">{item.name}</div>
-          <div className="item-price">
-            <span className="mono">${item.price.toFixed(2)}</span>
-            <span className="item-per"> / {item.unit}</span>
-          </div>
-        </div>
-        <div className="item-line2">
+        <div className="item-name">{item.name}</div>
+        <div className="item-meta-row">
+          <span className="item-price">
+            <span className="mono">${selected.price.toFixed(2)}</span>
+            <span className="item-per"> / {selected.label}</span>
+          </span>
           {out ?
           <span className="item-meta meta-sold-out">Sold out</span> :
           remaining <= 3 ?
-          <span className="item-meta meta-low">only {remaining} {item.unit}{remaining !== 1 ? "s" : ""} left</span> :
+          <span className="item-meta meta-low">only {remaining} {selected.label}{remaining !== 1 ? "s" : ""} left</span> :
 
-          <span className="item-meta">{remaining} {item.unit}{remaining !== 1 ? "s" : ""} available</span>
+          <span className="item-meta">{remaining} {selected.label}{remaining !== 1 ? "s" : ""} available</span>
           }
         </div>
+        {hasPicker &&
+          <div className="unit-picker" role="radiogroup" aria-label={`${item.name} unit`}>
+            {item.units.map((u) => {
+              const disabled = item.avail < u.conv;
+              const isSel = u.id === selected.id;
+              return (
+                <label
+                  key={u.id}
+                  className={
+                    "unit-option" +
+                    (isSel ? " is-selected" : "") +
+                    (disabled ? " is-disabled" : "")
+                  }>
+                  <input
+                    type="radio"
+                    name={`unit-${item.id}`}
+                    value={u.id}
+                    checked={isSel}
+                    disabled={disabled}
+                    onChange={() => onUnitChange(u.id)} />
+                  <span className="unit-option-label">{u.label}</span>
+                  <span className="unit-option-price mono">${u.price.toFixed(2)}</span>
+                </label>);
+            })}
+          </div>
+        }
       </div>
       <div className="item-stepper">
         <Stepper
           value={qty}
           onChange={onQty}
-          max={item.avail}
+          max={perUnitMax}
           disabled={out} />
-        
+
       </div>
     </div>);
 
@@ -115,6 +153,7 @@ function OrderPage({ tweaks }) {
     tomato: 4, kale: 6, lettuce: 0, beets: 2, carrots: 0,
     shallots: 0, basil: 0, flowers: 0, garlic: 0
   });
+  const [selectedUnit, setSelectedUnit] = useState({ basil: "bunch" });
   const [mode, setMode] = useState(tweaks.mode || "delivery");
   const [window, setWindow] = useState("w1");
   const [notes, setNotes] = useState("");
@@ -206,7 +245,12 @@ function OrderPage({ tweaks }) {
                   key={i.id}
                   item={i}
                   qty={qty[i.id] || 0}
-                  onQty={(n) => setItemQty(i.id, n)} />
+                  onQty={(n) => setItemQty(i.id, n)}
+                  selectedUnitId={selectedUnit[i.id]}
+                  onUnitChange={(unitId) => {
+                    setSelectedUnit((s) => ({ ...s, [i.id]: unitId }));
+                    setItemQty(i.id, 0);
+                  }} />
 
                 )}
               </div>

--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -345,7 +345,11 @@ export function OrderForm({
                   // the stepper never offers a quantity that would oversell.
                   const perUnitMax = Math.floor(p.qty_available / conv);
                   const out = p.qty_available === 0;
-                  const remaining = out ? 0 : perUnitMax - current;
+                  // Math.max guards the rare case where the selected unit's
+                  // perUnitMax dropped below the in-cart qty mid-session
+                  // (inventory reduced under our feet). Don't render
+                  // "only -2 lbs left".
+                  const remaining = out ? 0 : Math.max(0, perUnitMax - current);
                   const showPicker = p.units.length >= 2;
                   return (
                     <div

--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { placeOrder } from "@/actions/place-order";
-import type { ProductRow } from "@/lib/customer/queries";
+import type { ProductRow, ProductUnitRow } from "@/lib/customer/queries";
 
 type Customer = {
   id: string;
@@ -200,6 +200,10 @@ export function OrderForm({
   weekLabel,
 }: Props) {
   const [qty, setQty] = useState<Record<string, number>>({});
+  // selectedUnit[productId] → product_units.id. Unset entries fall back to the
+  // product's first active unit at render time. Switching units zeros qty for
+  // that product (per #153 AC) — see the radio onChange handler below.
+  const [selectedUnit, setSelectedUnit] = useState<Record<string, string>>({});
   const [mode, setMode] = useState<Mode>("delivery");
   const [pickupNote, setPickupNote] = useState("");
   const [deliveryPreference, setDeliveryPreference] = useState(
@@ -224,10 +228,26 @@ export function OrderForm({
     () => products.filter((p) => (qty[p.id] ?? 0) > 0),
     [products, qty],
   );
+
+  // Resolve a product's currently-selected unit. The selectedUnit map is
+  // sparse — products the user hasn't touched fall through to the first
+  // active unit, which 6.5a guarantees exists. Stale ids (e.g. an admin
+  // deactivated a unit mid-session) silently revert to the same default.
+  const unitFor = (p: ProductRow): ProductUnitRow | null => {
+    const id = selectedUnit[p.id] ?? p.units[0]?.id;
+    return p.units.find((u) => u.id === id) ?? p.units[0] ?? null;
+  };
+
   const subtotalCents = useMemo(
     () =>
-      itemsWithQty.reduce((sum, p) => sum + (qty[p.id] ?? 0) * p.price_cents, 0),
-    [itemsWithQty, qty],
+      itemsWithQty.reduce((sum, p) => {
+        const u = unitFor(p);
+        const price = u?.unit_price_cents ?? p.price_cents;
+        return sum + (qty[p.id] ?? 0) * price;
+      }, 0),
+    // unitFor reads selectedUnit; rebuild the subtotal when either map shifts.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [itemsWithQty, qty, selectedUnit],
   );
   const itemCount = useMemo(
     () => itemsWithQty.reduce((sum, p) => sum + (qty[p.id] ?? 0), 0),
@@ -242,11 +262,19 @@ export function OrderForm({
     if (lineCount === 0 || submittingRef.current) return;
     submittingRef.current = true;
     setSubmitError(null);
-    const payloadItems = itemsWithQty.map((p) => ({
-      product_id: p.id,
-      qty: qty[p.id] ?? 0,
-      unit_price_cents: p.price_cents,
-    }));
+    // unit_price_cents snapshots the *selected* unit's price. The qty value
+    // is in selected-unit quantities — the place_order RPC still interprets
+    // it as base units (6.5d closes that gap with fractional decrement +
+    // product_unit_id pass-through). For single-unit products the two are
+    // identical and behavior is unchanged.
+    const payloadItems = itemsWithQty.map((p) => {
+      const u = unitFor(p);
+      return {
+        product_id: p.id,
+        qty: qty[p.id] ?? 0,
+        unit_price_cents: u?.unit_price_cents ?? p.price_cents,
+      };
+    });
     startTransition(async () => {
       try {
         const result = await placeOrder({
@@ -308,45 +336,94 @@ export function OrderForm({
               <div className="item-list">
                 {products.map((p) => {
                   const current = qty[p.id] ?? 0;
+                  const selected = unitFor(p);
+                  const conv = selected?.conversion_to_base ?? 1;
+                  const label = selected?.label ?? p.unit;
+                  const priceCents = selected?.unit_price_cents ?? p.price_cents;
+                  // Per-unit max: number of selected-unit chunks that fit in
+                  // current base inventory. Floors fractional remainders so
+                  // the stepper never offers a quantity that would oversell.
+                  const perUnitMax = Math.floor(p.qty_available / conv);
                   const out = p.qty_available === 0;
-                  const remaining = out ? 0 : p.qty_available - current;
+                  const remaining = out ? 0 : perUnitMax - current;
+                  const showPicker = p.units.length >= 2;
                   return (
                     <div
                       key={p.id}
-                      className={"item-row" + (out ? " is-sold-out" : "")}
+                      className={
+                        "item-row" +
+                        (out ? " is-sold-out" : "") +
+                        (showPicker ? " has-picker" : "")
+                      }
                     >
                       <div className="item-thumb" aria-hidden="true">
                         <div className="item-thumb-inner"></div>
                       </div>
                       <div className="item-body">
-                        <div className="item-line1">
-                          <div className="item-name">{p.name}</div>
-                          <div className="item-price">
-                            <span className="mono">${formatPrice(p.price_cents)}</span>
-                            <span className="item-per"> / {p.unit}</span>
-                          </div>
-                        </div>
-                        <div className="item-line2">
+                        <div className="item-name">{p.name}</div>
+                        <div className="item-meta-row">
+                          <span className="item-price">
+                            <span className="mono">${formatPrice(priceCents)}</span>
+                            <span className="item-per"> / {label}</span>
+                          </span>
                           {out ? (
                             <span className="item-meta meta-sold-out">Sold out</span>
                           ) : remaining <= 3 ? (
                             <span className="item-meta meta-low">
-                              only {remaining} {p.unit}
+                              only {remaining} {label}
                               {remaining !== 1 ? "s" : ""} left
                             </span>
                           ) : (
                             <span className="item-meta">
-                              {remaining} {p.unit}
+                              {remaining} {label}
                               {remaining !== 1 ? "s" : ""} available
                             </span>
                           )}
                         </div>
+                        {showPicker ? (
+                          <div
+                            className="unit-picker"
+                            role="radiogroup"
+                            aria-label={`${p.name} unit`}
+                          >
+                            {p.units.map((u) => {
+                              const disabled = p.qty_available < u.conversion_to_base;
+                              const isSel = u.id === selected?.id;
+                              return (
+                                <label
+                                  key={u.id}
+                                  className={
+                                    "unit-option" +
+                                    (isSel ? " is-selected" : "") +
+                                    (disabled ? " is-disabled" : "")
+                                  }
+                                >
+                                  <input
+                                    type="radio"
+                                    name={`unit-${p.id}`}
+                                    value={u.id}
+                                    checked={isSel}
+                                    disabled={disabled}
+                                    onChange={() => {
+                                      setSelectedUnit((s) => ({ ...s, [p.id]: u.id }));
+                                      setItemQty(p.id, 0);
+                                    }}
+                                  />
+                                  <span className="unit-option-label">{u.label}</span>
+                                  <span className="unit-option-price mono">
+                                    ${formatPrice(u.unit_price_cents)}
+                                  </span>
+                                </label>
+                              );
+                            })}
+                          </div>
+                        ) : null}
                       </div>
                       <div className="item-stepper">
                         <Stepper
                           value={current}
                           onChange={(n) => setItemQty(p.id, n)}
-                          max={p.qty_available}
+                          max={perUnitMax}
                         />
                       </div>
                     </div>

--- a/src/lib/customer/queries.ts
+++ b/src/lib/customer/queries.ts
@@ -7,17 +7,42 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { Database } from "@/lib/supabase/types";
 
-export type ProductRow = Database["public"]["Tables"]["products"]["Row"];
+export type ProductUnitRow = Database["public"]["Tables"]["product_units"]["Row"];
+export type ProductRow = Database["public"]["Tables"]["products"]["Row"] & {
+  // Active units only, sorted by (sort_order nulls last, created_at). The base
+  // unit (conversion_to_base = 1) is the implicit default for the customer
+  // picker. 6.5a guarantees every product has at least one active unit.
+  units: ProductUnitRow[];
+};
 
 export async function getAvailableProducts(): Promise<ProductRow[]> {
   const supabase = createAdminClient();
   const { data, error } = await supabase
     .from("products")
-    .select("*")
+    .select("*, product_units(*)")
     .eq("is_available", true)
     .order("sort_order", { ascending: true });
   if (error) throw new Error(`getAvailableProducts: ${error.message}`);
-  return data ?? [];
+  if (!data) return [];
+  return data.map((row) => {
+    const allUnits = (row.product_units ?? []) as ProductUnitRow[];
+    const units = allUnits
+      .filter((u) => u.is_active)
+      .sort((a, b) => {
+        const ao = a.sort_order;
+        const bo = b.sort_order;
+        if (ao === null && bo === null) return a.created_at.localeCompare(b.created_at);
+        if (ao === null) return 1;
+        if (bo === null) return -1;
+        return ao - bo;
+      });
+    // Strip the raw join field so the returned row matches ProductRow exactly.
+    const { product_units: _product_units, ...rest } = row as typeof row & {
+      product_units: ProductUnitRow[];
+    };
+    void _product_units;
+    return { ...rest, units };
+  });
 }
 
 // Reads the ordering_schedule singleton. Customer page uses this to decide

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1163,6 +1163,12 @@
   background: var(--leaf-50);
   color: var(--leaf-700);
 }
+/* The native radio is visually hidden, so keyboard focus would otherwise
+   be invisible. Hoist the focus ring onto the label via :has(). */
+.unit-option:has(input:focus-visible) {
+  outline: 2px solid var(--leaf-600);
+  outline-offset: 2px;
+}
 .unit-option.is-disabled {
   opacity: 0.45;
   cursor: not-allowed;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1061,7 +1061,11 @@
   display: grid;
   grid-template-columns: 44px minmax(0, 1fr) auto;
   gap: 12px;
-  align-items: center;
+  /* align-items: start gives the name + meta + picker stack room to grow
+     while keeping the thumb pinned to the top. Stepper top-aligns too so
+     it sits next to the price (visually paired) instead of drifting down
+     when a long name wraps. 6.5c restructure (#144). */
+  align-items: start;
   padding: 12px 14px;
   border-top: 1px solid var(--ink-200);
 }
@@ -1096,26 +1100,77 @@
     );
 }
 
-.item-body { min-width: 0; }
-.item-line1 {
-  display: flex; justify-content: space-between; align-items: baseline;
-  gap: 12px;
+.item-body {
+  min-width: 0;
+  display: flex; flex-direction: column; gap: 4px;
 }
 .item-name {
   font-weight: 600; color: var(--ink-900);
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  /* min-width: 0 lets the ellipsis actually trigger inside the .item-line1
-     flex container — without it the name fights the price for space and
-     crowds the stepper at 375px. 6.1 review. */
-  min-width: 0;
+  font-size: 1rem;
+  line-height: 1.25;
+  /* Wrap freely — name owns its row now, no longer competing with the
+     price for horizontal space. Closes #144. */
+  overflow-wrap: anywhere;
 }
-.item-price { font-size: 0.92rem; white-space: nowrap; flex-shrink: 0; }
+.item-meta-row {
+  display: flex; align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 0.82rem;
+  flex-wrap: wrap;
+}
+.item-price { white-space: nowrap; flex-shrink: 0; }
 .item-price .mono { font-weight: 600; color: var(--ink-900); }
 .item-per { color: var(--ink-500); }
-.item-line2 { font-size: 0.82rem; }
 .item-meta { color: var(--ink-500); }
 .item-meta.meta-low { color: var(--leaf-700); font-weight: 600; }
 .item-meta.meta-sold-out { color: var(--rose-600); font-weight: 600; }
+
+.item-stepper { padding-top: 2px; }
+
+/* Per-product unit picker (6.5c — multi-unit products). The native radio
+   stays in-DOM for a11y but is visually hidden; the .unit-option label is
+   the click target. Mirrors the .window pickup-window pattern. */
+.unit-picker {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+.unit-option {
+  position: relative;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
+  padding: 5px 9px;
+  background: var(--paper);
+  border: 1px solid var(--ink-300);
+  border-radius: var(--r-sm);
+  font-size: 0.82rem;
+  color: var(--ink-700);
+  cursor: pointer;
+  user-select: none;
+  transition: border-color 0.12s, background 0.12s, color 0.12s;
+}
+.unit-option input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+.unit-option:hover:not(.is-disabled) { border-color: var(--leaf-600); }
+.unit-option.is-selected {
+  border-color: var(--leaf-600);
+  background: var(--leaf-50);
+  color: var(--leaf-700);
+}
+.unit-option.is-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.unit-option-label { font-weight: 600; }
+.unit-option-price { font-weight: 600; color: var(--ink-900); font-variant-numeric: tabular-nums; }
+.unit-option.is-selected .unit-option-price { color: var(--leaf-700); }
+.unit-option.is-disabled .unit-option-price { color: var(--ink-500); }
 
 .stepper {
   position: relative;

--- a/tests/customer-order-units.spec.ts
+++ b/tests/customer-order-units.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from "@playwright/test";
+import {
+  TEST_CUSTOMERS,
+  TEST_PRODUCTS,
+  customerOrderUrl,
+  resetCustomerOrderState,
+  resetProductUnits,
+  setProductUnits,
+  setProductQty,
+} from "./helpers";
+
+// 6.5c — Customer order form: per-product unit picker (#153). Kale is set up
+// as a two-unit product (bunch base + pound at 2× conversion). Eggs stays
+// single-unit so single-unit regression assertions have a known-good row.
+
+const KALE = TEST_PRODUCTS.kale;
+const EGGS = TEST_PRODUCTS.eggs;
+
+const KALE_BUNCH_PRICE = KALE.price_cents;       // 300 — base unit
+const KALE_LB_PRICE = 500;                       // 1 lb sells for $5.00
+const KALE_LB_CONV = 2;                          // 1 lb = 2 base bunches
+
+function kaleRow(page: import("@playwright/test").Page) {
+  return page.locator(".item-row", { hasText: KALE.name });
+}
+function eggsRow(page: import("@playwright/test").Page) {
+  return page.locator(".item-row", { hasText: EGGS.name });
+}
+
+test.describe("/c/[token] · per-product unit picker", () => {
+  test.beforeEach(async () => {
+    await resetCustomerOrderState();
+    await setProductUnits(KALE.id, [
+      { label: KALE.unit, conversion_to_base: 1, unit_price_cents: KALE_BUNCH_PRICE },
+      { label: "lb", conversion_to_base: KALE_LB_CONV, unit_price_cents: KALE_LB_PRICE },
+    ]);
+  });
+
+  test.afterEach(async () => {
+    await resetProductUnits(KALE.id, KALE_BUNCH_PRICE);
+  });
+
+  test("multi-unit row renders a picker with both options; single-unit row has none", async ({ page }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+
+    const picker = kaleRow(page).locator(".unit-picker");
+    await expect(picker).toBeVisible();
+    await expect(picker.locator("label.unit-option")).toHaveCount(2);
+    await expect(picker.locator("label.unit-option").filter({ hasText: KALE.unit })).toBeVisible();
+    await expect(picker.locator("label.unit-option").filter({ hasText: "lb" })).toBeVisible();
+
+    // Single-unit Eggs row has no picker.
+    await expect(eggsRow(page).locator(".unit-picker")).toHaveCount(0);
+  });
+
+  test("switching unit resets qty to 0 and price + meta track the selected unit", async ({ page }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+
+    const row = kaleRow(page);
+    const stepperInput = row.locator(".stepper-val");
+    const price = row.locator(".item-price .mono");
+    const perLabel = row.locator(".item-per");
+
+    // Default to base unit (bunch).
+    await expect(price).toHaveText("$3.00");
+    await expect(perLabel).toContainText(KALE.unit);
+
+    // Bump qty to 3 in the base unit.
+    await row.getByRole("button", { name: "increase" }).click();
+    await row.getByRole("button", { name: "increase" }).click();
+    await row.getByRole("button", { name: "increase" }).click();
+    await expect(stepperInput).toHaveValue("3");
+
+    // Switch to lb — qty resets, price + meta unit follow the selection.
+    await row.locator("label.unit-option").filter({ hasText: "lb" }).click();
+    await expect(stepperInput).toHaveValue("0");
+    await expect(price).toHaveText("$5.00");
+    await expect(perLabel).toContainText("lb");
+  });
+
+  test("per-unit sold-out: lb radio is disabled when base inventory < 1 lb-conversion", async ({ page }) => {
+    // qty_available = 1 bunch is enough for the bunch radio (conv=1) but
+    // below the lb conversion (conv=2), so the lb radio must be disabled.
+    await setProductQty(KALE.id, 1);
+
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+
+    const row = kaleRow(page);
+    const bunchInput = row.locator("label.unit-option").filter({ hasText: KALE.unit }).locator("input");
+    const lbInput = row.locator("label.unit-option").filter({ hasText: "lb" }).locator("input");
+
+    await expect(bunchInput).toBeEnabled();
+    await expect(lbInput).toBeDisabled();
+    await expect(
+      row.locator("label.unit-option").filter({ hasText: "lb" })
+    ).toHaveClass(/is-disabled/);
+  });
+
+  test("single-unit row stepper still works (regression for non-multi products)", async ({ page }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+
+    const row = eggsRow(page);
+    await row.getByRole("button", { name: "increase" }).click();
+    await row.getByRole("button", { name: "increase" }).click();
+    await expect(row.locator(".stepper-val")).toHaveValue("2");
+
+    // 2 × $6.00 = $12.00 — sticky/summary totals reflect Eggs only.
+    await expect(page.locator(".summary-total")).toContainText("12.00");
+  });
+
+  test("long product name is fully visible at 375px (resolves #144)", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "mobile", "Wrap behavior is mobile-viewport-specific.");
+    // Temporarily rename Kale to a long name to exercise the wrap path.
+    const sb = (await import("./helpers")).admin();
+    const longName = "Heirloom Tuscan dinosaur kale (extra long name)";
+    await sb.from("products").update({ name: longName }).eq("id", KALE.id);
+    try {
+      await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+
+      const row = page.locator(".item-row", { hasText: longName });
+      const name = row.locator(".item-name");
+      await expect(name).toBeVisible();
+
+      // Two assertions: the rendered text matches exactly (no CSS truncation),
+      // and the box height exceeds a single line — proves it wrapped instead
+      // of clipping with text-overflow: ellipsis.
+      await expect(name).toHaveText(longName);
+      const lineCount = await name.evaluate((el) => {
+        const lh = parseFloat(getComputedStyle(el).lineHeight);
+        return Math.round(el.getBoundingClientRect().height / lh);
+      });
+      expect(lineCount).toBeGreaterThan(1);
+    } finally {
+      await sb.from("products").update({ name: KALE.name }).eq("id", KALE.id);
+    }
+  });
+});

--- a/tests/customer-order-units.spec.ts
+++ b/tests/customer-order-units.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect } from "@playwright/test";
+import { weekOfMondayNY } from "@/lib/week";
 import {
   TEST_CUSTOMERS,
   TEST_PRODUCTS,
+  admin,
   customerOrderUrl,
   resetCustomerOrderState,
   resetProductUnits,
@@ -106,6 +108,45 @@ test.describe("/c/[token] · per-product unit picker", () => {
 
     // 2 × $6.00 = $12.00 — sticky/summary totals reflect Eggs only.
     await expect(page.locator(".summary-total")).toContainText("12.00");
+  });
+
+  test("submit payload snapshots the selected unit's unit_price_cents (not the base)", async ({ page }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+
+    const row = kaleRow(page);
+    // Switch to lb (selected unit's price = $5.00) and order 2.
+    await row.locator("label.unit-option").filter({ hasText: "lb" }).click();
+    await row.getByRole("button", { name: "increase" }).click();
+    await row.getByRole("button", { name: "increase" }).click();
+    await expect(row.locator(".stepper-val")).toHaveValue("2");
+
+    await page.locator(".submit-btn").click();
+    await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
+
+    const sb = admin();
+    const { data: customer } = await sb
+      .from("customers")
+      .select("id")
+      .eq("token", TEST_CUSTOMERS.farmStand.token)
+      .single();
+    const { data: order } = await sb
+      .from("orders")
+      .select("id")
+      .eq("customer_id", customer!.id)
+      .eq("week_of", weekOfMondayNY())
+      .single();
+    const { data: lineItem } = await sb
+      .from("order_items")
+      .select("qty, unit_price_cents")
+      .eq("order_id", order!.id)
+      .eq("product_id", KALE.id)
+      .single();
+
+    // The selected unit (lb) was $5.00 — base bunch is $3.00. Recording the
+    // selected unit's price is the 6.5c contract; full unit_id + fractional
+    // decrement land in 6.5d.
+    expect(lineItem?.unit_price_cents).toBe(KALE_LB_PRICE);
+    expect(lineItem?.qty).toBe(2);
   });
 
   test("long product name is fully visible at 375px (resolves #144)", async ({ page }, testInfo) => {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -243,3 +243,53 @@ export async function resetProductUnits(productId: string, basePriceCents: numbe
     slug: `${nameSlug}-${id8}`,
   });
 }
+
+// Replaces a product's entire unit set in one call. The list is interpreted as
+// the desired post-state; existing units are wiped first to avoid label/slug
+// collisions. Units are inserted in array order so `sort_order` follows the
+// caller's intent. Use this in beforeEach to set up a multi-unit fixture; pair
+// with `resetProductUnits` in afterEach to restore the single-base default.
+export type UnitSeed = {
+  label: string;
+  conversion_to_base: number;
+  unit_price_cents: number;
+  is_active?: boolean;
+};
+export async function setProductUnits(
+  productId: string,
+  units: UnitSeed[],
+): Promise<void> {
+  const sb = admin();
+  const { data: product } = await sb
+    .from("products")
+    .select("name")
+    .eq("id", productId)
+    .single();
+  if (!product) return;
+
+  await sb.from("product_units").delete().eq("product_id", productId);
+
+  const nameSlug = product.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const id8 = productId.slice(0, 8);
+
+  const rows = units.map((u, idx) => {
+    const labelSlug = u.label
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    return {
+      product_id: productId,
+      label: u.label,
+      conversion_to_base: u.conversion_to_base,
+      unit_price_cents: u.unit_price_cents,
+      is_active: u.is_active ?? true,
+      sort_order: idx,
+      slug: `${nameSlug}-${labelSlug}-${id8}`,
+    };
+  });
+
+  await sb.from("product_units").insert(rows);
+}


### PR DESCRIPTION
## Summary
Adds a per-product unit picker to the customer order form. Multi-unit products render a radio-pill picker; selecting a unit zeroes that product's qty and tracks the selected unit's price + label in the meta line, stepper max, and submit payload. Single-unit products render unchanged. Item-row layout restructured so the product name owns its row at 375px — subsumes #144 long-name truncation.

Closes #153. Subsumes #144.

## Files changed
- `src/lib/customer/queries.ts` — joins `product_units` into `getAvailableProducts()`; new `ProductUnitRow` type; active-only filter + sort by `(sort_order nulls last, created_at)`.
- `src/components/customer/OrderForm.tsx` — new \`selectedUnit\` state, \`unitFor()\` helper, item-row restructured, \`perUnitMax = floor(qty_available / conversion_to_base)\`, submit payload sends selected unit's price. \`Math.max(0, …)\` guard on \`remaining\` to keep meta non-negative if inventory drifts mid-session.
- `src/styles/app.css` — restructured \`.item-row\` (\`align-items: start\`), new \`.item-meta-row\`, \`.unit-picker\`, \`.unit-option\` primitives. \`.item-name\` wraps freely (closes #144). \`:has(input:focus-visible)\` ring on .unit-option for keyboard a11y.
- `design/order-page.jsx` + `design/order-page.css` — mockup lockstep per the bushel design-folder rule.
- `tests/customer-order-units.spec.ts` — new spec: 6 cases on desktop + mobile webkit covering picker rendering, qty reset, per-unit sold-out, single-unit regression, payload \`unit_price_cents\` snapshot, and #144 wrap.
- `tests/helpers.ts` — new \`setProductUnits()\` helper.

## Code review
@code-review flagged: (1) clamp \`remaining\` to ≥ 0 if a selected unit drops below in-cart qty mid-session, (2) focus-visible ring on the picker label (radio is visually hidden), (3) missing assertion that submit payload carries the selected unit's price. All three addressed in commit 28f3f89. Nits on \`useCallback\` wrapping of \`unitFor\` and switching to anon client deferred (cosmetic / load-bearing). The \`conv=0\` divide concern is enforced at the DB layer via the table's \`check (conversion_to_base > 0)\` constraint.

## Known scope dependency (sequenced for 6.5d)
The `place_order` RPC still treats payload \`qty\` as base units and \`order_items.product_unit_id\` falls through the 6.5a safety-net trigger to the product's base unit. **Selected unit's price IS recorded on the order row** (new test asserts this), but the recorded `product_unit_id` and the qty_available decrement math are not yet unit-aware. 6.5d (#154) closes both via fractional decrement and unit-id pass-through.

## Test plan
- [x] `npx playwright test tests/customer-order-units.spec.ts --project=desktop` — 5 passing, 1 skipped (mobile-only wrap).
- [x] `npx playwright test tests/customer-order-units.spec.ts --project=mobile` — 6/6 including #144 wrap assertion.
- [x] `npx playwright test tests/customer-order-form.spec.ts tests/customer-place-order.spec.ts --project=desktop` — 11 passing (regression).
- [x] `npx playwright test tests/customer-order-form.spec.ts tests/customer-place-order.spec.ts --project=mobile` — 12 passing.
- [x] `npx playwright test tests/admin-inventory-units.spec.ts --project=desktop` — 6 passing (admin-side untouched).
- [x] Mobile 375px screenshot — picker visible, name wraps, single-unit rows unchanged.
- [x] `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)