### PR TITLE
Phase 6.5f — Per-line unit label everywhere + cross-cutting e2e tests (#156)

### DIFF
--- a/src/app/c/[token]/confirmed/page.tsx
+++ b/src/app/c/[token]/confirmed/page.tsx
@@ -86,7 +86,12 @@ export default async function ConfirmedPage({
           {items.map((item) => {
             const product = item.products;
             const name = product?.name ?? "(item)";
-            const unit = product?.unit ?? "";
+            // 6.5f: prefer the per-line unit label from product_units (what
+            // the customer actually selected). Fall back to the legacy
+            // products.unit only if the join misses (single-unit case where
+            // the safety-net trigger filled in the base unit anyway).
+            const unit =
+              item.product_units?.label ?? product?.unit ?? "";
             return (
               <li key={item.id}>
                 <span className="confirm-line-name">

--- a/src/components/admin/order-detail.tsx
+++ b/src/components/admin/order-detail.tsx
@@ -4,6 +4,15 @@ function formatMoney(cents: number): string {
   return `$${(cents / 100).toFixed(2)}`;
 }
 
+// Compact qty render for the oversold flag: integers as-is, fractionals
+// trimmed to 2 decimals with trailing zeros removed (so "1.5 lb" not
+// "1.50 lb"). Used for per-unit availability + shortBy figures that can
+// land fractional for non-base units (e.g. 1 bunch left ÷ 2 base/lb = 0.5 lb).
+function fmtQty(n: number): string {
+  if (Number.isInteger(n)) return n.toString();
+  return n.toFixed(2).replace(/\.?0+$/, "");
+}
+
 export function OrderDetail({ order }: { order: OrderRowData }) {
   return (
     <div className="ord-detail">
@@ -15,9 +24,22 @@ export function OrderDetail({ order }: { order: OrderRowData }) {
               // 6.5f: oversold math is unit-aware. A line of 5 lb (conv=2)
               // consumes 10 base units, so qty_available=8 is oversold by 2
               // base units — not "5 > 8 = false" from the old integer compare.
+              // Display is framed in the selected unit (matches the line's
+              // qty + unitLabel) so the message reads as a single coherent
+              // statement: "2× · lb / Only 0.5 lb available — 1.5 lb oversold".
               const baseRequested = i.qty * i.conversionToBase;
               const oversold = baseRequested > i.qtyAvailable;
-              const shortBy = oversold ? baseRequested - i.qtyAvailable : 0;
+              // Clamp available to ≥ 0. Under DEC-012's optimistic decrement,
+              // qty_available is allowed to go negative after a runaway order —
+              // showing "Only -1.5 lb available" is nonsensical to Annabel.
+              // shortBy measures the gap between order qty and the *clamped*
+              // available, so the message stays coherent: full order qty when
+              // inventory is already exhausted, partial when some was on hand.
+              const availableBase = Math.max(0, i.qtyAvailable);
+              const availableInUnit = availableBase / i.conversionToBase;
+              const shortByInUnit = oversold
+                ? (baseRequested - availableBase) / i.conversionToBase
+                : 0;
               return (
                 <li key={i.productId} className={oversold ? "is-oversold" : ""}>
                   <span className="ord-li-qty mono">{i.qty}×</span>
@@ -27,8 +49,8 @@ export function OrderDetail({ order }: { order: OrderRowData }) {
                   </span>
                   {oversold && (
                     <span className="ord-li-flag">
-                      Only {i.qtyAvailable} {i.unit} available — {shortBy} {i.unit}
-                      {shortBy !== 1 ? "s" : ""} oversold
+                      Only {fmtQty(availableInUnit)} {i.unitLabel} available —{" "}
+                      {fmtQty(shortByInUnit)} {i.unitLabel} oversold
                     </span>
                   )}
                   <span className="ord-li-amt mono">

--- a/src/components/admin/order-detail.tsx
+++ b/src/components/admin/order-detail.tsx
@@ -12,18 +12,23 @@ export function OrderDetail({ order }: { order: OrderRowData }) {
           <div className="ord-detail-label">Line items</div>
           <ul className="ord-detail-list">
             {order.items.map((i) => {
-              const oversold = i.qty > i.qtyAvailable;
-              const shortBy = oversold ? i.qty - i.qtyAvailable : 0;
+              // 6.5f: oversold math is unit-aware. A line of 5 lb (conv=2)
+              // consumes 10 base units, so qty_available=8 is oversold by 2
+              // base units — not "5 > 8 = false" from the old integer compare.
+              const baseRequested = i.qty * i.conversionToBase;
+              const oversold = baseRequested > i.qtyAvailable;
+              const shortBy = oversold ? baseRequested - i.qtyAvailable : 0;
               return (
                 <li key={i.productId} className={oversold ? "is-oversold" : ""}>
                   <span className="ord-li-qty mono">{i.qty}×</span>
                   <span className="ord-li-name">
                     {i.name}
-                    <span className="ord-li-unit"> · {i.unit}</span>
+                    <span className="ord-li-unit"> · {i.unitLabel}</span>
                   </span>
                   {oversold && (
                     <span className="ord-li-flag">
-                      Only {i.qtyAvailable} available — {shortBy} oversold
+                      Only {i.qtyAvailable} {i.unit} available — {shortBy} {i.unit}
+                      {shortBy !== 1 ? "s" : ""} oversold
                     </span>
                   )}
                   <span className="ord-li-amt mono">

--- a/src/lib/admin/orders-queries.ts
+++ b/src/lib/admin/orders-queries.ts
@@ -18,7 +18,17 @@ export type OrderItem = {
   // 5.2 mapping (e.g. "KALE-BUNCH"). Null when unset — Wave just gets a blank
   // Item Number cell, which Annabel fills before posting the invoice.
   description: string | null;
+  // Legacy single-unit base label from products.unit. Kept for callers that
+  // need the product-level unit (export, etc.); display surfaces should use
+  // unitLabel for per-line accuracy under multi-unit.
   unit: string;
+  // 6.5f: per-line unit label resolved from product_units.label via
+  // order_items.product_unit_id. For single-unit products this matches `unit`;
+  // for multi-unit lines this is the unit the customer actually selected.
+  unitLabel: string;
+  // 6.5f: conversion factor for the line's unit. Used for unit-aware oversold
+  // math (qty * conversionToBase vs base qty_available).
+  conversionToBase: number;
   qty: number;
   unitPriceCents: number;
   qtyAvailable: number;
@@ -67,7 +77,8 @@ export async function listOrders(weekOf: string): Promise<OrderRow[]> {
        status, needs_reconciliation,
        customers(id, name),
        order_items(product_id, qty, unit_price_cents,
-         products(name, description, unit, qty_available))`,
+         products(name, description, unit, qty_available),
+         product_units(label, conversion_to_base))`,
     )
     .eq("week_of", weekOf)
     .order("created_at", { ascending: false });
@@ -88,6 +99,10 @@ export async function listOrders(weekOf: string): Promise<OrderRow[]> {
           unit: string;
           qty_available: number;
         } | null;
+        product_units: {
+          label: string;
+          conversion_to_base: number;
+        } | null;
       }>)
         .filter((i) => i.products !== null)
         .map((i) => ({
@@ -95,6 +110,12 @@ export async function listOrders(weekOf: string): Promise<OrderRow[]> {
           name: i.products!.name,
           description: i.products!.description,
           unit: i.products!.unit,
+          // 6.5f: per-line unit label from product_units. The legacy
+          // safety-net is the products.unit string — only kicks in if the
+          // join misses, which 6.5a's invariant (every product has ≥1 unit
+          // row) prevents in practice.
+          unitLabel: i.product_units?.label ?? i.products!.unit,
+          conversionToBase: Number(i.product_units?.conversion_to_base ?? 1),
           qty: i.qty,
           unitPriceCents: i.unit_price_cents,
           qtyAvailable: i.products!.qty_available,

--- a/src/lib/customer/queries.ts
+++ b/src/lib/customer/queries.ts
@@ -97,7 +97,8 @@ export async function getCurrentWeekOrder(customerId: string, weekOf: string) {
         id,
         qty,
         unit_price_cents,
-        products ( name, unit )
+        products ( name, unit ),
+        product_units ( label )
       )
     `,
     )

--- a/tests/orders-flow.spec.ts
+++ b/tests/orders-flow.spec.ts
@@ -10,6 +10,9 @@ import {
   clearOrdersForWeek,
   seedOrder,
   resetCustomerOrderState,
+  resetProductUnits,
+  setProductQty,
+  setProductUnits,
 } from "./helpers";
 import { weekOfMondayNY } from "@/lib/week";
 import { EXPORT_COLUMNS } from "@/lib/admin/export-orders";
@@ -257,5 +260,150 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
     expect(lastText).not.toContain(TEST_PRODUCTS.kale.name);
 
     await adminCtx.close();
+  });
+
+  // 6.5f — multi-unit cross-cutting end-to-end. Exercises the full path:
+  // admin seeds units → customer picks a non-base unit → place_order does
+  // unit-aware decrement + per-unit price snapshot → admin orders detail
+  // displays the correct unit label per line.
+  test.describe("multi-unit end-to-end (6.5f)", () => {
+    const LB_CONV = 2;
+    const BUNCH_PRICE = TEST_PRODUCTS.kale.price_cents; // $3.00 base
+    const LB_PRICE = 500;                                // $5.00 per lb
+
+    test.beforeEach(async () => {
+      await setProductUnits(TEST_PRODUCTS.kale.id, [
+        { label: TEST_PRODUCTS.kale.unit, conversion_to_base: 1, unit_price_cents: BUNCH_PRICE },
+        { label: "lb",                    conversion_to_base: LB_CONV, unit_price_cents: LB_PRICE },
+      ]);
+    });
+
+    test.afterEach(async () => {
+      await resetProductUnits(TEST_PRODUCTS.kale.id, BUNCH_PRICE);
+      await setProductQty(TEST_PRODUCTS.kale.id, TEST_PRODUCTS.kale.qty_available);
+    });
+
+    test("happy path: customer orders lb → admin sees correct unit label + price + decrement", async ({
+      browser,
+    }) => {
+      // Customer picks lb, orders 2.
+      const customerCtx = await browser.newContext();
+      const customerPage = await customerCtx.newPage();
+      await customerPage.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+
+      const kaleRow = customerPage.locator(".item-row", { hasText: TEST_PRODUCTS.kale.name });
+      await kaleRow.locator("label.unit-option").filter({ hasText: "lb" }).click();
+      await kaleRow.getByRole("button", { name: "increase" }).click();
+      await kaleRow.getByRole("button", { name: "increase" }).click();
+      await customerPage.locator(".submit-btn").click();
+      await customerPage.waitForURL(/\/c\/[^/]+\/confirmed$/);
+
+      // /confirmed shows "lb", not the base "bunch".
+      const confirmList = customerPage.locator(".confirm-list");
+      await expect(confirmList).toContainText(/lb/);
+      await expect(confirmList).not.toContainText(/bunch/);
+      await customerCtx.close();
+
+      // Find the order id.
+      const sb = admin();
+      const ids = await customerIds();
+      const { data: order } = await sb
+        .from("orders")
+        .select("id")
+        .eq("customer_id", ids.farmStand)
+        .eq("week_of", thisWeek)
+        .single();
+      expect(order?.id).toBeTruthy();
+
+      // Inventory decremented by qty * conversion_to_base = 2 * 2 = 4.
+      const { data: kale } = await sb
+        .from("products")
+        .select("qty_available")
+        .eq("id", TEST_PRODUCTS.kale.id)
+        .single();
+      expect(Number(kale?.qty_available)).toBeCloseTo(
+        TEST_PRODUCTS.kale.qty_available - 2 * LB_CONV,
+        2,
+      );
+
+      // Admin orders expand row → line shows "lb", $5.00 line price.
+      const adminCtx = await browser.newContext({ storageState: ADMIN_STORAGE_STATE });
+      const adminPage = await adminCtx.newPage();
+      await adminPage.goto("/admin/orders");
+      const row = adminPage.locator(`tr.ord-row[data-order-id="${order!.id}"]`);
+      await row.click();
+
+      const detail = adminPage.locator("tr.ord-detail-row .ord-detail");
+      await expect(detail).toBeVisible();
+      const lineItem = detail.locator(".ord-detail-list li").first();
+      await expect(lineItem.locator(".ord-li-name")).toContainText(TEST_PRODUCTS.kale.name);
+      // The unit segment is " · lb", not " · bunch" — the line corresponds to
+      // the customer's lb selection. Be precise so a bug that falls back to
+      // the base unit doesn't pass.
+      await expect(lineItem.locator(".ord-li-unit")).toHaveText(/· lb$/);
+      await expect(lineItem.locator(".ord-li-unit")).not.toHaveText(/bunch/);
+      // 2 lb × $5.00 = $10.00 (selected unit's price, not base).
+      await expect(lineItem.locator(".ord-li-amt")).toHaveText("$10.00");
+
+      await adminCtx.close();
+    });
+
+    test("oversell-by-unit: customer orders past per-unit availability → admin sees recon pin + correct label", async ({
+      browser,
+    }) => {
+      // Tight inventory: 3 base units = 1.5 lb at conv=2 → 1 lb is OK but
+      // 2 lb tips over. Stepper max is 1 lb (floor(3/2)=1), so the customer
+      // can't normally order 2 lb. Set qty_available so 2 lb is the
+      // stepper's max BUT the order WILL still trigger the oversold path
+      // when stock is reduced after page render. Cleanest setup: render
+      // page with qty=4 (max=2 lb), then drop qty to 1 before submit so
+      // the place_order RPC oversells.
+      await setProductQty(TEST_PRODUCTS.kale.id, 4);
+
+      const customerCtx = await browser.newContext();
+      const customerPage = await customerCtx.newPage();
+      await customerPage.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+
+      const kaleRow = customerPage.locator(".item-row", { hasText: TEST_PRODUCTS.kale.name });
+      await kaleRow.locator("label.unit-option").filter({ hasText: "lb" }).click();
+      await kaleRow.getByRole("button", { name: "increase" }).click();
+      await kaleRow.getByRole("button", { name: "increase" }).click();
+      await expect(kaleRow.locator(".stepper-val")).toHaveValue("2");
+
+      // Drop inventory under the customer's feet — emulates a parallel
+      // customer or an admin edit between page render and submit.
+      await setProductQty(TEST_PRODUCTS.kale.id, 1);
+
+      await customerPage.locator(".submit-btn").click();
+      await customerPage.waitForURL(/\/c\/[^/]+\/confirmed$/);
+      await customerCtx.close();
+
+      const sb = admin();
+      const ids = await customerIds();
+      const { data: order } = await sb
+        .from("orders")
+        .select("id, needs_reconciliation")
+        .eq("customer_id", ids.farmStand)
+        .eq("week_of", thisWeek)
+        .single();
+      expect(order?.needs_reconciliation).toBe(true);
+
+      // Admin orders detail → recon callout + per-line "lb oversold" message.
+      const adminCtx = await browser.newContext({ storageState: ADMIN_STORAGE_STATE });
+      const adminPage = await adminCtx.newPage();
+      await adminPage.goto("/admin/orders");
+      const row = adminPage.locator(`tr.ord-row[data-order-id="${order!.id}"]`);
+      await row.click();
+      const detail = adminPage.locator("tr.ord-detail-row .ord-detail");
+      await expect(detail.locator(".callout-warn")).toBeVisible();
+      const oversoldLine = detail.locator(".ord-detail-list li.is-oversold");
+      await expect(oversoldLine.locator(".ord-li-unit")).toHaveText(/· lb$/);
+      // Inventory dropped to 1 base unit before submit; order needed 4
+      // (2 lb × conv 2). Flag should read "Only 1 bunch available — 3 ..."
+      // (qty_available is in base units, the customer-side base label).
+      await expect(oversoldLine.locator(".ord-li-flag")).toContainText(/oversold/i);
+
+      await adminCtx.close();
+    });
   });
 });

--- a/tests/orders-flow.spec.ts
+++ b/tests/orders-flow.spec.ts
@@ -398,10 +398,13 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
       await expect(detail.locator(".callout-warn")).toBeVisible();
       const oversoldLine = detail.locator(".ord-detail-list li.is-oversold");
       await expect(oversoldLine.locator(".ord-li-unit")).toHaveText(/· lb$/);
-      // Inventory dropped to 1 base unit before submit; order needed 4
-      // (2 lb × conv 2). Flag should read "Only 1 bunch available — 3 ..."
-      // (qty_available is in base units, the customer-side base label).
-      await expect(oversoldLine.locator(".ord-li-flag")).toContainText(/oversold/i);
+      // place_order decrements optimistically (DEC-012); inventory was 1
+      // base unit at place_order time, the 4-base-unit order (2 lb × conv 2)
+      // ran it to -3. The display clamps qty_available to 0 — there's no
+      // such thing as "negative lb available." shortBy = (4 - 0) / 2 = 2 lb.
+      await expect(oversoldLine.locator(".ord-li-flag")).toHaveText(
+        "Only 0 lb available — 2 lb oversold",
+      );
 
       await adminCtx.close();
     });


### PR DESCRIPTION
## Summary
Final task in Phase 6.5 multi-unit. The named scope was "cross-cutting Playwright + pgTAP coverage", but during planning we discovered `listOrders()` and `getCurrentWeekOrder()` were still pulling `products.unit` (the legacy base label) instead of `product_units.label` per line — so the admin orders expand row + customer /confirmed page both showed the WRONG unit for multi-unit orders. The PR rolls the display-string bug fix in alongside the new cross-cutting e2e tests.

**Stacked on #164** — base is `task/6.5e-prefill-units`. Chain: #162 → #163 → #164 → this PR → main. Auto-retargets as each parent merges.

**Repointing `preview.baybranchfarm.com` to this branch exercises the full Phase 6.5 stack** (admin units drawer + customer unit picker + unit-aware place_order + unit-aware pre-populate + correct unit labels in admin/customer order views).

Closes #156.

## Files changed
- `src/lib/admin/orders-queries.ts` — \`listOrders()\` joins \`product_units(label, conversion_to_base)\`. \`OrderItem\` gains \`unitLabel\` (per-line label) and \`conversionToBase\` (for unit-aware oversold math).
- `src/components/admin/order-detail.tsx` — line items render \`i.unitLabel\`. Oversold detection upgraded to \`qty * conversionToBase > qtyAvailable\`. Display reframed in selected-unit ("Only 0.5 lb available — 1.5 lb oversold"). Negative qty_available clamped to 0 for display under DEC-012 optimistic-decrement. Pluralization dropped.
- `src/lib/customer/queries.ts` — \`getCurrentWeekOrder\` joins \`product_units(label)\` per order_items row.
- `src/app/c/[token]/confirmed/page.tsx` — line items render the per-line product_units label.
- `tests/orders-flow.spec.ts` — new "multi-unit end-to-end (6.5f)" describe with happy-path (customer picks lb → admin sees correct label, price, decrement) and oversell-by-unit (mid-session qty drop triggers needs_reconciliation, admin sees clamped "0 lb available" message).

## Code review
@code-review flagged: oversold flag mixed unit frames (line in lb, flag in bunch), pluralization broke "bunch", and the oversell test exposed a display bug when qty_available went negative. All three addressed in commit \`0181fce\`: oversold copy now framed in selected unit, qty clamped to ≥ 0 in the display, naive pluralization dropped. Display-string fallback to \`products.unit\` deemed acceptable belt-and-suspenders given 6.5a's invariant. No other UI seams pull \`products.unit\` for order line items (confirmed by grep).

## Test plan
- [x] `npx playwright test tests/orders-flow.spec.ts --project=desktop` — 5 passing (3 prior + 2 new multi-unit).
- [x] `npx playwright test tests/orders-flow.spec.ts tests/admin-orders.spec.ts tests/customer-order-units.spec.ts tests/customer-place-order.spec.ts tests/admin-prepopulate.spec.ts tests/admin-orders-export.spec.ts tests/customer-order-form.spec.ts tests/admin-inventory-units.spec.ts --project=desktop` — 44 passing, 3 skipped.
- [x] `npx playwright test tests/customer-order-units.spec.ts tests/customer-place-order.spec.ts tests/customer-order-form.spec.ts --project=mobile` — 18 passing.
- [x] `supabase test db` — 116 pgTAP tests passing (no schema change in this PR, just sanity).
- [x] `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)