### PR TITLE
Phase 6.5d — Unit-aware place_order: fractional decrement + price snapshot (#154)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -74,7 +74,8 @@
       "Bash(kill -9 3368201)",
       "Bash(awk '/^## Phase 6.5/,/^## Phase 7/' docs/PROJECT_PLAN.md)",
       "Bash(kill 2777394 2777433)",
-      "Bash(pkill -f \"next-server\")"
+      "Bash(pkill -f \"next-server\")",
+      "Bash(pkill -f next-server)"
     ]
   }
 }

--- a/docs/OPEN_ITEMS.md
+++ b/docs/OPEN_ITEMS.md
@@ -18,6 +18,7 @@ Promote to a GitHub `phase:N` issue when the trigger fires (real-world signal, d
 - **Weekly inventory snapshots / history** — beyond pre-fill. Vague. Trigger: real use case ("what did I have on hand 6 weeks ago?").
 - **Per-customer reminder preferences (incl. email channel)** (DEC-020) — `notification_preference` enum was replaced by `send_weekly_link` in migration 20260510. Email channel needs a real design.
 - **Cron auto-close opt-in** (DEC-030) — infrastructure exists; Annabel hasn't asked. Trigger: Annabel mentions wanting orders to close automatically Wednesday night.
+- **Whole-only vs. fractional units** (DEC-032 follow-on) — some units only make sense as whole counts (a "bag of lettuce", a "head of garlic") and others reasonably split (half-pound of basil). Add a `product_units.is_whole_only` boolean (default true matching current integer-qty behavior). When false, the customer stepper / qty input on that unit accepts decimals; `order_items.qty` would need to widen from `integer` to `numeric(10,2)` and the place_order decrement math is already numeric-safe. Trigger: real customer wants to order a half-pound of something. Dependency: 6.5c picker (#153) shipped, 6.5d fractional decrement (#154) shipped.
 
 ## Promoted
 

--- a/src/actions/place-order.ts
+++ b/src/actions/place-order.ts
@@ -13,6 +13,11 @@ import { weekOfMondayNY } from "@/lib/week";
 
 export type PlaceOrderItem = {
   product_id: string;
+  // 6.5d: identifies which unit of the product is being ordered. The
+  // place_order RPC looks up unit_price_cents + conversion_to_base from
+  // product_units at order time — the unit_price_cents field on the
+  // payload is now informational only (the RPC ignores it).
+  product_unit_id: string;
   qty: number;
   unit_price_cents: number;
 };

--- a/src/app/c/[token]/page.tsx
+++ b/src/app/c/[token]/page.tsx
@@ -43,7 +43,12 @@ export default async function CustomerTokenPage({
     return <ClosedShell customerName={greetingName} />;
   }
 
-  const anyOrderable = products.some((p) => p.qty_available > 0);
+  // 6.5d: orderable means at least one active unit fits in current base
+  // inventory. A product with only a conv=4 unit and qty_available=2 is
+  // effectively sold out even though qty_available > 0.
+  const anyOrderable = products.some((p) =>
+    p.units.some((u) => p.qty_available >= u.conversion_to_base),
+  );
   if (!anyOrderable) {
     return <AllSoldOutShell customerName={greetingName} />;
   }

--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -262,15 +262,15 @@ export function OrderForm({
     if (lineCount === 0 || submittingRef.current) return;
     submittingRef.current = true;
     setSubmitError(null);
-    // unit_price_cents snapshots the *selected* unit's price. The qty value
-    // is in selected-unit quantities — the place_order RPC still interprets
-    // it as base units (6.5d closes that gap with fractional decrement +
-    // product_unit_id pass-through). For single-unit products the two are
-    // identical and behavior is unchanged.
+    // Payload identifies the selected unit; place_order looks up the
+    // canonical unit_price_cents + conversion_to_base from product_units
+    // at RPC time (6.5d). unit_price_cents is sent for display continuity
+    // but the RPC ignores it — strict "price at moment of order" semantics.
     const payloadItems = itemsWithQty.map((p) => {
       const u = unitFor(p);
       return {
         product_id: p.id,
+        product_unit_id: u!.id,
         qty: qty[p.id] ?? 0,
         unit_price_cents: u?.unit_price_cents ?? p.price_cents,
       };
@@ -344,7 +344,12 @@ export function OrderForm({
                   // current base inventory. Floors fractional remainders so
                   // the stepper never offers a quantity that would oversell.
                   const perUnitMax = Math.floor(p.qty_available / conv);
-                  const out = p.qty_available === 0;
+                  // 6.5d: a product is "out" when no active unit fits in the
+                  // remaining base inventory — qty_available=2 with only a
+                  // conv=4 unit active is sold out, not "0 lbs left".
+                  const out =
+                    p.qty_available === 0 ||
+                    !p.units.some((u) => p.qty_available >= u.conversion_to_base);
                   // Math.max guards the rare case where the selected unit's
                   // perUnitMax dropped below the in-cart qty mid-session
                   // (inventory reduced under our feet). Don't render

--- a/supabase/migrations/20260524141544_place_order_unit_aware.sql
+++ b/supabase/migrations/20260524141544_place_order_unit_aware.sql
@@ -81,6 +81,12 @@ begin
        where product_id = v_product_id and is_active = true
        order by sort_order nulls last, created_at
        limit 1;
+      -- Distinct error path from the cross-product-id case below so the
+      -- message points at the right remedy: re-activate (or seed) a unit
+      -- on this product, not "fix the unit_id in your payload."
+      if v_unit_id is null then
+        raise exception 'place_order: product % has no active units', v_product_id;
+      end if;
     end if;
 
     -- Snapshot from product_units, not from the client payload. If a unit

--- a/supabase/migrations/20260524141544_place_order_unit_aware.sql
+++ b/supabase/migrations/20260524141544_place_order_unit_aware.sql
@@ -1,0 +1,133 @@
+-- Phase 6.5d — unit-aware place_order RPC (closes #154, DEC-032).
+--
+-- Replaces the place_order function from 20260514173354 with a body that:
+--   1. Reads product_unit_id per item from the payload (optional — legacy
+--      callers without it still work because the 6.5a safety-net trigger
+--      on order_items fills in the first active unit).
+--   2. Snapshots unit_price_cents from product_units at order time. The
+--      payload's unit_price_cents is ignored — strict "matches the unit's
+--      price at the moment of order" semantics, no client-tamper surface.
+--   3. Decrements products.qty_available by qty * conversion_to_base
+--      instead of just qty. For single-unit products (conv=1) this is
+--      identical to the prior behavior.
+--
+-- Signature is unchanged — the JSONB shape inside p_items grew an optional
+-- product_unit_id field, but the function arguments themselves are the same.
+
+create or replace function public.place_order(
+  p_customer_id          uuid,
+  p_week_of              date,
+  p_fulfillment_type     text,
+  p_delivery_address     text,
+  p_delivery_preference  text,
+  p_pickup_note          text,
+  p_notes                text,
+  p_items                jsonb
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  v_order_id     uuid;
+  v_item         jsonb;
+  v_product_id   uuid;
+  v_unit_id      uuid;
+  v_qty          int;
+  v_unit_price   int;
+  v_conv         numeric(10,4);
+  v_negative     boolean;
+begin
+  if jsonb_typeof(p_items) is distinct from 'array' or jsonb_array_length(p_items) = 0 then
+    raise exception 'place_order: p_items must be a non-empty json array';
+  end if;
+
+  -- Atomic double-submit handling. See prior migration's comment block for
+  -- the TOCTOU rationale (20260514173354_place_order_function.sql).
+  insert into public.orders (
+    customer_id, week_of, fulfillment_type,
+    delivery_address, delivery_preference, pickup_note,
+    notes, status, needs_reconciliation
+  )
+  values (
+    p_customer_id, p_week_of, p_fulfillment_type,
+    p_delivery_address, p_delivery_preference, p_pickup_note,
+    p_notes, 'new', false
+  )
+  on conflict (customer_id, week_of) do nothing
+  returning id into v_order_id;
+
+  if v_order_id is null then
+    select id into v_order_id
+    from public.orders
+    where customer_id = p_customer_id and week_of = p_week_of;
+    return v_order_id;
+  end if;
+
+  for v_item in select * from jsonb_array_elements(p_items)
+  loop
+    v_product_id := (v_item->>'product_id')::uuid;
+    v_qty        := (v_item->>'qty')::int;
+    -- product_unit_id is optional in the payload. When absent, the
+    -- order_items_default_unit BEFORE-INSERT trigger (from 6.5a) fills
+    -- in the first active unit for this product. We resolve the unit
+    -- here too so the price snapshot + decrement math match what the
+    -- row will end up with.
+    v_unit_id := nullif(v_item->>'product_unit_id', '')::uuid;
+    if v_unit_id is null then
+      select id into v_unit_id
+        from public.product_units
+       where product_id = v_product_id and is_active = true
+       order by sort_order nulls last, created_at
+       limit 1;
+    end if;
+
+    -- Snapshot from product_units, not from the client payload. If a unit
+    -- id was supplied but doesn't belong to this product (mismatched),
+    -- the lookup returns null and we raise — refusing to record a
+    -- cross-product unit reference rather than silently falling through.
+    select unit_price_cents, conversion_to_base
+      into v_unit_price, v_conv
+      from public.product_units
+     where id = v_unit_id and product_id = v_product_id;
+
+    if v_unit_price is null then
+      raise exception
+        'place_order: product_unit_id % does not belong to product %', v_unit_id, v_product_id;
+    end if;
+
+    insert into public.order_items (order_id, product_id, product_unit_id, qty, unit_price_cents)
+    values (v_order_id, v_product_id, v_unit_id, v_qty, v_unit_price);
+
+    update public.products
+       set qty_available = qty_available - (v_qty::numeric * v_conv),
+           updated_at = now()
+     where id = v_product_id;
+  end loop;
+
+  -- Flip needs_reconciliation if any product touched by this order is now
+  -- negative. Same one-shot check as the prior version.
+  select exists (
+    select 1
+    from public.products p
+    join public.order_items oi on oi.product_id = p.id
+    where oi.order_id = v_order_id
+      and p.qty_available < 0
+  ) into v_negative;
+
+  if v_negative then
+    update public.orders
+       set needs_reconciliation = true
+     where id = v_order_id;
+  end if;
+
+  return v_order_id;
+end;
+$$;
+
+-- Re-apply grants. CREATE OR REPLACE preserves the prior REVOKE/GRANT state
+-- when the signature is unchanged, but it's cheap to be explicit so a future
+-- hand-edit doesn't accidentally widen access.
+revoke all on function public.place_order(uuid, date, text, text, text, text, text, jsonb) from public;
+grant execute on function public.place_order(uuid, date, text, text, text, text, text, jsonb) to service_role;

--- a/supabase/tests/place_order_units.sql
+++ b/supabase/tests/place_order_units.sql
@@ -1,0 +1,236 @@
+begin;
+select plan(12);
+
+-- ============================================================
+-- 6.5d — place_order RPC under multi-unit (DEC-032)
+--
+-- Verifies the post-6.5d contract:
+--   - place_order accepts product_unit_id per line item.
+--   - order_items.unit_price_cents is snapshotted from product_units AT
+--     ORDER TIME (not trusted from the payload, not retroactively updated
+--     when admin edits the unit's price afterward).
+--   - products.qty_available decrements by qty * conversion_to_base.
+--   - Oversell still flips orders.needs_reconciliation = true.
+-- ============================================================
+
+-- Fresh fixture rows scoped to this test (rolled back at end-of-file).
+insert into public.customers (id, name, token)
+values ('dddd0000-0000-0000-0000-000000000001'::uuid, 'PlaceOrder Customer', 'token-place-order-65d');
+
+insert into public.products (id, name, unit, price_cents, qty_available, sort_order, category)
+values ('dddd0000-0000-0000-0000-aaaa00000001'::uuid, 'Basil', 'bunch', 350, 10.00, 1, 'Herbs');
+
+-- Two units: bunch (base) + lb (conv=2 — one lb = 2 bunches' worth).
+-- The trigger from 6.5a will have spawned a base unit on insert; we'll
+-- replace that with deterministic rows for assertion stability.
+delete from public.product_units where product_id = 'dddd0000-0000-0000-0000-aaaa00000001'::uuid;
+
+insert into public.product_units (id, product_id, label, conversion_to_base, unit_price_cents, is_active, slug, sort_order)
+values
+  ('dddd0000-0000-0000-0000-bbbb00000001'::uuid,
+   'dddd0000-0000-0000-0000-aaaa00000001'::uuid,
+   'bunch', 1, 350, true, 'basil-bunch-dddd0000', 0),
+  ('dddd0000-0000-0000-0000-bbbb00000002'::uuid,
+   'dddd0000-0000-0000-0000-aaaa00000001'::uuid,
+   'lb', 2, 600, true, 'basil-lb-dddd0000', 1);
+
+-- ============================================================
+-- 1. Fractional decrement: order qty=2 of the lb unit (conv=2)
+--    should drop qty_available by 4 (2 * 2 = 4).
+-- ============================================================
+select lives_ok(
+  $$ select public.place_order(
+       'dddd0000-0000-0000-0000-000000000001'::uuid,
+       '2026-06-01'::date,
+       'delivery', '123 Test St', '', '', '',
+       jsonb_build_array(
+         jsonb_build_object(
+           'product_id',       'dddd0000-0000-0000-0000-aaaa00000001'::text,
+           'product_unit_id',  'dddd0000-0000-0000-0000-bbbb00000002'::text,
+           'qty',              2,
+           'unit_price_cents', 999
+         )
+       )
+     ) $$,
+  'place_order accepts product_unit_id in p_items'
+);
+
+select is(
+  (select qty_available from public.products
+   where id = 'dddd0000-0000-0000-0000-aaaa00000001'::uuid),
+  6.00::numeric(10,2),
+  'qty_available decremented by qty * conversion_to_base (10 - 2*2 = 6)'
+);
+
+-- ============================================================
+-- 2. unit_price_cents is snapshotted from product_units, NOT from
+--    the client payload (the payload sent 999 — a value that would
+--    be flagged as tampering — and the RPC should override it).
+-- ============================================================
+select is(
+  (select unit_price_cents from public.order_items
+   where product_id = 'dddd0000-0000-0000-0000-aaaa00000001'::uuid
+   limit 1),
+  600,
+  'order_items.unit_price_cents pulled from product_units, ignoring payload value'
+);
+
+-- ============================================================
+-- 3. product_unit_id persists from the payload (not the trigger fallback)
+-- ============================================================
+select is(
+  (select product_unit_id from public.order_items
+   where product_id = 'dddd0000-0000-0000-0000-aaaa00000001'::uuid
+   limit 1),
+  'dddd0000-0000-0000-0000-bbbb00000002'::uuid,
+  'order_items.product_unit_id matches the payload (lb unit, not base)'
+);
+
+-- ============================================================
+-- 4. Price snapshot survives unit-price edits after order placement.
+-- ============================================================
+update public.product_units
+   set unit_price_cents = 99999
+ where id = 'dddd0000-0000-0000-0000-bbbb00000002'::uuid;
+
+select is(
+  (select unit_price_cents from public.order_items
+   where product_id = 'dddd0000-0000-0000-0000-aaaa00000001'::uuid
+   limit 1),
+  600,
+  'order_items.unit_price_cents stays at snapshot value after unit price edit'
+);
+
+-- ============================================================
+-- 5. Oversell-by-unit reconciliation. New customer + product so we get
+--    a clean (customer, week) — place_order otherwise no-ops on conflict.
+-- ============================================================
+insert into public.customers (id, name, token)
+values ('dddd0000-0000-0000-0000-000000000002'::uuid, 'Oversell Customer', 'token-oversell-65d');
+
+insert into public.products (id, name, unit, price_cents, qty_available, sort_order, category)
+values ('dddd0000-0000-0000-0000-aaaa00000002'::uuid, 'Mint', 'bunch', 250, 3.00, 2, 'Herbs');
+
+delete from public.product_units where product_id = 'dddd0000-0000-0000-0000-aaaa00000002'::uuid;
+insert into public.product_units (id, product_id, label, conversion_to_base, unit_price_cents, is_active, slug, sort_order)
+values
+  ('dddd0000-0000-0000-0000-cccc00000001'::uuid,
+   'dddd0000-0000-0000-0000-aaaa00000002'::uuid,
+   'bunch', 1, 250, true, 'mint-bunch-dddd0000', 0),
+  ('dddd0000-0000-0000-0000-cccc00000002'::uuid,
+   'dddd0000-0000-0000-0000-aaaa00000002'::uuid,
+   'lb', 4, 800, true, 'mint-lb-dddd0000', 1);
+
+-- Order 2 lb of mint = 8 base units, but only 3 in stock → oversold by 5.
+select lives_ok(
+  $$ select public.place_order(
+       'dddd0000-0000-0000-0000-000000000002'::uuid,
+       '2026-06-01'::date,
+       'delivery', '456 Oversell Ln', '', '', '',
+       jsonb_build_array(
+         jsonb_build_object(
+           'product_id',       'dddd0000-0000-0000-0000-aaaa00000002'::text,
+           'product_unit_id',  'dddd0000-0000-0000-0000-cccc00000002'::text,
+           'qty',              2,
+           'unit_price_cents', 800
+         )
+       )
+     ) $$,
+  'oversold order is accepted (DEC-012)'
+);
+
+select is(
+  (select qty_available from public.products
+   where id = 'dddd0000-0000-0000-0000-aaaa00000002'::uuid),
+  (-5.00)::numeric(10,2),
+  'oversold inventory goes negative (3 - 2*4 = -5)'
+);
+
+select is(
+  (select needs_reconciliation from public.orders
+   where customer_id = 'dddd0000-0000-0000-0000-000000000002'::uuid
+     and week_of = '2026-06-01'),
+  true,
+  'orders.needs_reconciliation flipped true on oversold place_order'
+);
+
+-- ============================================================
+-- 6. Single-unit regression: a product with one unit (the base) still
+--    decrements as qty * 1 = qty. This guards against the multi-unit
+--    code path breaking legacy single-unit orders.
+-- ============================================================
+insert into public.customers (id, name, token)
+values ('dddd0000-0000-0000-0000-000000000003'::uuid, 'Single-Unit Customer', 'token-single-unit-65d');
+
+insert into public.products (id, name, unit, price_cents, qty_available, sort_order, category)
+values ('dddd0000-0000-0000-0000-aaaa00000003'::uuid, 'Chives', 'bunch', 200, 20.00, 3, 'Herbs');
+
+delete from public.product_units where product_id = 'dddd0000-0000-0000-0000-aaaa00000003'::uuid;
+insert into public.product_units (id, product_id, label, conversion_to_base, unit_price_cents, is_active, slug, sort_order)
+values
+  ('dddd0000-0000-0000-0000-eeee00000001'::uuid,
+   'dddd0000-0000-0000-0000-aaaa00000003'::uuid,
+   'bunch', 1, 200, true, 'chives-bunch-dddd0000', 0);
+
+select lives_ok(
+  $$ select public.place_order(
+       'dddd0000-0000-0000-0000-000000000003'::uuid,
+       '2026-06-01'::date,
+       'delivery', '789 Single St', '', '', '',
+       jsonb_build_array(
+         jsonb_build_object(
+           'product_id',       'dddd0000-0000-0000-0000-aaaa00000003'::text,
+           'product_unit_id',  'dddd0000-0000-0000-0000-eeee00000001'::text,
+           'qty',              5,
+           'unit_price_cents', 200
+         )
+       )
+     ) $$,
+  'single-unit order accepted'
+);
+
+select is(
+  (select qty_available from public.products
+   where id = 'dddd0000-0000-0000-0000-aaaa00000003'::uuid),
+  15.00::numeric(10,2),
+  'single-unit decrement is qty * 1 (20 - 5 = 15)'
+);
+
+-- ============================================================
+-- 7. Missing product_unit_id falls through to the 6.5a safety-net
+--    trigger (legacy callers — the trigger fills in the first active
+--    unit). Decrement still uses qty * conv from the resolved unit.
+-- ============================================================
+insert into public.customers (id, name, token)
+values ('dddd0000-0000-0000-0000-000000000004'::uuid, 'Trigger Fallback Customer', 'token-fallback-65d');
+
+select lives_ok(
+  $$ select public.place_order(
+       'dddd0000-0000-0000-0000-000000000004'::uuid,
+       '2026-06-01'::date,
+       'delivery', '999 Fallback Rd', '', '', '',
+       jsonb_build_array(
+         jsonb_build_object(
+           'product_id',       'dddd0000-0000-0000-0000-aaaa00000003'::text,
+           'qty',              2,
+           'unit_price_cents', 200
+         )
+       )
+     ) $$,
+  'payload without product_unit_id falls through to safety-net trigger'
+);
+
+select is(
+  (select product_unit_id from public.order_items
+   where product_id = 'dddd0000-0000-0000-0000-aaaa00000003'::uuid
+     and order_id in (
+       select id from public.orders
+       where customer_id = 'dddd0000-0000-0000-0000-000000000004'::uuid
+         and week_of = '2026-06-01'
+     )),
+  'dddd0000-0000-0000-0000-eeee00000001'::uuid,
+  'trigger filled in product_unit_id from the first active unit'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/place_order_units.sql
+++ b/supabase/tests/place_order_units.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(12);
+select plan(13);
 
 -- ============================================================
 -- 6.5d — place_order RPC under multi-unit (DEC-032)
@@ -230,6 +230,38 @@ select is(
      )),
   'dddd0000-0000-0000-0000-eeee00000001'::uuid,
   'trigger filled in product_unit_id from the first active unit'
+);
+
+-- ============================================================
+-- 8. Product with NO active units + payload that omits product_unit_id
+--    raises a distinct "no active units" error (not the misleading
+--    "product_unit_id <NULL> does not belong to product …" path).
+-- ============================================================
+insert into public.customers (id, name, token)
+values ('dddd0000-0000-0000-0000-000000000005'::uuid, 'No Units Customer', 'token-no-units-65d');
+
+insert into public.products (id, name, unit, price_cents, qty_available, sort_order, category)
+values ('dddd0000-0000-0000-0000-aaaa00000004'::uuid, 'Phantom', 'unit', 100, 5.00, 4, 'Herbs');
+
+-- Wipe all units (including the trigger-spawned default) so the product
+-- has zero active units, which is the case the error path covers.
+delete from public.product_units where product_id = 'dddd0000-0000-0000-0000-aaaa00000004'::uuid;
+
+select throws_like(
+  $$ select public.place_order(
+       'dddd0000-0000-0000-0000-000000000005'::uuid,
+       '2026-06-01'::date,
+       'delivery', '111 No Units Way', '', '', '',
+       jsonb_build_array(
+         jsonb_build_object(
+           'product_id', 'dddd0000-0000-0000-0000-aaaa00000004'::text,
+           'qty',        1,
+           'unit_price_cents', 100
+         )
+       )
+     ) $$,
+  '%has no active units%',
+  'product with zero active units raises a targeted error (not the unit-mismatch message)'
 );
 
 select * from finish();

--- a/tests/customer-order-units.spec.ts
+++ b/tests/customer-order-units.spec.ts
@@ -110,11 +110,11 @@ test.describe("/c/[token] · per-product unit picker", () => {
     await expect(page.locator(".summary-total")).toContainText("12.00");
   });
 
-  test("submit payload snapshots the selected unit's unit_price_cents (not the base)", async ({ page }) => {
+  test("submit payload records selected unit's price + id + fractional decrement (6.5d contract)", async ({ page }) => {
     await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
 
     const row = kaleRow(page);
-    // Switch to lb (selected unit's price = $5.00) and order 2.
+    // Switch to lb (price $5.00, conv=2) and order 2 lb.
     await row.locator("label.unit-option").filter({ hasText: "lb" }).click();
     await row.getByRole("button", { name: "increase" }).click();
     await row.getByRole("button", { name: "increase" }).click();
@@ -137,16 +137,31 @@ test.describe("/c/[token] · per-product unit picker", () => {
       .single();
     const { data: lineItem } = await sb
       .from("order_items")
-      .select("qty, unit_price_cents")
+      .select("qty, unit_price_cents, product_unit_id, product_units(label)")
       .eq("order_id", order!.id)
       .eq("product_id", KALE.id)
       .single();
 
-    // The selected unit (lb) was $5.00 — base bunch is $3.00. Recording the
-    // selected unit's price is the 6.5c contract; full unit_id + fractional
-    // decrement land in 6.5d.
+    // 6.5d: order_items.unit_price_cents pulled from product_units at RPC
+    // time, product_unit_id matches the lb row (not the bunch fallback),
+    // and qty stays in selected-unit units.
     expect(lineItem?.unit_price_cents).toBe(KALE_LB_PRICE);
     expect(lineItem?.qty).toBe(2);
+    expect(
+      (lineItem as unknown as { product_units: { label: string } })
+        ?.product_units?.label,
+    ).toBe("lb");
+
+    // qty_available decremented by qty * conversion_to_base.
+    const { data: kale } = await sb
+      .from("products")
+      .select("qty_available")
+      .eq("id", KALE.id)
+      .single();
+    expect(Number(kale?.qty_available)).toBeCloseTo(
+      KALE.qty_available - 2 * KALE_LB_CONV,
+      2,
+    );
   });
 
   test("long product name is fully visible at 375px (resolves #144)", async ({ page }, testInfo) => {


### PR DESCRIPTION
## Summary
Closes the gap intentionally left by 6.5c. The `place_order` RPC is now unit-aware: payload carries `product_unit_id` per line item, the RPC looks up `unit_price_cents` + `conversion_to_base` from `product_units` at RPC time (no client trust), and the inventory decrement becomes `qty * conversion_to_base`. Customer-side sold-out logic updated to consider per-unit conversion against base inventory.

**Stacked on #162** — base is `task/6.5c-customer-unit-picker`. GitHub will auto-retarget to `main` once #162 merges.

Closes #154.

## Files changed
- `supabase/migrations/20260524141544_place_order_unit_aware.sql` — replaces \`place_order\` function body. Signature unchanged. \`p_items\` JSONB elements gained an optional \`product_unit_id\` field. Distinct error path when a product has no active units.
- `supabase/tests/place_order_units.sql` — 13 pgTAP cases: fractional decrement, payload-vs-DB price reconciliation, snapshot stability after unit-price edits, oversell-by-unit reconciliation, single-unit regression, trigger-fallback when payload omits product_unit_id, and the no-active-units error path.
- `src/actions/place-order.ts` — \`PlaceOrderItem\` gains \`product_unit_id: string\`.
- `src/components/customer/OrderForm.tsx` — payload sends selected unit's id; per-product \`out\` detection now considers whether any active unit fits in remaining base inventory.
- `src/app/c/[token]/page.tsx` — \`anyOrderable\` uses per-unit conversion check.
- `tests/customer-order-units.spec.ts` — payload spec asserts \`product_unit_id\` matches selected lb unit AND \`qty_available\` decremented by \`qty * conversion_to_base\`.
- `docs/OPEN_ITEMS.md` — triage entry for \`product_units.is_whole_only\` (lettuce-by-the-bag vs. basil-by-the-lb).

## Code review
@code-review flagged one real issue (misleading error message when payload omits \`product_unit_id\` for a product with zero active units) and several non-issues. Fix landed in commit \`1a42d12\`: distinct \"product X has no active units\" raise, plus a pgTAP case to cover it. Numeric precision, prod-push timing, and migration safety all confirmed clean.

## Prod-push sequencing
Migration applied to dev/preview only. Prod will get the migration once the PR merges (link to prod project, `supabase db push`, relink back to dev). The 6.5c client sending `product_unit_id` against the old prod RPC is forward-compatible — old function ignores unknown JSON keys via `jsonb_array_elements`.

## Test plan
- [x] `supabase test db` — 107 pgTAP tests passing locally including the 13 new place_order cases.
- [x] `supabase db reset --local` clean replay of all migrations.
- [x] `supabase db push` to dev/preview (after `supabase migration repair --status reverted` to re-apply the corrected body).
- [x] `npx playwright test tests/customer-order-units.spec.ts --project=desktop` — 5 passing, 1 skipped (mobile-only).
- [x] `npx playwright test tests/customer-order-units.spec.ts --project=mobile` — 6 passing.
- [x] `npx playwright test tests/customer-order-form.spec.ts tests/customer-place-order.spec.ts --project=desktop` — 11 passing.
- [x] `npx playwright test tests/customer-order-form.spec.ts tests/customer-place-order.spec.ts --project=mobile` — 12 passing.
- [x] `npx playwright test tests/admin-orders.spec.ts tests/admin-orders-export.spec.ts tests/admin-prepopulate.spec.ts tests/orders-flow.spec.ts --project=desktop` — 19 passing (RPC-change regression).
- [x] `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)