### PR TITLE
Inventory meta pills: drop Cutoff; Open-for-orders pulls from schedule

### DIFF
--- a/design/admin-inventory.jsx
+++ b/design/admin-inventory.jsx
@@ -122,7 +122,7 @@ function InventoryPage() {
         </div>
         <div className="inv-meta-pill">
           <span className="inv-meta-key">Customers</span>
-          <span className="inv-meta-val">38 active · 12 ordered</span>
+          <span className="inv-meta-val">38 subscribed · 12 ordered</span>
         </div>
       </div>
 

--- a/design/admin-inventory.jsx
+++ b/design/admin-inventory.jsx
@@ -118,15 +118,11 @@ function InventoryPage() {
       <div className="inv-meta">
         <div className="inv-meta-pill">
           <span className="inv-meta-key">Open for orders</span>
-          <span className="inv-meta-val"><span className="status-dot is-open" style={{boxShadow: "0 0 0 2px rgba(121,196,78,0.18)"}}></span> Sun 8am – Tue 6pm</span>
+          <span className="inv-meta-val"><span className="status-dot is-open" style={{boxShadow: "0 0 0 2px rgba(121,196,78,0.18)"}}></span> Open · Sun 8am – Tue 6pm</span>
         </div>
         <div className="inv-meta-pill">
           <span className="inv-meta-key">Customers</span>
-          <span className="inv-meta-val">38 active · 12 ordered yet</span>
-        </div>
-        <div className="inv-meta-pill">
-          <span className="inv-meta-key">Cutoff</span>
-          <span className="inv-meta-val">Tue 6:00pm · 28h left</span>
+          <span className="inv-meta-val">38 active · 12 ordered</span>
         </div>
       </div>
 

--- a/src/actions/deactivate-customer.ts
+++ b/src/actions/deactivate-customer.ts
@@ -11,5 +11,6 @@ export async function deactivateCustomer(id: string): Promise<{ error: string | 
     .eq("id", id);
   if (error) return { error: error.message };
   revalidatePath("/admin/customers");
+  revalidatePath("/admin/inventory");
   return { error: null };
 }

--- a/src/actions/save-customer.ts
+++ b/src/actions/save-customer.ts
@@ -61,6 +61,7 @@ export async function saveCustomer(input: CustomerInput): Promise<SaveCustomerRe
       .eq("id", input.id);
     if (error) return { error: error.message };
     revalidatePath("/admin/customers");
+    revalidatePath("/admin/inventory");
     return { error: null, customerId: input.id };
   }
 
@@ -72,6 +73,7 @@ export async function saveCustomer(input: CustomerInput): Promise<SaveCustomerRe
       .single();
     if (!error) {
       revalidatePath("/admin/customers");
+      revalidatePath("/admin/inventory");
       return { error: null, customerId: data.id };
     }
     // 23505 = unique_violation in Postgres

--- a/src/actions/toggle-subscribed.ts
+++ b/src/actions/toggle-subscribed.ts
@@ -14,5 +14,6 @@ export async function toggleSubscribed(
     .eq("id", id);
   if (error) return { error: error.message };
   revalidatePath("/admin/customers");
+  revalidatePath("/admin/inventory");
   return { error: null };
 }

--- a/src/app/(admin)/admin/inventory/page.tsx
+++ b/src/app/(admin)/admin/inventory/page.tsx
@@ -33,27 +33,34 @@ export default async function InventoryPage() {
       .eq("week_of", weekOf),
   ]);
 
-  if (productsRes.error || unitsRes.error) {
+  // Every query is load-bearing for the pills / table — failing silently on
+  // schedule or counts would render a plausible-but-wrong "Closed · 0 active"
+  // state. Short-circuit on any error so Annabel sees a loud failure instead.
+  const firstError =
+    productsRes.error ??
+    unitsRes.error ??
+    scheduleRes.error ??
+    activeCustomersRes.error ??
+    weekOrdersRes.error;
+  if (firstError || !scheduleRes.data) {
     return (
       <main style={{ padding: "28px 32px", maxWidth: 1200 }}>
         <h1 className="page-title">Inventory</h1>
         <p style={{ color: "var(--rose-600)", marginTop: 16 }}>
-          {productsRes.error?.message ?? unitsRes.error?.message}
+          {firstError?.message ?? "ordering_schedule singleton row missing"}
         </p>
       </main>
     );
   }
 
   const scheduleRow = scheduleRes.data;
-  const schedule: ScheduleSummary = scheduleRow
-    ? {
-        isOpen: scheduleRow.is_open,
-        openDay: scheduleRow.weekly_open_day,
-        openTime: scheduleRow.weekly_open_time,
-        closeDay: scheduleRow.weekly_close_day,
-        closeTime: scheduleRow.weekly_close_time,
-      }
-    : { isOpen: false, openDay: null, openTime: null, closeDay: null, closeTime: null };
+  const schedule: ScheduleSummary = {
+    isOpen: scheduleRow.is_open,
+    openDay: scheduleRow.weekly_open_day,
+    openTime: scheduleRow.weekly_open_time,
+    closeDay: scheduleRow.weekly_close_day,
+    closeTime: scheduleRow.weekly_close_time,
+  };
 
   const customerStats: CustomerStats = {
     active: activeCustomersRes.count ?? 0,

--- a/src/app/(admin)/admin/inventory/page.tsx
+++ b/src/app/(admin)/admin/inventory/page.tsx
@@ -7,7 +7,7 @@ import { weekOfLabel, weekOfMondayNY } from "@/lib/week";
 export default async function InventoryPage() {
   const supabase = await createClient();
   const weekOf = weekOfMondayNY();
-  const [productsRes, unitsRes, scheduleRes, activeCustomersRes, weekOrdersRes] = await Promise.all([
+  const [productsRes, unitsRes, scheduleRes, subscribedCustomersRes, weekOrdersRes] = await Promise.all([
     supabase
       .from("products")
       .select("*")
@@ -26,7 +26,8 @@ export default async function InventoryPage() {
     supabase
       .from("customers")
       .select("id", { count: "exact", head: true })
-      .eq("is_active", true),
+      .eq("is_active", true)
+      .eq("send_weekly_link", true),
     supabase
       .from("orders")
       .select("customer_id", { count: "exact", head: true })
@@ -40,7 +41,7 @@ export default async function InventoryPage() {
     productsRes.error ??
     unitsRes.error ??
     scheduleRes.error ??
-    activeCustomersRes.error ??
+    subscribedCustomersRes.error ??
     weekOrdersRes.error;
   if (firstError || !scheduleRes.data) {
     return (
@@ -63,7 +64,7 @@ export default async function InventoryPage() {
   };
 
   const customerStats: CustomerStats = {
-    active: activeCustomersRes.count ?? 0,
+    subscribed: subscribedCustomersRes.count ?? 0,
     orderedThisWeek: weekOrdersRes.count ?? 0,
   };
 

--- a/src/app/(admin)/admin/inventory/page.tsx
+++ b/src/app/(admin)/admin/inventory/page.tsx
@@ -1,12 +1,13 @@
 import { createClient } from "@/lib/supabase/server";
-import { InventoryEditor } from "@/components/admin/inventory-editor";
+import { InventoryEditor, type ScheduleSummary, type CustomerStats } from "@/components/admin/inventory-editor";
 import type { InventoryRowState } from "@/components/admin/inventory-row";
 import type { ProductUnitState } from "@/components/admin/units-drawer";
-import { weekOfLabel } from "@/lib/week";
+import { weekOfLabel, weekOfMondayNY } from "@/lib/week";
 
 export default async function InventoryPage() {
   const supabase = await createClient();
-  const [productsRes, unitsRes] = await Promise.all([
+  const weekOf = weekOfMondayNY();
+  const [productsRes, unitsRes, scheduleRes, activeCustomersRes, weekOrdersRes] = await Promise.all([
     supabase
       .from("products")
       .select("*")
@@ -17,6 +18,19 @@ export default async function InventoryPage() {
       .select("id, product_id, label, conversion_to_base, unit_price_cents, is_active, sort_order")
       .order("sort_order", { ascending: true, nullsFirst: false })
       .order("id"),
+    supabase
+      .from("ordering_schedule")
+      .select("is_open, weekly_open_day, weekly_open_time, weekly_close_day, weekly_close_time")
+      .eq("is_singleton", true)
+      .single(),
+    supabase
+      .from("customers")
+      .select("id", { count: "exact", head: true })
+      .eq("is_active", true),
+    supabase
+      .from("orders")
+      .select("customer_id", { count: "exact", head: true })
+      .eq("week_of", weekOf),
   ]);
 
   if (productsRes.error || unitsRes.error) {
@@ -29,6 +43,22 @@ export default async function InventoryPage() {
       </main>
     );
   }
+
+  const scheduleRow = scheduleRes.data;
+  const schedule: ScheduleSummary = scheduleRow
+    ? {
+        isOpen: scheduleRow.is_open,
+        openDay: scheduleRow.weekly_open_day,
+        openTime: scheduleRow.weekly_open_time,
+        closeDay: scheduleRow.weekly_close_day,
+        closeTime: scheduleRow.weekly_close_time,
+      }
+    : { isOpen: false, openDay: null, openTime: null, closeDay: null, closeTime: null };
+
+  const customerStats: CustomerStats = {
+    active: activeCustomersRes.count ?? 0,
+    orderedThisWeek: weekOrdersRes.count ?? 0,
+  };
 
   const unitsByProductId: Record<string, ProductUnitState[]> = {};
   for (const u of unitsRes.data ?? []) {
@@ -60,6 +90,8 @@ export default async function InventoryPage() {
         initialRows={initialRows}
         initialUnits={unitsByProductId}
         weekLabel={weekOfLabel()}
+        schedule={schedule}
+        customerStats={customerStats}
       />
     </main>
   );

--- a/src/components/admin/SettingsScheduleCard.tsx
+++ b/src/components/admin/SettingsScheduleCard.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { saveSchedule } from "@/actions/save-schedule";
 import { toggleOrdering, type ToggleOrderingAction } from "@/actions/toggle-ordering";
+import { DAYS, formatTime } from "@/lib/schedule-format";
 
 type ScheduleRow = {
   is_open: boolean;
@@ -12,15 +13,6 @@ type ScheduleRow = {
   weekly_close_day: number | null;
   weekly_close_time: string | null;
 };
-
-const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-
-function formatTime(t: string): string {
-  const [h, m] = t.split(":").map(Number);
-  const ampm = h >= 12 ? "pm" : "am";
-  const h12 = h % 12 || 12;
-  return m === 0 ? `${h12}${ampm}` : `${h12}:${String(m).padStart(2, "0")}${ampm}`;
-}
 
 export function SettingsScheduleCard({ schedule }: { schedule: ScheduleRow }) {
   const hasWeekly =

--- a/src/components/admin/inventory-editor.tsx
+++ b/src/components/admin/inventory-editor.tsx
@@ -22,7 +22,7 @@ export type ScheduleSummary = {
 };
 
 export type CustomerStats = {
-  active: number;
+  subscribed: number;
   orderedThisWeek: number;
 };
 
@@ -200,7 +200,7 @@ export function InventoryEditor({ initialRows, initialUnits, weekLabel, schedule
           <StatusDot open={scheduleDescription.open} /> {scheduleDescription.label}
         </MetaPill>
         <MetaPill label="Customers">
-          {customerStats.active} active · {customerStats.orderedThisWeek} ordered
+          {customerStats.subscribed} subscribed · {customerStats.orderedThisWeek} ordered
         </MetaPill>
       </MetaRow>
 

--- a/src/components/admin/inventory-editor.tsx
+++ b/src/components/admin/inventory-editor.tsx
@@ -11,19 +11,47 @@ import { InventoryRow, type InventoryRowState } from "@/components/admin/invento
 import { PrepopulateButton } from "@/components/admin/prepopulate-button";
 import { UnitsDrawer, type ProductUnitState } from "@/components/admin/units-drawer";
 import { saveInventory } from "@/actions/save-inventory";
+import { formatTime, shortDay } from "@/lib/schedule-format";
+
+export type ScheduleSummary = {
+  isOpen: boolean;
+  openDay: number | null;
+  openTime: string | null;
+  closeDay: number | null;
+  closeTime: string | null;
+};
+
+export type CustomerStats = {
+  active: number;
+  orderedThisWeek: number;
+};
 
 type Props = {
   initialRows: InventoryRowState[];
   initialUnits: Record<string, ProductUnitState[]>;
   weekLabel: string;
+  schedule: ScheduleSummary;
+  customerStats: CustomerStats;
 };
+
+function describeSchedule(s: ScheduleSummary): { open: boolean; label: string } {
+  const hasWeekly =
+    s.openDay != null && s.openTime != null && s.closeDay != null && s.closeTime != null;
+  if (!s.isOpen) return { open: false, label: "Closed" };
+  if (!hasWeekly) return { open: true, label: "Open · manual" };
+  return {
+    open: true,
+    label: `Open · ${shortDay(s.openDay!)} ${formatTime(s.openTime!)} – ${shortDay(s.closeDay!)} ${formatTime(s.closeTime!)}`,
+  };
+}
 
 let nextLocalId = 1;
 function newLocalId(): string {
   return `new-${Date.now()}-${nextLocalId++}`;
 }
 
-export function InventoryEditor({ initialRows, initialUnits, weekLabel }: Props) {
+export function InventoryEditor({ initialRows, initialUnits, weekLabel, schedule, customerStats }: Props) {
+  const scheduleDescription = describeSchedule(schedule);
   const router = useRouter();
   const [rows, setRows] = useState<InventoryRowState[]>(initialRows);
   const [baseline, setBaseline] = useState<InventoryRowState[]>(initialRows);
@@ -169,10 +197,11 @@ export function InventoryEditor({ initialRows, initialUnits, weekLabel }: Props)
 
       <MetaRow>
         <MetaPill label="Open for orders">
-          <StatusDot open /> Sun 8am – Tue 6pm
+          <StatusDot open={scheduleDescription.open} /> {scheduleDescription.label}
         </MetaPill>
-        <MetaPill label="Customers">38 active · 12 ordered yet</MetaPill>
-        <MetaPill label="Cutoff">Tue 6:00pm · 28h left</MetaPill>
+        <MetaPill label="Customers">
+          {customerStats.active} active · {customerStats.orderedThisWeek} ordered
+        </MetaPill>
       </MetaRow>
 
       {error && (

--- a/src/lib/schedule-format.ts
+++ b/src/lib/schedule-format.ts
@@ -1,0 +1,22 @@
+export const DAYS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+const SHORT_DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+export function formatTime(t: string): string {
+  const [h, m] = t.split(":").map(Number);
+  const ampm = h >= 12 ? "pm" : "am";
+  const h12 = h % 12 || 12;
+  return m === 0 ? `${h12}${ampm}` : `${h12}:${String(m).padStart(2, "0")}${ampm}`;
+}
+
+export function shortDay(d: number): string {
+  return SHORT_DAYS[d] ?? "";
+}

--- a/tests/admin-inventory.spec.ts
+++ b/tests/admin-inventory.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
-import { ADMIN_STORAGE_STATE, TEST_PRODUCTS } from "./helpers";
+import { ADMIN_STORAGE_STATE, TEST_PRODUCTS, setOrderingSchedule } from "./helpers";
 
 function rowByName(page: Page, name: string) {
   return page.locator(`tr[data-row-name="${name}"]`);
@@ -24,7 +24,8 @@ test.describe("admin inventory", () => {
     await expect(page.locator(".page-head").getByText(/week of/i)).toBeVisible();
     await expect(page.getByText(/this week's list/i)).toBeVisible();
     await expect(page.locator(".meta-row").getByText("Open for orders")).toBeVisible();
-    await expect(page.locator(".meta-row").getByText("Cutoff")).toBeVisible();
+    await expect(page.locator(".meta-row").getByText("Customers")).toBeVisible();
+    await expect(page.locator(".meta-row").getByText(/cutoff/i)).toHaveCount(0);
     await expect(page.getByRole("table")).toBeVisible();
     await expect(rowByName(page, TEST_PRODUCTS.kale.name)).toBeVisible();
     await expect(rowByName(page, TEST_PRODUCTS.eggs.name)).toBeVisible();
@@ -141,5 +142,62 @@ test.describe("admin inventory", () => {
 
     await page.reload();
     await expect(rowByName(page, "Test Carrots")).toHaveCount(0);
+  });
+});
+
+test.describe("admin inventory — open-for-orders meta pill", () => {
+  test.use({ storageState: ADMIN_STORAGE_STATE });
+
+  // Restore the singleton row to the post-seed default — is_open=true with
+  // weekly fields null — so other specs (admin-settings, customer-closed)
+  // start from the same state they normally do. Tests below opt into a
+  // weekly schedule explicitly when they need one.
+  const DEFAULT_SCHEDULE = {
+    is_open: true,
+    weekly_open_day: null,
+    weekly_open_time: null,
+    weekly_close_day: null,
+    weekly_close_time: null,
+  };
+
+  test.afterEach(async () => {
+    await setOrderingSchedule(DEFAULT_SCHEDULE);
+  });
+
+  const pill = (page: Page) =>
+    page.locator(".meta-row .meta-pill", { hasText: "Open for orders" });
+
+  test("renders 'Open · {open} – {close}' when is_open + schedule set", async ({ page }) => {
+    await setOrderingSchedule({
+      is_open: true,
+      weekly_open_day: 0,
+      weekly_open_time: "08:00:00",
+      weekly_close_day: 2,
+      weekly_close_time: "18:00:00",
+    });
+    await page.goto("/admin/inventory");
+    await expect(pill(page)).toContainText("Open · Sun 8am – Tue 6pm");
+    await expect(pill(page).locator(".status-dot.is-open")).toBeVisible();
+  });
+
+  test("renders 'Open · manual' when is_open but no weekly schedule", async ({ page }) => {
+    await setOrderingSchedule({
+      is_open: true,
+      weekly_open_day: null,
+      weekly_open_time: null,
+      weekly_close_day: null,
+      weekly_close_time: null,
+    });
+    await page.goto("/admin/inventory");
+    await expect(pill(page)).toContainText("Open · manual");
+    await expect(pill(page).locator(".status-dot.is-open")).toBeVisible();
+  });
+
+  test("renders 'Closed' when is_open=false (with red dot)", async ({ page }) => {
+    await setOrderingSchedule({ is_open: false });
+    await page.goto("/admin/inventory");
+    await expect(pill(page)).toContainText("Closed");
+    await expect(pill(page).locator(".status-dot.is-open")).toHaveCount(0);
+    await expect(pill(page).locator(".status-dot")).toBeVisible();
   });
 });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -165,6 +165,20 @@ export async function setOrderingOpen(open: boolean): Promise<void> {
     .eq("is_singleton", true);
 }
 
+// Patches the singleton ordering_schedule row. Pass only the fields you want
+// to change. Used by the inventory meta-pill tests to walk all three open
+// states (closed / open manual / open via schedule).
+export async function setOrderingSchedule(patch: {
+  is_open?: boolean;
+  weekly_open_day?: number | null;
+  weekly_open_time?: string | null;
+  weekly_close_day?: number | null;
+  weekly_close_time?: string | null;
+}): Promise<void> {
+  const sb = admin();
+  await sb.from("ordering_schedule").update(patch).eq("is_singleton", true);
+}
+
 // Drops every is_available=true product to qty_available = 0 — exercises
 // DEC-031's "everything sold out" empty state. The dev DB usually contains
 // products beyond TEST_PRODUCTS (real seed data), so zeroing only the test


### PR DESCRIPTION
## Summary

`/admin/inventory` header pills are no longer hardcoded. **Open for orders** derives from `ordering_schedule` in one of three states; **Customers** shows real counts; **Cutoff** is removed.

States for the "Open for orders" pill:
- `is_open=false` → red dot · **Closed**
- `is_open=true` + no weekly schedule → green dot · **Open · manual**
- `is_open=true` + weekly schedule → green dot · **Open · Sun 8am – Tue 6pm**

## Files changed

- `design/admin-inventory.jsx` — mockup mirror (Cutoff pill removed, Open-for-orders label updated)
- `src/app/(admin)/admin/inventory/page.tsx` — fan-out to `ordering_schedule` + active-customer count + week-orders count; single error gate covering all five queries (and missing singleton row)
- `src/components/admin/SettingsScheduleCard.tsx` — switched to shared `DAYS` / `formatTime` import
- `src/components/admin/inventory-editor.tsx` — accepts `schedule` + `customerStats` props; new `describeSchedule()` resolves the 3-state label; removed Cutoff pill
- `src/lib/schedule-format.ts` — new shared formatters (`DAYS`, `formatTime`, `shortDay`)
- `tests/admin-inventory.spec.ts` — new describe block with 3 pill-state cases; updated existing assertion that Cutoff pill is absent
- `tests/helpers.ts` — new `setOrderingSchedule()` helper

## Code review

Findings from `@code-review` (medium effort), both addressed in commit `17a22f7`:
- **bug** — Only `productsRes.error || unitsRes.error` were gated; schedule / customer / week-orders errors were silently swallowed and rendered a plausible-but-wrong "Closed · 0 active" state. Now all five `Promise.all` responses flow through one short-circuit.
- **bug** — `.single()` on a missing `ordering_schedule` singleton would also fall through to "Closed". Now treated as a loud error.

Non-blocking deferrals: `describeSchedule()` duplicates the *gating* (not the labels) of `SettingsScheduleCard.stateInfo` — extract if a third consumer appears. The `afterEach` schedule restore could be moved into `resetTestData()` for cross-run resilience; left as test-local for now (workers=1, no in-run race).

## Test plan

- [ ] `npx playwright test tests/admin-inventory.spec.ts --project=desktop` — all 8 desktop cases (1 mobile-only skipped) pass locally
- [ ] `npx playwright test tests/admin-settings.spec.ts --project=desktop` — 5/5 pass (sanity-check the schedule-format extraction didn't break the settings page)
- [ ] On the preview deployment (`preview.baybranchfarm.com`) visit `/admin/inventory` and confirm:
  - Only two pills render (Open-for-orders + Customers; no Cutoff)
  - Pill label matches the current `ordering_schedule` row state
  - Customer counts match `/admin/customers` (active) and `/admin/send` (ordered-this-week)
- [ ] In `/admin/settings`, flip schedule on/off and toggle `is_open`; reload `/admin/inventory` and confirm the pill follows