### PR TITLE
Consistent "items" count across customer, admin, Telegram (closes #159)

### DIFF
--- a/design/admin-orders.jsx
+++ b/design/admin-orders.jsx
@@ -157,7 +157,7 @@ function OrdersPage() {
                       <div className="ord-when">{o.placed}</div>
                     </td>
                     <td className="col-o-items">
-                      <div className="ord-items-count"><strong>{o.items.length}</strong> items</div>
+                      <div className="ord-items-count"><strong>{o.items.reduce((sum, i) => sum + i.qty, 0)}</strong> items</div>
                       <div className="ord-items-prev">{itemsPreview}</div>
                     </td>
                     <td className="col-o-ful">

--- a/design/customer-preview.jsx
+++ b/design/customer-preview.jsx
@@ -12,7 +12,7 @@ function CustomerPreview() {
     { id: "flowers", name: "Mixed bouquet",    unit: "stem",   price: 12.00, avail: 6 },
   ];
   const total = items.reduce((s, i) => s + (qty[i.id] || 0) * i.price, 0);
-  const lineCount = items.reduce((s, i) => s + (qty[i.id] > 0 ? 1 : 0), 0);
+  const itemCount = items.reduce((s, i) => s + (qty[i.id] || 0), 0);
 
   const setN = (id, n) => setQty(q => ({ ...q, [id]: Math.max(0, n) }));
 
@@ -61,7 +61,7 @@ function CustomerPreview() {
         padding: "14px 18px 16px", background: "var(--paper)", borderTop: "1px solid var(--ink-200)"
       }}>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 10 }}>
-          <div style={{ fontSize: "0.82rem", color: "var(--ink-500)" }}>{lineCount} item{lineCount !== 1 ? "s" : ""}</div>
+          <div style={{ fontSize: "0.82rem", color: "var(--ink-500)" }}>{itemCount} item{itemCount !== 1 ? "s" : ""}</div>
           <div style={{ fontFamily: "var(--serif)", fontSize: "1.5rem", fontWeight: 600 }}>${total.toFixed(2)}</div>
         </div>
         <button className="btn btn-primary" style={{ width: "100%" }}>Place order</button>

--- a/design/order-page.css
+++ b/design/order-page.css
@@ -59,11 +59,7 @@
 
 /* ── Inventory ──────────────────────────────────────────── */
 .inv { margin-bottom: 36px; }
-.inv-head {
-  display: flex; justify-content: space-between; align-items: baseline;
-  margin-bottom: 10px;
-}
-.inv-count { font-size: 0.82rem; color: var(--ink-500); }
+.inv-head { margin-bottom: 10px; }
 
 .item-list {
   background: var(--paper);

--- a/design/order-page.jsx
+++ b/design/order-page.jsx
@@ -237,7 +237,6 @@ function OrderPage({ tweaks }) {
             <section className="inv">
               <div className="inv-head">
                 <Eyebrow>availability</Eyebrow>
-                <span className="inv-count">{inventory.filter((i) => i.avail > 0).length} items</span>
               </div>
               <div className="item-list">
                 {inventory.map((i) =>
@@ -352,7 +351,7 @@ function OrderPage({ tweaks }) {
             <section className="submit-block" style={{ fontFamily: "-apple-system" }}>
               <div className="submit-summary">
                 <div className="summary-line">
-                  <span className="summary-label">{lineCount} item{lineCount !== 1 ? "s" : ""}</span>
+                  <span className="summary-label">{itemCount} item{itemCount !== 1 ? "s" : ""}</span>
                   <span className="summary-total mono">${subtotal.toFixed(2)}</span>
                 </div>
                 <div className="summary-sub">

--- a/src/actions/place-order.ts
+++ b/src/actions/place-order.ts
@@ -8,6 +8,7 @@ import {
   lookupCustomerByToken,
 } from "@/lib/customer/session";
 import { sendAdminOrderAlert } from "@/lib/notifications/admin-telegram";
+import { totalItemCount } from "@/lib/order-items";
 import type { Json } from "@/lib/supabase/types";
 import { weekOfMondayNY } from "@/lib/week";
 
@@ -75,7 +76,7 @@ export async function placeOrder(
   await sendAdminOrderAlert({
     customerName: customer.name,
     weekOf: weekOfMondayNY(),
-    lineItemCount: payload.items.length,
+    itemCount: totalItemCount(payload.items),
     totalCents: total,
     adminOrdersUrl: `${adminBaseUrl()}/admin/orders`,
   });

--- a/src/components/admin/order-row.tsx
+++ b/src/components/admin/order-row.tsx
@@ -5,6 +5,7 @@ import { useState, useTransition, Fragment } from "react";
 import { advanceOrderStatus } from "@/actions/advance-order-status";
 import { OrderDetail } from "@/components/admin/order-detail";
 import type { OrderRow as OrderRowData, OrderStatus } from "@/lib/admin/orders-queries";
+import { totalItemCount } from "@/lib/order-items";
 
 type Props = {
   order: OrderRowData;
@@ -136,7 +137,7 @@ export function OrderRow({ order, isOpen, onToggle }: Props) {
         </td>
         <td className="col-o-items">
           <div className="ord-items-count">
-            <strong>{view.items.length}</strong> items
+            <strong>{totalItemCount(view.items)}</strong> items
           </div>
           <div className="ord-items-prev">{itemsPreview(view.items)}</div>
         </td>

--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -329,9 +329,6 @@ export function OrderForm({
             <section className="inv">
               <div className="inv-head">
                 <div className="eyebrow">availability</div>
-                <span className="inv-count">
-                  {products.filter((p) => p.qty_available > 0).length} items
-                </span>
               </div>
               <div className="item-list">
                 {products.map((p) => {
@@ -526,7 +523,7 @@ export function OrderForm({
               <div className="submit-summary">
                 <div className="summary-line">
                   <span className="summary-label">
-                    {lineCount} item{lineCount !== 1 ? "s" : ""}
+                    {itemCount} item{itemCount !== 1 ? "s" : ""}
                   </span>
                   <span className="summary-total mono">
                     ${formatPrice(subtotalCents)}

--- a/src/lib/notifications/admin-alert-template.ts
+++ b/src/lib/notifications/admin-alert-template.ts
@@ -5,7 +5,7 @@
 export type AdminOrderAlertInput = {
   customerName: string;
   weekOf: string;
-  lineItemCount: number;
+  itemCount: number;
   totalCents: number;
   adminOrdersUrl: string;
 };
@@ -22,12 +22,12 @@ function formatDollars(cents: number): string {
 export function adminOrderAlertText({
   customerName,
   weekOf,
-  lineItemCount,
+  itemCount,
   totalCents,
   adminOrdersUrl,
 }: AdminOrderAlertInput): string {
   const total = formatDollars(totalCents);
-  const itemsLabel = lineItemCount === 1 ? "1 line" : `${lineItemCount} lines`;
+  const itemsLabel = itemCount === 1 ? "1 item" : `${itemCount} items`;
   return [
     `New order — ${customerName}, ${total}`,
     "",

--- a/src/lib/notifications/admin-telegram.ts
+++ b/src/lib/notifications/admin-telegram.ts
@@ -20,7 +20,7 @@ export async function sendAdminOrderAlert(input: AdminOrderAlertInput): Promise<
     // don't spam Vercel logs on every order. Real misconfiguration on a
     // configured env surfaces via the .ok check below.
     console.debug(
-      `[admin-alert] skipped (not configured) — ${input.customerName}, ${input.lineItemCount} items`,
+      `[admin-alert] skipped (not configured) — ${input.customerName}, ${input.itemCount} items`,
     );
     return;
   }

--- a/src/lib/order-items.ts
+++ b/src/lib/order-items.ts
@@ -3,12 +3,14 @@
 // the Telegram order-arrival alert — every place uses this so the number
 // matches everywhere (issue #159).
 //
-// `qty` is `numeric(10,2)` in Postgres and arrives as a string on
-// joined reads in some Supabase shapes; `Number(...)` normalises that.
-// Fractional values are summed verbatim (1.5 lb basil + 2 lettuce = 3.5)
-// — display layer formats however it likes.
+// `qty` is `numeric(10,2)` in Postgres and arrives as a string on some
+// joined Supabase shapes; `Number(...)` normalises that. `|| 0` guards
+// against a non-numeric escape (corrupt row, future caller bypassing
+// types) so we never render literal "NaN items" to Annabel or the
+// customer. Fractional values are rounded to 2dp to avoid the classic
+// float-precision render (1.1 + 2.2 → "3.3000000000000003 items").
 export function totalItemCount(items: ReadonlyArray<{ qty: number | string }>): number {
   let sum = 0;
-  for (const it of items) sum += Number(it.qty);
-  return sum;
+  for (const it of items) sum += Number(it.qty) || 0;
+  return Math.round(sum * 100) / 100;
 }

--- a/src/lib/order-items.ts
+++ b/src/lib/order-items.ts
@@ -1,0 +1,14 @@
+// Total items in an order = sum of qty across every line. The "items"
+// label is shown verbatim on the customer form, admin orders list, and
+// the Telegram order-arrival alert — every place uses this so the number
+// matches everywhere (issue #159).
+//
+// `qty` is `numeric(10,2)` in Postgres and arrives as a string on
+// joined reads in some Supabase shapes; `Number(...)` normalises that.
+// Fractional values are summed verbatim (1.5 lb basil + 2 lettuce = 3.5)
+// — display layer formats however it likes.
+export function totalItemCount(items: ReadonlyArray<{ qty: number | string }>): number {
+  let sum = 0;
+  for (const it of items) sum += Number(it.qty);
+  return sum;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1046,11 +1046,7 @@
 }
 
 .inv { margin-bottom: 36px; }
-.inv-head {
-  display: flex; justify-content: space-between; align-items: baseline;
-  margin-bottom: 10px;
-}
-.inv-count { font-size: 0.82rem; color: var(--ink-500); }
+.inv-head { margin-bottom: 10px; }
 
 .item-list {
   background: var(--paper);

--- a/tests/admin-alert-template.spec.ts
+++ b/tests/admin-alert-template.spec.ts
@@ -4,14 +4,17 @@ import { adminOrderAlertText } from "@/lib/notifications/admin-alert-template";
 
 // Pure-function unit tests for the Telegram message body sent to the operator
 // when a customer submits an order (Phase 4.3, DEC-033).
+//
+// #159: items count = sum of qty across lines (5 lb basil + 10 lettuce = 15),
+// labelled "items" not "lines".
 
 test.describe("adminOrderAlertText", () => {
-  test("single-line-item order — singular wording", () => {
+  test("single-item order — singular wording", () => {
     expect(
       adminOrderAlertText({
         customerName: "Hannah",
         weekOf: "2026-05-11",
-        lineItemCount: 1,
+        itemCount: 1,
         totalCents: 3000,
         adminOrdersUrl: "https://order.baybranchfarm.com/admin/orders",
       }),
@@ -21,7 +24,7 @@ test.describe("adminOrderAlertText", () => {
         "",
         "Customer: Hannah",
         "Week of: 2026-05-11",
-        "Items: 1 line",
+        "Items: 1 item",
         "Total: $30.00",
         "",
         "https://order.baybranchfarm.com/admin/orders",
@@ -29,15 +32,15 @@ test.describe("adminOrderAlertText", () => {
     );
   });
 
-  test("multi-line-item order — plural wording", () => {
+  test("multi-item order — plural wording", () => {
     const body = adminOrderAlertText({
       customerName: "Hannah",
       weekOf: "2026-05-11",
-      lineItemCount: 5,
+      itemCount: 15,
       totalCents: 4320,
       adminOrdersUrl: "https://order.baybranchfarm.com/admin/orders",
     });
-    expect(body).toContain("Items: 5 lines");
+    expect(body).toContain("Items: 15 items");
     expect(body).toContain("Total: $43.20");
     expect(body).toContain("New order — Hannah, $43.20");
   });
@@ -46,7 +49,7 @@ test.describe("adminOrderAlertText", () => {
     const body = adminOrderAlertText({
       customerName: "Tom",
       weekOf: "2026-05-11",
-      lineItemCount: 2,
+      itemCount: 2,
       totalCents: 305,
       adminOrdersUrl: "x",
     });
@@ -57,7 +60,7 @@ test.describe("adminOrderAlertText", () => {
     const body = adminOrderAlertText({
       customerName: "Tom",
       weekOf: "2026-05-11",
-      lineItemCount: 2,
+      itemCount: 2,
       totalCents: 1000,
       adminOrdersUrl: "x",
     });
@@ -68,7 +71,7 @@ test.describe("adminOrderAlertText", () => {
     const body = adminOrderAlertText({
       customerName: "Big Order Co",
       weekOf: "2026-05-11",
-      lineItemCount: 25,
+      itemCount: 25,
       totalCents: 123456,
       adminOrdersUrl: "x",
     });
@@ -79,7 +82,7 @@ test.describe("adminOrderAlertText", () => {
     const body = adminOrderAlertText({
       customerName: "Hannah",
       weekOf: "2026-05-11",
-      lineItemCount: 1,
+      itemCount: 1,
       totalCents: 100,
       adminOrdersUrl: "https://order.baybranchfarm.com/admin/orders",
     });

--- a/tests/admin-orders.spec.ts
+++ b/tests/admin-orders.spec.ts
@@ -42,7 +42,8 @@ test.describe("admin orders list", () => {
     await expect(row).toHaveCount(1);
     await expect(row.locator(".ord-cust-name")).toHaveText(TEST_CUSTOMERS.farmStand.name);
     await expect(row.locator(".ord-total")).toHaveText("$12.00");
-    await expect(row.locator(".ord-items-count")).toContainText("2");
+    // #159: items count = sum of qty (2 × kale + 1 × eggs = 3), not line count.
+    await expect(row.locator(".ord-items-count")).toContainText("3");
     await expect(row.locator(".chip-ful")).toHaveText("Pickup");
   });
 


### PR DESCRIPTION
## Summary

Every "items" label across the app now shows the same value: **sum of qty across the order's lines**. 5 lb basil + 10 bags lettuce = **15 items** — not "2 lines".

Annabel flagged that the labels were inconsistent: customer sticky bar said one thing, customer submit summary said another, admin orders list said something else, Telegram alert said "X lines", and the order form header carried a static count that never updated.

## Files changed

- `design/admin-orders.jsx`, `design/customer-preview.jsx`, `design/order-page.{jsx,css}` — mockup mirrors
- `src/actions/place-order.ts` — wraps Telegram payload with `totalItemCount(payload.items)`
- `src/components/admin/order-row.tsx` — items column uses the helper
- `src/components/customer/OrderForm.tsx` — submit summary uses `itemCount` (already memoized); availability-header static count removed
- `src/lib/notifications/admin-alert-template.ts` — field renamed `lineItemCount` → `itemCount`; body label "5 lines" → "5 items" / "1 item"
- `src/lib/notifications/admin-telegram.ts` — debug log updated
- `src/lib/order-items.ts` — new shared `totalItemCount(items)` helper. `Number(it.qty) || 0` guards a non-numeric escape, `Math.round(× 100) / 100` keeps fractional sums readable
- `src/styles/app.css` — dropped now-orphan `.inv-count` rule
- `tests/admin-alert-template.spec.ts`, `tests/admin-orders.spec.ts` — assertion updates

## Code review

Findings from `@code-review` (medium effort), all addressed in commit \`fbef714\`:
- **consistency** — `design/customer-preview.jsx` still showed the old distinct-line count under an "items" label; now uses `itemCount`.
- **cleanup** — `Number(it.qty)` could yield NaN propagation; guarded with `|| 0`.
- **cleanup** — fractional sums rendered with full float precision (1.1 + 2.2 → "3.3000000000000003"); helper now rounds to 2dp.
- **cleanup** — `.inv-count` CSS rule orphaned by the header removal; dropped.

## Test plan

- [ ] `npx playwright test tests/admin-orders.spec.ts tests/admin-alert-template.spec.ts tests/customer-order-form.spec.ts --project=desktop` — all pass locally (19/19, 2 mobile-only skipped)
- [ ] `npx playwright test tests/customer-place-order.spec.ts tests/orders-flow.spec.ts --project=desktop` — confirms the Telegram alert payload swap didn't regress place-order (13/13 locally)
- [ ] On preview: `/c/[token]` — verify the static "X items" header is gone above the inventory list, and that the submit-summary + sticky-bar item counts match each other and update as you change qty
- [ ] On preview: `/admin/orders` — verify the items column shows total qty (e.g. an order with `kale × 2 + eggs × 1` reads "3", not "2")
- [ ] If Telegram is wired up on this preview, place a test order and confirm the alert reads "X items" (not "X lines")

closes #159