### PR TITLE
Phase 6.5e — Unit-aware pre-populate + last-week price restore (#155)

### DIFF
--- a/src/components/admin/prepopulate-button.tsx
+++ b/src/components/admin/prepopulate-button.tsx
@@ -21,7 +21,7 @@ export function PrepopulateButton() {
   function handleClick() {
     if (
       !window.confirm(
-        "Restore last week's starting inventory? This adds last week's ordered quantities back to current values.",
+        "Restore last week's starting inventory and unit prices? Adds last week's ordered quantities back to current qty (unit-aware), and resets each unit's price to its last-week snapshot.",
       )
     )
       return;

--- a/supabase/migrations/20260524144640_prepopulate_unit_aware.sql
+++ b/supabase/migrations/20260524144640_prepopulate_unit_aware.sql
@@ -21,6 +21,11 @@
 -- match products.qty_available's numeric(10,2). Callers using data.length
 -- (the action does) are unaffected.
 
+-- `drop function` is required (not `create or replace`) because the return
+-- signature changes from (uuid, integer) → (uuid, numeric). Postgres rejects
+-- a column-type change inside `create or replace`. In bushel's solo-Annabel
+-- context the brief drop window between this statement and the create below
+-- has no concurrent-caller risk.
 drop function if exists public.prepopulate_inventory_from_last_week();
 
 create or replace function public.prepopulate_inventory_from_last_week()

--- a/supabase/migrations/20260524144640_prepopulate_unit_aware.sql
+++ b/supabase/migrations/20260524144640_prepopulate_unit_aware.sql
@@ -1,0 +1,91 @@
+-- Phase 6.5e — unit-aware pre-populate (closes #155, DEC-032).
+--
+-- Two changes to prepopulate_inventory_from_last_week():
+--
+-- 1. Inventory restore is now unit-aware. Pre-6.5d, the function summed
+--    oi.qty per product — fine when every line item was 1 base unit. Post-
+--    6.5d, ordering 2 lb of basil (conv=2) decremented qty_available by 4,
+--    but the old restore only added back 2. New body multiplies by
+--    product_units.conversion_to_base so the math reverses cleanly.
+--
+-- 2. Unit prices restored to last-week snapshot. For each product_unit
+--    that appears in any last-week order_items row, update its
+--    unit_price_cents to the value recorded on the most recent (by
+--    created_at) last-week line item referencing that unit. Units that
+--    weren't ordered last week are left alone. Re-activation of
+--    deactivated units is NOT in scope — flipping is_active back to true
+--    on a unit Annabel deliberately deactivated mid-week would silently
+--    undo admin intent (see 6.5e plan).
+--
+-- The function return shape widens from added_qty integer → numeric to
+-- match products.qty_available's numeric(10,2). Callers using data.length
+-- (the action does) are unaffected.
+
+drop function if exists public.prepopulate_inventory_from_last_week();
+
+create or replace function public.prepopulate_inventory_from_last_week()
+returns table(product_id uuid, added_qty numeric)
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  v_last_week date;
+begin
+  select max(week_of) into v_last_week
+    from public.orders
+   where week_of < current_date;
+
+  if v_last_week is null then
+    return;
+  end if;
+
+  -- Step 1: restore unit prices to last week's snapshot. Done before the
+  -- qty restore so a hand-rolled trigger on product_units (none exists
+  -- today, but defensive) wouldn't see the qty change first and react.
+  with last_week_unit_orders as (
+    select
+      oi.product_unit_id,
+      oi.unit_price_cents,
+      row_number() over (
+        partition by oi.product_unit_id
+        order by oi.created_at desc, oi.id desc
+      ) as rn
+    from public.order_items oi
+    join public.orders o on o.id = oi.order_id
+    where o.week_of = v_last_week
+  )
+  update public.product_units pu
+     set unit_price_cents = lw.unit_price_cents,
+         updated_at = now()
+    from last_week_unit_orders lw
+   where lw.product_unit_id = pu.id
+     and lw.rn = 1
+     and pu.unit_price_cents is distinct from lw.unit_price_cents;
+
+  -- Step 2: per-product base-unit qty restore. Multiplies each line's qty
+  -- by its unit's conversion_to_base — the inverse of 6.5d's decrement.
+  return query
+    with totals as (
+      select
+        oi.product_id,
+        sum(oi.qty::numeric * pu.conversion_to_base)::numeric(10,2) as ordered_base_qty
+      from public.order_items oi
+      join public.orders o          on o.id = oi.order_id
+      join public.product_units pu  on pu.id = oi.product_unit_id
+      where o.week_of = v_last_week
+      group by oi.product_id
+    ),
+    updated as (
+      update public.products p
+         set qty_available = p.qty_available + t.ordered_base_qty,
+             updated_at = now()
+        from totals t
+       where t.product_id = p.id
+      returning p.id, t.ordered_base_qty
+    )
+    select id, ordered_base_qty from updated;
+end;
+$$;
+
+grant execute on function public.prepopulate_inventory_from_last_week() to authenticated;

--- a/supabase/tests/prepopulate_units.sql
+++ b/supabase/tests/prepopulate_units.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(8);
+select plan(9);
 
 -- ============================================================
 -- 6.5e — prepopulate_inventory_from_last_week() under multi-unit
@@ -135,12 +135,9 @@ values ('eeee0000-0000-0000-0000-bbbb00000004'::uuid,
         'eeee0000-0000-0000-0000-aaaa00000002'::uuid,
         'pinch', 0.25, 50, true, 'testchives-pinch-eeee0000', 1);
 
--- Re-run the function and confirm the new untouched unit's price is unchanged.
--- Wipe products' qty back to a known state so the qty assertion stays simple.
-update public.products set qty_available = 25.00 where id = 'eeee0000-0000-0000-0000-aaaa00000002'::uuid;
-update public.products set qty_available = 17.00 where id = 'eeee0000-0000-0000-0000-aaaa00000001'::uuid;
-
--- Re-invoke; discard the returned rowset by tossing it into a temp table.
+-- Re-invoke; discard the returned rowset. The first call already touched
+-- units that had last-week orders; this second call is about asserting
+-- that a unit added AFTER last week's orders is left alone.
 create temporary table prepop_result_2 as
   select * from public.prepopulate_inventory_from_last_week();
 
@@ -149,6 +146,28 @@ select is(
    where id = 'eeee0000-0000-0000-0000-bbbb00000004'::uuid),
   50,
   'unit with no last-week order keeps its current price (untouched)'
+);
+
+-- ============================================================
+-- 4b. Deactivated unit invariant: a unit that's been turned off
+--     by admin (is_active = false) stays deactivated even when it
+--     had last-week orders. Pins the 6.5e scope decision NOT to
+--     silently re-enable units that Annabel deliberately disabled.
+-- ============================================================
+update public.product_units
+   set is_active = false
+ where id = 'eeee0000-0000-0000-0000-bbbb00000002'::uuid;  -- basil lb
+
+-- Run pre-populate again. The lb unit had a last-week order, so its
+-- price would update if it were reactivated. is_active must NOT change.
+create temporary table prepop_result_3 as
+  select * from public.prepopulate_inventory_from_last_week();
+
+select is(
+  (select is_active from public.product_units
+   where id = 'eeee0000-0000-0000-0000-bbbb00000002'::uuid),
+  false,
+  'deactivated unit stays deactivated through pre-populate (6.5e scope pin)'
 );
 
 -- ============================================================

--- a/supabase/tests/prepopulate_units.sql
+++ b/supabase/tests/prepopulate_units.sql
@@ -1,0 +1,170 @@
+begin;
+select plan(8);
+
+-- ============================================================
+-- 6.5e — prepopulate_inventory_from_last_week() under multi-unit
+--
+-- Verifies post-6.5e behavior:
+--   - qty restore is unit-aware (qty * conversion_to_base).
+--   - unit_price_cents on each ordered unit reverts to last week's
+--     snapshot (the most-recent order_items.unit_price_cents).
+--   - Units NOT ordered last week have their prices left alone.
+--   - Single-unit (conv=1) products are unchanged from the old math.
+--   - No last-week orders → function returns empty rowset, no error.
+-- ============================================================
+
+-- Use a fixed last-week date relative to the run so the function picks it up.
+-- The function checks week_of < current_date and takes max(week_of).
+-- All test orders go in current_date - 7 days; nothing else in that week.
+-- Clear any pre-existing orders in that week to avoid pollution from seed data.
+delete from public.orders where week_of = (current_date - interval '7 days')::date;
+
+-- Fixture: basil (multi-unit, bunch base + lb conv=2) + chives (single).
+insert into public.customers (id, name, token)
+values ('eeee0000-0000-0000-0000-000000000001'::uuid, 'Prepop Customer', 'token-prepop-65e');
+
+insert into public.products (id, name, unit, price_cents, qty_available, sort_order, category)
+values
+  ('eeee0000-0000-0000-0000-aaaa00000001'::uuid, 'TestBasil',  'bunch', 350, 10.00, 90, 'Herbs'),
+  ('eeee0000-0000-0000-0000-aaaa00000002'::uuid, 'TestChives', 'bunch', 200, 20.00, 91, 'Herbs');
+
+-- Replace trigger-spawned units with deterministic ones.
+delete from public.product_units where product_id in (
+  'eeee0000-0000-0000-0000-aaaa00000001'::uuid,
+  'eeee0000-0000-0000-0000-aaaa00000002'::uuid
+);
+
+insert into public.product_units (id, product_id, label, conversion_to_base, unit_price_cents, is_active, slug, sort_order)
+values
+  ('eeee0000-0000-0000-0000-bbbb00000001'::uuid,
+   'eeee0000-0000-0000-0000-aaaa00000001'::uuid,
+   'bunch', 1, 350, true, 'testbasil-bunch-eeee0000', 0),
+  ('eeee0000-0000-0000-0000-bbbb00000002'::uuid,
+   'eeee0000-0000-0000-0000-aaaa00000001'::uuid,
+   'lb', 2, 600, true, 'testbasil-lb-eeee0000', 1),
+  ('eeee0000-0000-0000-0000-bbbb00000003'::uuid,
+   'eeee0000-0000-0000-0000-aaaa00000002'::uuid,
+   'bunch', 1, 200, true, 'testchives-bunch-eeee0000', 0);
+
+-- Seed last week's orders: 3 bunch + 2 lb basil; 5 bunch chives.
+insert into public.orders (id, customer_id, week_of, fulfillment_type, status)
+values ('eeee0000-0000-0000-0000-cccc00000001'::uuid,
+        'eeee0000-0000-0000-0000-000000000001'::uuid,
+        (current_date - interval '7 days')::date,
+        'delivery', 'delivered');
+
+-- Manually insert order_items with snapshot prices (different from current
+-- product_units prices for the price-restore assertion).
+insert into public.order_items (order_id, product_id, product_unit_id, qty, unit_price_cents, created_at)
+values
+  ('eeee0000-0000-0000-0000-cccc00000001'::uuid,
+   'eeee0000-0000-0000-0000-aaaa00000001'::uuid,
+   'eeee0000-0000-0000-0000-bbbb00000001'::uuid,
+   3, 325, now() - interval '6 days'),   -- bunch snapshot @ $3.25 (current $3.50)
+  ('eeee0000-0000-0000-0000-cccc00000001'::uuid,
+   'eeee0000-0000-0000-0000-aaaa00000001'::uuid,
+   'eeee0000-0000-0000-0000-bbbb00000002'::uuid,
+   2, 575, now() - interval '6 days'),   -- lb snapshot @ $5.75 (current $6.00)
+  ('eeee0000-0000-0000-0000-cccc00000001'::uuid,
+   'eeee0000-0000-0000-0000-aaaa00000002'::uuid,
+   'eeee0000-0000-0000-0000-bbbb00000003'::uuid,
+   5, 200, now() - interval '6 days');   -- chives snapshot @ $2.00 (current $2.00)
+
+-- Capture pre-restore state so we can assert the deltas.
+-- Run the function and capture its rowset.
+create temporary table prepop_result as
+  select * from public.prepopulate_inventory_from_last_week();
+
+-- ============================================================
+-- 1. Basil: 3 bunch + 2 lb at conv 2 = 3*1 + 2*2 = 7 base units added.
+-- ============================================================
+select is(
+  (select added_qty from prepop_result
+   where product_id = 'eeee0000-0000-0000-0000-aaaa00000001'::uuid),
+  7.00::numeric,
+  'multi-unit qty restore sums qty * conversion_to_base'
+);
+
+select is(
+  (select qty_available from public.products
+   where id = 'eeee0000-0000-0000-0000-aaaa00000001'::uuid),
+  17.00::numeric(10,2),
+  'basil qty_available bumped 10 + 7 = 17'
+);
+
+-- ============================================================
+-- 2. Chives (single-unit conv=1): 5 bunch → added_qty 5, unchanged math.
+-- ============================================================
+select is(
+  (select added_qty from prepop_result
+   where product_id = 'eeee0000-0000-0000-0000-aaaa00000002'::uuid),
+  5.00::numeric,
+  'single-unit qty restore is qty * 1'
+);
+
+select is(
+  (select qty_available from public.products
+   where id = 'eeee0000-0000-0000-0000-aaaa00000002'::uuid),
+  25.00::numeric(10,2),
+  'chives qty_available bumped 20 + 5 = 25'
+);
+
+-- ============================================================
+-- 3. Price restore: basil bunch + lb reverted to last week's snapshot.
+-- ============================================================
+select is(
+  (select unit_price_cents from public.product_units
+   where id = 'eeee0000-0000-0000-0000-bbbb00000001'::uuid),
+  325,
+  'basil bunch unit_price_cents restored to last-week snapshot ($3.25)'
+);
+
+select is(
+  (select unit_price_cents from public.product_units
+   where id = 'eeee0000-0000-0000-0000-bbbb00000002'::uuid),
+  575,
+  'basil lb unit_price_cents restored to last-week snapshot ($5.75)'
+);
+
+-- ============================================================
+-- 4. Unit that didn't have a last-week order keeps its current price.
+-- Seed a new unit AFTER the orders existed; it shouldn't be touched.
+-- ============================================================
+insert into public.product_units (id, product_id, label, conversion_to_base, unit_price_cents, is_active, slug, sort_order)
+values ('eeee0000-0000-0000-0000-bbbb00000004'::uuid,
+        'eeee0000-0000-0000-0000-aaaa00000002'::uuid,
+        'pinch', 0.25, 50, true, 'testchives-pinch-eeee0000', 1);
+
+-- Re-run the function and confirm the new untouched unit's price is unchanged.
+-- Wipe products' qty back to a known state so the qty assertion stays simple.
+update public.products set qty_available = 25.00 where id = 'eeee0000-0000-0000-0000-aaaa00000002'::uuid;
+update public.products set qty_available = 17.00 where id = 'eeee0000-0000-0000-0000-aaaa00000001'::uuid;
+
+-- Re-invoke; discard the returned rowset by tossing it into a temp table.
+create temporary table prepop_result_2 as
+  select * from public.prepopulate_inventory_from_last_week();
+
+select is(
+  (select unit_price_cents from public.product_units
+   where id = 'eeee0000-0000-0000-0000-bbbb00000004'::uuid),
+  50,
+  'unit with no last-week order keeps its current price (untouched)'
+);
+
+-- ============================================================
+-- 5. No last-week orders → function returns empty rowset, no error.
+-- Wipe last-week orders and call again.
+-- ============================================================
+delete from public.orders where week_of = (current_date - interval '7 days')::date;
+
+-- Also need to wipe anything else in any prior week so max(week_of) is null.
+delete from public.orders where week_of < current_date;
+
+select is(
+  (select count(*)::int from public.prepopulate_inventory_from_last_week()),
+  0,
+  'no prior-week orders → function returns empty rowset (no exception)'
+);
+
+select * from finish();
+rollback;

--- a/tests/admin-prepopulate.spec.ts
+++ b/tests/admin-prepopulate.spec.ts
@@ -15,6 +15,7 @@ function rowByName(page: Page, name: string) {
 // Fixed UUIDs so the seed is idempotent across re-runs.
 const LAST_WEEK_ORDER_ID = "eeeeeeee-0000-0000-0000-000000000001";
 const LAST_WEEK_ORDER_ITEM_ID = "ffffffff-0000-0000-0000-000000000001";
+const LAST_WEEK_MULTI_ORDER_ID = "eeeeeeee-0000-0000-0000-000000000002";
 const LAST_WEEK_QTY = 3;
 
 function lastWeekDate(): string {
@@ -69,12 +70,20 @@ test.describe("admin inventory — pre-populate from last week", () => {
 
   test.afterEach(async () => {
     const supabase = admin();
-    await supabase.from("orders").delete().eq("id", LAST_WEEK_ORDER_ID);
-    // Reset Kale qty back to the canonical seed value
+    // Defensive cleanup covers both the single-unit and multi-unit fixture
+    // ids in case an inner afterEach throws between order-delete and
+    // resetProductUnits. Orders first (cascade order_items), then units —
+    // order_items.product_unit_id is ON DELETE RESTRICT, so swapped order
+    // would leak a partial state into the next test.
+    await supabase
+      .from("orders")
+      .delete()
+      .in("id", [LAST_WEEK_ORDER_ID, LAST_WEEK_MULTI_ORDER_ID]);
     await supabase
       .from("products")
       .update({ qty_available: TEST_PRODUCTS.kale.qty_available })
       .eq("id", TEST_PRODUCTS.kale.id);
+    await resetProductUnits(TEST_PRODUCTS.kale.id, TEST_PRODUCTS.kale.price_cents);
   });
 
   test("button restores last week's ordered qty onto current inventory", async ({ page }) => {
@@ -115,8 +124,6 @@ test.describe("admin inventory — pre-populate from last week", () => {
     const LB_QTY = 1;
     // 2 * 1 + 1 * 2 = 4 base units restored
     const EXPECTED_RESTORED_QTY = BUNCH_QTY * 1 + LB_QTY * LB_CONV;
-
-    const LAST_WEEK_MULTI_ORDER_ID = "eeeeeeee-0000-0000-0000-000000000002";
 
     test.beforeEach(async () => {
       const supabase = admin();

--- a/tests/admin-prepopulate.spec.ts
+++ b/tests/admin-prepopulate.spec.ts
@@ -4,6 +4,8 @@ import {
   TEST_CUSTOMERS,
   TEST_PRODUCTS,
   admin,
+  resetProductUnits,
+  setProductUnits,
 } from "./helpers";
 
 function rowByName(page: Page, name: string) {
@@ -96,5 +98,134 @@ test.describe("admin inventory — pre-populate from last week", () => {
     page.once("dialog", (d) => d.dismiss());
     await page.getByRole("button", { name: /pre-populate from last week/i }).click();
     await expect(rowByName(page, TEST_PRODUCTS.kale.name).getByRole("spinbutton", { name: /quantity/i })).toHaveValue("0");
+  });
+
+  // 6.5e — pre-populate is unit-aware. Builds a multi-unit Kale (bunch base
+  // + lb conv=2), seeds last-week orders with both units at snapshot prices
+  // different from current, and asserts that after pre-populate (a) qty
+  // adds back qty * conversion_to_base and (b) unit prices revert to the
+  // last-week snapshot.
+  test.describe("multi-unit pre-populate (6.5e)", () => {
+    const BUNCH_SNAPSHOT_CENTS = 275; // $2.75 — different from current $3.00
+    const LB_SNAPSHOT_CENTS = 450;    // $4.50 — different from current $5.00
+    const BUNCH_CURRENT_CENTS = 300;
+    const LB_CURRENT_CENTS = 500;
+    const LB_CONV = 2;
+    const BUNCH_QTY = 2;
+    const LB_QTY = 1;
+    // 2 * 1 + 1 * 2 = 4 base units restored
+    const EXPECTED_RESTORED_QTY = BUNCH_QTY * 1 + LB_QTY * LB_CONV;
+
+    const LAST_WEEK_MULTI_ORDER_ID = "eeeeeeee-0000-0000-0000-000000000002";
+
+    test.beforeEach(async () => {
+      const supabase = admin();
+
+      // Defensive cleanup: blow away any prior single-unit OR multi-unit
+      // last-week order so setProductUnits can free up Kale's old unit
+      // rows. order_items.product_unit_id is ON DELETE RESTRICT, so any
+      // residual reference would silently break the unit delete-then-
+      // insert (FK violation → unit insert collides on unique label).
+      await supabase
+        .from("orders")
+        .delete()
+        .in("id", [LAST_WEEK_ORDER_ID, LAST_WEEK_MULTI_ORDER_ID]);
+
+      // Replace Kale's single base unit with a two-unit set (bunch + lb).
+      // Capture the inserted unit ids so we can stamp last-week orders.
+      await setProductUnits(TEST_PRODUCTS.kale.id, [
+        { label: TEST_PRODUCTS.kale.unit, conversion_to_base: 1, unit_price_cents: BUNCH_CURRENT_CENTS },
+        { label: "lb",                    conversion_to_base: LB_CONV, unit_price_cents: LB_CURRENT_CENTS },
+      ]);
+
+      const { data: units, error: unitsError } = await supabase
+        .from("product_units")
+        .select("id, label")
+        .eq("product_id", TEST_PRODUCTS.kale.id);
+      if (unitsError || !units) throw new Error(`Unit lookup failed: ${unitsError?.message}`);
+      const bunchUnit = units.find((u) => u.label === TEST_PRODUCTS.kale.unit);
+      const lbUnit = units.find((u) => u.label === "lb");
+      if (!bunchUnit || !lbUnit) throw new Error("Multi-unit fixture missing bunch/lb");
+
+      // Resolve test customer + reset Kale qty to a known 0 starting state.
+      const { data: customer } = await supabase
+        .from("customers")
+        .select("id")
+        .eq("token", TEST_CUSTOMERS.farmStand.token)
+        .single();
+      if (!customer) throw new Error("Test customer not found");
+
+      await supabase.from("products").update({ qty_available: 0 }).eq("id", TEST_PRODUCTS.kale.id);
+
+      await supabase.from("orders").delete().eq("id", LAST_WEEK_MULTI_ORDER_ID);
+
+      // Seed last week's order with two line items, each at a snapshot price
+      // that differs from the current unit price.
+      await supabase.from("orders").insert({
+        id: LAST_WEEK_MULTI_ORDER_ID,
+        customer_id: customer.id,
+        week_of: lastWeekDate(),
+        fulfillment_type: "delivery",
+        status: "delivered",
+      });
+
+      const { error: itemsError } = await supabase.from("order_items").insert([
+        {
+          order_id: LAST_WEEK_MULTI_ORDER_ID,
+          product_id: TEST_PRODUCTS.kale.id,
+          product_unit_id: bunchUnit.id,
+          qty: BUNCH_QTY,
+          unit_price_cents: BUNCH_SNAPSHOT_CENTS,
+        },
+        {
+          order_id: LAST_WEEK_MULTI_ORDER_ID,
+          product_id: TEST_PRODUCTS.kale.id,
+          product_unit_id: lbUnit.id,
+          qty: LB_QTY,
+          unit_price_cents: LB_SNAPSHOT_CENTS,
+        },
+      ]);
+      if (itemsError) throw new Error(`Multi-unit order_items insert failed: ${itemsError.message}`);
+    });
+
+    test.afterEach(async () => {
+      const supabase = admin();
+      await supabase.from("orders").delete().eq("id", LAST_WEEK_MULTI_ORDER_ID);
+      // Restore Kale to seed defaults (qty + single base unit).
+      await supabase
+        .from("products")
+        .update({ qty_available: TEST_PRODUCTS.kale.qty_available })
+        .eq("id", TEST_PRODUCTS.kale.id);
+      await resetProductUnits(TEST_PRODUCTS.kale.id, TEST_PRODUCTS.kale.price_cents);
+    });
+
+    test("restores qty unit-aware AND reverts each unit's price to last-week snapshot", async ({ page }) => {
+      await page.goto("/admin/inventory");
+
+      const qtySpin = rowByName(page, TEST_PRODUCTS.kale.name).getByRole("spinbutton", { name: /quantity/i });
+      await expect(qtySpin).toHaveValue("0");
+
+      page.once("dialog", (d) => d.accept());
+      await page.getByRole("button", { name: /pre-populate from last week/i }).click();
+      await expect(page.getByText(/restored qty on/i)).toBeVisible();
+
+      // qty_available should be 4 (2 bunch * 1 + 1 lb * 2).
+      await page.reload();
+      await expect(
+        rowByName(page, TEST_PRODUCTS.kale.name).getByRole("spinbutton", { name: /quantity/i }),
+      ).toHaveValue(String(EXPECTED_RESTORED_QTY));
+
+      // Unit prices reverted to last-week snapshot (not current).
+      const supabase = admin();
+      const { data: units } = await supabase
+        .from("product_units")
+        .select("label, unit_price_cents")
+        .eq("product_id", TEST_PRODUCTS.kale.id);
+      const byLabel = Object.fromEntries(
+        (units ?? []).map((u) => [u.label, u.unit_price_cents]),
+      );
+      expect(byLabel[TEST_PRODUCTS.kale.unit]).toBe(BUNCH_SNAPSHOT_CENTS);
+      expect(byLabel["lb"]).toBe(LB_SNAPSHOT_CENTS);
+    });
   });
 });


### PR DESCRIPTION
## Summary
Makes `prepopulate_inventory_from_last_week()` unit-aware (closes #155). Pre-6.5d's `sum(oi.qty)` per product was wrong post-6.5d — ordering 2 lb of basil (conv=2) decremented 4 base units but restore only added back 2. New body sums `qty * conversion_to_base` AND reverts each unit's `unit_price_cents` to the last-week snapshot. Deactivated units are explicitly NOT re-enabled (would silently undo admin intent).

**Stacked on #163** — base is `task/6.5d-fractional-decrement`. Auto-retargets to main as the stack merges.

Closes #155.

## Files changed
- `supabase/migrations/20260524144640_prepopulate_unit_aware.sql` — rewrites `prepopulate_inventory_from_last_week()`. Body widens from SQL → plpgsql; return type widens from `(uuid, integer)` → `(uuid, numeric)`. \`drop function\` required because PostgreSQL rejects return-signature changes in `create or replace` — comment block in the file explains the brief drop window.
- `supabase/tests/prepopulate_units.sql` — new pgTAP suite, 9 cases (116 total): multi-unit fractional reversal, single-unit regression, price restore to snapshot, untouched-unit price preserved, no-prior-week-orders no-op, and the deactivated-unit invariant.
- `src/components/admin/prepopulate-button.tsx` — confirm-dialog copy updated to mention price reset side-effect so Annabel sees it before clicking through.
- `tests/admin-prepopulate.spec.ts` — new "multi-unit pre-populate (6.5e)" describe seeds Kale as bunch + lb with snapshot prices distinct from current, places last-week order, asserts qty restored unit-aware AND both unit prices reverted. Outer afterEach now defensively cleans up both single-unit and multi-unit fixture ids and unconditionally resets units.

## Code review
@code-review flagged one real issue (outer afterEach didn't clean up the multi-unit fixture, risking poison between tests on partial failure), one stale-comment nit, and a missing pgTAP scope-pin for the deactivated-unit invariant. All three addressed in commit \`26be5ba\`. SQL math, plpgsql conversion, `is distinct from` price-update guard, and `row_number() ... desc` snapshot picking all confirmed correct.

## Prod-push sequencing
Migration applied to dev/preview. Prod gets it as the stack merges. Stacked-PR sequencing: #162 → #163 → #165 → main. Each PR's base auto-retargets when its parent merges. Prod `supabase db push` after the final merge picks up all four migrations in timestamp order.

## Test plan
- [x] `supabase test db` — 116 pgTAP tests passing including the 9 new prepopulate cases.
- [x] `supabase db reset --local` clean replay.
- [x] `supabase db push` to dev/preview.
- [x] `npx playwright test tests/admin-prepopulate.spec.ts --project=desktop` — 3 passing (single-unit, cancel, multi-unit).
- [x] `npx playwright test tests/customer-order-units.spec.ts tests/customer-place-order.spec.ts tests/customer-order-form.spec.ts --project=desktop` — 16 passing, 2 skipped (regression).
- [x] `npx playwright test tests/admin-inventory.spec.ts tests/admin-inventory-units.spec.ts --project=desktop` — 11 passing, 1 skipped (regression).
- [x] `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)