### PR TITLE
Drag-to-reorder inventory rows (closes #143)

### DIFF
--- a/design/admin-inventory.css
+++ b/design/admin-inventory.css
@@ -83,6 +83,12 @@
 .inv-table tbody tr.inv-row.is-unavail td { background: var(--ink-100); }
 .inv-table tbody tr.inv-row.is-unavail .inv-cell { color: var(--ink-500); }
 
+/* Drag-to-reorder (#143) */
+.inv-table tbody tr.inv-row.is-dragging td { opacity: 0.4; }
+.inv-table tbody tr.inv-row.is-drop-target td {
+  box-shadow: inset 0 2px 0 0 var(--leaf-600);
+}
+
 /* columns */
 .col-handle  { width: 28px; padding: 0 0 0 6px !important; }
 .col-name    { width: 28%; min-width: 220px; }

--- a/design/admin-inventory.jsx
+++ b/design/admin-inventory.jsx
@@ -52,6 +52,22 @@ function InventoryPage() {
   const [rows, setRows] = useState(SEED_ROWS);
   const [originalRows] = useState(SEED_ROWS);
   const [unitsOpenFor, setUnitsOpenFor] = useState(null); // product id, or null
+  const [draggingId, setDraggingId] = useState(null);
+  const [dropTargetId, setDropTargetId] = useState(null);
+
+  const reorderRows = (fromId, toId) => {
+    if (fromId === toId) return;
+    setRows(rs => {
+      const fromIdx = rs.findIndex(r => r.id === fromId);
+      if (fromIdx === -1) return rs;
+      const next = rs.slice();
+      const [moved] = next.splice(fromIdx, 1);
+      const insertAt = next.findIndex(r => r.id === toId);
+      if (insertAt === -1) return rs;
+      next.splice(insertAt, 0, moved);
+      return next;
+    });
+  };
 
   const dirty = useMemo(
     () => JSON.stringify(rows) !== JSON.stringify(originalRows),
@@ -149,6 +165,21 @@ function InventoryPage() {
                 onUpdate={(patch) => update(row.id, patch)}
                 onRemove={() => remove(row.id)}
                 onOpenUnits={() => setUnitsOpenFor(row.id)}
+                isDragging={draggingId === row.id}
+                isDropTarget={dropTargetId === row.id && draggingId !== row.id}
+                onDragStart={() => setDraggingId(row.id)}
+                onDragOverRow={() => {
+                  if (draggingId && draggingId !== row.id) setDropTargetId(row.id);
+                }}
+                onDropRow={() => {
+                  if (draggingId) reorderRows(draggingId, row.id);
+                  setDraggingId(null);
+                  setDropTargetId(null);
+                }}
+                onDragEnd={() => {
+                  setDraggingId(null);
+                  setDropTargetId(null);
+                }}
               />
             ))}
           </tbody>
@@ -184,15 +215,55 @@ function InventoryPage() {
   );
 }
 
-function InventoryRow({ row, index, onUpdate, onRemove, onOpenUnits }) {
+function InventoryRow({
+  row, index, onUpdate, onRemove, onOpenUnits,
+  isDragging, isDropTarget,
+  onDragStart, onDragOverRow, onDropRow, onDragEnd,
+}) {
   const [descOpen, setDescOpen] = useState(false);
+  const [dragArmed, setDragArmed] = useState(false);
   const extras = (row.units || []).filter(u => !u.base);
   const inactiveCount = extras.filter(u => !u.active).length;
+  const rowClass =
+    "inv-row" +
+    (!row.available ? " is-unavail" : "") +
+    (isDragging ? " is-dragging" : "") +
+    (isDropTarget ? " is-drop-target" : "");
   return (
     <>
-      <tr className={"inv-row" + (!row.available ? " is-unavail" : "")}>
+      <tr
+        className={rowClass}
+        draggable={dragArmed}
+        onDragStart={(e) => {
+          e.dataTransfer.effectAllowed = "move";
+          e.dataTransfer.setData("text/plain", row.id);
+          onDragStart && onDragStart();
+        }}
+        onDragOver={(e) => {
+          if (!onDragOverRow) return;
+          e.preventDefault();
+          e.dataTransfer.dropEffect = "move";
+          onDragOverRow();
+        }}
+        onDrop={(e) => {
+          if (!onDropRow) return;
+          e.preventDefault();
+          onDropRow();
+          setDragArmed(false);
+        }}
+        onDragEnd={() => {
+          setDragArmed(false);
+          onDragEnd && onDragEnd();
+        }}
+      >
         <td className="col-handle">
-          <span className="inv-handle" title="Drag to reorder">
+          <span
+            className="inv-handle"
+            title="Drag to reorder"
+            style={{ cursor: "grab" }}
+            onMouseDown={() => setDragArmed(true)}
+            onMouseUp={() => setDragArmed(false)}
+          >
             <svg viewBox="0 0 12 18" width="10" height="14" aria-hidden="true">
               <circle cx="3" cy="3" r="1.5" fill="currentColor"/>
               <circle cx="9" cy="3" r="1.5" fill="currentColor"/>

--- a/src/components/admin/inventory-editor.tsx
+++ b/src/components/admin/inventory-editor.tsx
@@ -59,6 +59,8 @@ export function InventoryEditor({ initialRows, initialUnits, weekLabel, schedule
   const [error, setError] = useState<string | null>(null);
   const [saving, startSaving] = useTransition();
   const [unitsOpenFor, setUnitsOpenFor] = useState<string | null>(null);
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dropTargetId, setDropTargetId] = useState<string | null>(null);
 
   const baselineMap = useMemo(() => {
     const m = new Map<string, InventoryRowState>();
@@ -122,6 +124,24 @@ export function InventoryEditor({ initialRows, initialUnits, weekLabel, schedule
   function handleDiscard() {
     setRows(baseline);
     setDeletedIds([]);
+    setError(null);
+  }
+
+  // Drag-to-reorder (#143). Splice `from` to land immediately before `to`,
+  // then rewrite sort_order to (10, 20, 30, …) so the saved order matches
+  // the on-screen order. Same convention as addRow's `maxOrder + 10`.
+  function reorderRows(fromId: string, toId: string) {
+    if (fromId === toId) return;
+    setRows((rs) => {
+      const fromIdx = rs.findIndex((r) => r.id === fromId);
+      const toIdx = rs.findIndex((r) => r.id === toId);
+      if (fromIdx === -1 || toIdx === -1) return rs;
+      const next = rs.slice();
+      const [moved] = next.splice(fromIdx, 1);
+      const insertAt = next.findIndex((r) => r.id === toId);
+      next.splice(insertAt, 0, moved);
+      return next.map((r, i) => ({ ...r, sort_order: (i + 1) * 10 }));
+    });
     setError(null);
   }
 
@@ -247,6 +267,21 @@ export function InventoryEditor({ initialRows, initialUnits, weekLabel, schedule
                   onUpdate={(patch) => update(row.id, patch)}
                   onRemove={() => remove(row.id)}
                   onOpenUnits={row.isNew ? undefined : () => setUnitsOpenFor(row.id)}
+                  isDragging={draggingId === row.id}
+                  isDropTarget={dropTargetId === row.id && draggingId !== row.id}
+                  onDragStart={() => setDraggingId(row.id)}
+                  onDragOverRow={() => {
+                    if (draggingId && draggingId !== row.id) setDropTargetId(row.id);
+                  }}
+                  onDropRow={() => {
+                    if (draggingId) reorderRows(draggingId, row.id);
+                    setDraggingId(null);
+                    setDropTargetId(null);
+                  }}
+                  onDragEnd={() => {
+                    setDraggingId(null);
+                    setDropTargetId(null);
+                  }}
                 />
               );
             })}

--- a/src/components/admin/inventory-editor.tsx
+++ b/src/components/admin/inventory-editor.tsx
@@ -132,13 +132,18 @@ export function InventoryEditor({ initialRows, initialUnits, weekLabel, schedule
   // the on-screen order. Same convention as addRow's `maxOrder + 10`.
   function reorderRows(fromId: string, toId: string) {
     if (fromId === toId) return;
+    // Defensive: drop targets if dragend was dropped by the browser (rare —
+    // cross-window drops, some WebView edge cases). Without this, a row can
+    // stick at 40% opacity until the next re-render.
+    setDraggingId(null);
+    setDropTargetId(null);
     setRows((rs) => {
       const fromIdx = rs.findIndex((r) => r.id === fromId);
-      const toIdx = rs.findIndex((r) => r.id === toId);
-      if (fromIdx === -1 || toIdx === -1) return rs;
+      if (fromIdx === -1) return rs;
       const next = rs.slice();
       const [moved] = next.splice(fromIdx, 1);
       const insertAt = next.findIndex((r) => r.id === toId);
+      if (insertAt === -1) return rs;
       next.splice(insertAt, 0, moved);
       return next.map((r, i) => ({ ...r, sort_order: (i + 1) * 10 }));
     });

--- a/src/components/admin/inventory-row.tsx
+++ b/src/components/admin/inventory-row.tsx
@@ -25,6 +25,15 @@ type Props = {
   onUpdate: (patch: Partial<InventoryRowState>) => void;
   onRemove: () => void;
   onOpenUnits?: () => void;
+  // Drag-to-reorder (#143). The row is only `draggable` while the grip is
+  // armed (onMouseDown on grip → arm; onDragEnd → disarm) so clicks into
+  // fields don't accidentally start a drag.
+  isDragging?: boolean;
+  isDropTarget?: boolean;
+  onDragStart?: () => void;
+  onDragOverRow?: () => void;
+  onDropRow?: () => void;
+  onDragEnd?: () => void;
 };
 
 function priceToString(cents: number): string {
@@ -38,21 +47,63 @@ export function InventoryRow({
   onUpdate,
   onRemove,
   onOpenUnits,
+  isDragging = false,
+  isDropTarget = false,
+  onDragStart,
+  onDragOverRow,
+  onDropRow,
+  onDragEnd,
 }: Props) {
   const [descOpen, setDescOpen] = useState(false);
+  const [dragArmed, setDragArmed] = useState(false);
   const qtyClass =
     row.qty_available === 0 ? " is-zero" : row.qty_available <= 3 ? " is-low" : "";
   const extras = Math.max(0, unitsCount - 1);
 
+  const rowClass =
+    "data-row" +
+    (!row.is_available ? " is-disabled" : "") +
+    (isDragging ? " is-dragging" : "") +
+    (isDropTarget ? " is-drop-target" : "");
+
   return (
     <>
       <tr
-        className={"data-row" + (!row.is_available ? " is-disabled" : "")}
+        className={rowClass}
         data-row-id={row.id}
         data-row-name={row.name}
+        draggable={dragArmed}
+        onDragStart={(e) => {
+          // Some browsers require setData for the drag to actually start.
+          e.dataTransfer.effectAllowed = "move";
+          e.dataTransfer.setData("text/plain", row.id);
+          onDragStart?.();
+        }}
+        onDragOver={(e) => {
+          if (!onDragOverRow) return;
+          e.preventDefault();
+          e.dataTransfer.dropEffect = "move";
+          onDragOverRow();
+        }}
+        onDrop={(e) => {
+          if (!onDropRow) return;
+          e.preventDefault();
+          onDropRow();
+          setDragArmed(false);
+        }}
+        onDragEnd={() => {
+          setDragArmed(false);
+          onDragEnd?.();
+        }}
       >
         <td className="row-handle">
-          <span className="row-handle-grip" title="Drag to reorder">
+          <span
+            className="row-handle-grip"
+            title="Drag to reorder"
+            onMouseDown={() => setDragArmed(true)}
+            onMouseUp={() => setDragArmed(false)}
+            style={{ cursor: "grab" }}
+          >
             <svg viewBox="0 0 12 18" width="10" height="14" aria-hidden="true">
               <circle cx="3" cy="3" r="1.5" fill="currentColor" />
               <circle cx="9" cy="3" r="1.5" fill="currentColor" />

--- a/src/components/admin/inventory-row.tsx
+++ b/src/components/admin/inventory-row.tsx
@@ -74,7 +74,8 @@ export function InventoryRow({
         data-row-name={row.name}
         draggable={dragArmed}
         onDragStart={(e) => {
-          // Some browsers require setData for the drag to actually start.
+          // Firefox refuses to start a drag without setData; the value
+          // isn't read on drop (the editor's draggingId is source of truth).
           e.dataTransfer.effectAllowed = "move";
           e.dataTransfer.setData("text/plain", row.id);
           onDragStart?.();

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -165,6 +165,12 @@
 .data-table tbody tr.data-row.is-disabled .field-num,
 .data-table tbody tr.data-row.is-disabled .field-select { color: var(--ink-500); }
 
+/* Drag-to-reorder (#143) */
+.data-table tbody tr.data-row.is-dragging td { opacity: 0.4; }
+.data-table tbody tr.data-row.is-drop-target td {
+  box-shadow: inset 0 2px 0 0 var(--leaf-600);
+}
+
 .row-handle {
   width: 28px;
   padding: 0 0 0 6px !important;

--- a/tests/admin-inventory.spec.ts
+++ b/tests/admin-inventory.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect, type Page } from "@playwright/test";
-import { ADMIN_STORAGE_STATE, TEST_PRODUCTS, setOrderingSchedule } from "./helpers";
+import {
+  ADMIN_STORAGE_STATE,
+  TEST_PRODUCTS,
+  resetProductSortOrder,
+  setOrderingSchedule,
+} from "./helpers";
 
 function rowByName(page: Page, name: string) {
   return page.locator(`tr[data-row-name="${name}"]`);
@@ -146,43 +151,44 @@ test.describe("admin inventory", () => {
 
   // #143 — drag the grip on the left of a row to reorder. Default fixture
   // is Kale (1), Eggs (2), Honey (3); drag Honey above Kale, save, reload,
-  // and confirm the new order persists. Restores the original sort order
-  // at the end so other specs see the seeded state.
+  // and confirm the new order persists. The try/finally + admin-client
+  // reset guarantees other specs see the seeded order even if an assertion
+  // here fails mid-test (cleanup-via-drag would otherwise leak).
   test("drag-to-reorder: grip drag updates row order, persists across reload", async ({ page }) => {
-    await page.goto("/admin/inventory");
+    try {
+      await page.goto("/admin/inventory");
 
-    // Order in the DOM matches insertion order; assert the baseline first
-    // so a fixture-leak from another spec doesn't masquerade as a pass.
-    const rowOrder = async () =>
-      page.locator("tr.data-row").evaluateAll((els) =>
-        els.map((el) => (el as HTMLElement).dataset.rowName),
-      );
-    await expect.poll(rowOrder).toEqual(["Kale", "Eggs", "Honey"]);
+      const rowOrder = async () =>
+        page.locator("tr.data-row").evaluateAll((els) =>
+          els.map((el) => (el as HTMLElement).dataset.rowName),
+        );
+      // Baseline assertion guards against fixture leak from another spec.
+      await expect.poll(rowOrder).toEqual(["Kale", "Eggs", "Honey"]);
 
-    // Arm the drag on Honey's grip, then drag the row onto Kale's row.
-    // Playwright's dragTo dispatches dragstart/dragover/drop in sequence —
-    // exactly what the armed-handle pattern expects.
-    const honeyRow = rowByName(page, TEST_PRODUCTS.honey.name);
-    const kaleRow = rowByName(page, TEST_PRODUCTS.kale.name);
-    await honeyRow.locator(".row-handle-grip").dispatchEvent("mousedown");
-    await honeyRow.dragTo(kaleRow);
-    await honeyRow.dispatchEvent("dragend");
+      // Arm the drag on Honey's grip, then drag the row onto Kale's row.
+      // Playwright's dragTo dispatches dragstart/dragover/drop in sequence —
+      // exactly what the armed-handle pattern expects.
+      const honeyRow = rowByName(page, TEST_PRODUCTS.honey.name);
+      const kaleRow = rowByName(page, TEST_PRODUCTS.kale.name);
+      await honeyRow.locator(".row-handle-grip").dispatchEvent("mousedown");
+      await honeyRow.dragTo(kaleRow);
+      await honeyRow.dispatchEvent("dragend");
 
-    await expect.poll(rowOrder).toEqual(["Honey", "Kale", "Eggs"]);
-    await expect(saveButton(page, 3)).toBeEnabled();
+      await expect.poll(rowOrder).toEqual(["Honey", "Kale", "Eggs"]);
+      // "Save 3 changes" is correct — every row's sort_order shifted to a
+      // new (10, 20, 30, …) slot. The "3 changes" copy is technically right
+      // but reads oddly for a one-row drag; follow-up issue tracks tightening
+      // the dirty copy for reorders.
+      await expect(saveButton(page, 3)).toBeEnabled();
 
-    await saveButton(page, 3).click();
-    await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
+      await saveButton(page, 3).click();
+      await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
 
-    await page.reload();
-    await expect.poll(rowOrder).toEqual(["Honey", "Kale", "Eggs"]);
-
-    // Restore the original order so downstream specs aren't surprised.
-    await kaleRow.locator(".row-handle-grip").dispatchEvent("mousedown");
-    await kaleRow.dragTo(honeyRow);
-    await kaleRow.dispatchEvent("dragend");
-    await saveButton(page).click();
-    await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
+      await page.reload();
+      await expect.poll(rowOrder).toEqual(["Honey", "Kale", "Eggs"]);
+    } finally {
+      await resetProductSortOrder();
+    }
   });
 });
 

--- a/tests/admin-inventory.spec.ts
+++ b/tests/admin-inventory.spec.ts
@@ -154,7 +154,12 @@ test.describe("admin inventory", () => {
   // and confirm the new order persists. The try/finally + admin-client
   // reset guarantees other specs see the seeded order even if an assertion
   // here fails mid-test (cleanup-via-drag would otherwise leak).
-  test("drag-to-reorder: grip drag updates row order, persists across reload", async ({ page }) => {
+  test("drag-to-reorder: grip drag updates row order, persists across reload", async ({ page }, testInfo) => {
+    // Native HTML5 DnD doesn't work on touch viewports — mobile project
+    // (iPhone-13 WebKit) is desktop-only for this interaction. Touch-friendly
+    // reorder is tracked in the #143 follow-up issue (#168) alongside the
+    // above/below drop-precision UX.
+    test.skip(testInfo.project.name === "mobile", "HTML5 drag is desktop-only; touch reorder is a follow-up (#168).");
     try {
       await page.goto("/admin/inventory");
 

--- a/tests/admin-inventory.spec.ts
+++ b/tests/admin-inventory.spec.ts
@@ -143,6 +143,47 @@ test.describe("admin inventory", () => {
     await page.reload();
     await expect(rowByName(page, "Test Carrots")).toHaveCount(0);
   });
+
+  // #143 — drag the grip on the left of a row to reorder. Default fixture
+  // is Kale (1), Eggs (2), Honey (3); drag Honey above Kale, save, reload,
+  // and confirm the new order persists. Restores the original sort order
+  // at the end so other specs see the seeded state.
+  test("drag-to-reorder: grip drag updates row order, persists across reload", async ({ page }) => {
+    await page.goto("/admin/inventory");
+
+    // Order in the DOM matches insertion order; assert the baseline first
+    // so a fixture-leak from another spec doesn't masquerade as a pass.
+    const rowOrder = async () =>
+      page.locator("tr.data-row").evaluateAll((els) =>
+        els.map((el) => (el as HTMLElement).dataset.rowName),
+      );
+    await expect.poll(rowOrder).toEqual(["Kale", "Eggs", "Honey"]);
+
+    // Arm the drag on Honey's grip, then drag the row onto Kale's row.
+    // Playwright's dragTo dispatches dragstart/dragover/drop in sequence —
+    // exactly what the armed-handle pattern expects.
+    const honeyRow = rowByName(page, TEST_PRODUCTS.honey.name);
+    const kaleRow = rowByName(page, TEST_PRODUCTS.kale.name);
+    await honeyRow.locator(".row-handle-grip").dispatchEvent("mousedown");
+    await honeyRow.dragTo(kaleRow);
+    await honeyRow.dispatchEvent("dragend");
+
+    await expect.poll(rowOrder).toEqual(["Honey", "Kale", "Eggs"]);
+    await expect(saveButton(page, 3)).toBeEnabled();
+
+    await saveButton(page, 3).click();
+    await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
+
+    await page.reload();
+    await expect.poll(rowOrder).toEqual(["Honey", "Kale", "Eggs"]);
+
+    // Restore the original order so downstream specs aren't surprised.
+    await kaleRow.locator(".row-handle-grip").dispatchEvent("mousedown");
+    await kaleRow.dragTo(honeyRow);
+    await kaleRow.dispatchEvent("dragend");
+    await saveButton(page).click();
+    await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
+  });
 });
 
 test.describe("admin inventory — open-for-orders meta pill", () => {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -165,6 +165,23 @@ export async function setOrderingOpen(open: boolean): Promise<void> {
     .eq("is_singleton", true);
 }
 
+// Reset TEST_PRODUCTS sort_order back to seeded values (kale=1, eggs=2,
+// honey=3). Use in a try/finally around drag-reorder specs so a mid-test
+// failure can't poison the order other specs see. Global setup already
+// upserts these values, but it only runs once per playwright invocation —
+// in-run leakage needs this finer-grained reset.
+export async function resetProductSortOrder(): Promise<void> {
+  const sb = admin();
+  const seeded: Array<{ id: string; sort_order: number }> = [
+    { id: TEST_PRODUCTS.kale.id,  sort_order: 1 },
+    { id: TEST_PRODUCTS.eggs.id,  sort_order: 2 },
+    { id: TEST_PRODUCTS.honey.id, sort_order: 3 },
+  ];
+  for (const row of seeded) {
+    await sb.from("products").update({ sort_order: row.sort_order }).eq("id", row.id);
+  }
+}
+
 // Patches the singleton ordering_schedule row. Pass only the fields you want
 // to change. Used by the inventory meta-pill tests to walk all three open
 // states (closed / open manual / open via schedule).


### PR DESCRIPTION
## Summary

Wires the already-present left-side grip on each inventory row to actual drag-and-drop. Annabel can now reorder products from `/admin/inventory` — drag the grip, drop on the row you want to land above, save. New order persists.

Native HTML5 DnD, no new dependency. Reorder rewrites \`sort_order\` to (10, 20, 30, …) of the new array (same convention as \`addRow\`'s \`maxOrder + 10\`); mutation flows through the existing dirty-detection + save pipeline; no schema or action changes (save-inventory already accepted sort_order).

## Files changed

- \`design/admin-inventory.{jsx,css}\` — mockup mirror of the same drag logic + state classes
- \`src/components/admin/inventory-editor.tsx\` — \`draggingId\`/\`dropTargetId\` state, \`reorderRows(fromId, toId)\` splice + sort_order rewrite, defensive state clear at top of reorder
- \`src/components/admin/inventory-row.tsx\` — armed-handle pattern: \`<tr draggable={dragArmed}>\`, grip \`onMouseDown\` arms, \`onDragEnd\` disarms; \`onDragStart\`/\`onDragOver\`/\`onDrop\` wired through new props
- \`src/styles/app.css\` — \`.is-dragging\` (40% opacity), \`.is-drop-target\` (2px leaf-green top border)
- \`tests/admin-inventory.spec.ts\` — new spec drags Honey above Kale via Playwright's \`dragTo()\`, asserts DOM order + dirty count + Save + reload persistence; try/finally restores via new helper
- \`tests/helpers.ts\` — new \`resetProductSortOrder()\` helper

## Code review

Findings from \`@code-review\` (medium effort). Addressed in commit \`36eddf9\`:
- **cleanup** — defensive \`setDraggingId(null)\` at top of \`reorderRows\` so a dropped \`dragend\` event can't strand a row at 40% opacity.
- **consistency** — dropped redundant \`toIdx\` pre-check; the spliced-array \`insertAt findIndex\` is the authoritative bounds check.
- **cleanup** — narrowed the \`setData\` comment from "some browsers" to "Firefox".
- **cleanup** — test wrapped in try/finally with \`resetProductSortOrder()\` so a mid-test assertion failure can't leak ordering to downstream specs.
- **comment** — inline note on the "Save 3 changes" assertion (technically correct — every row's sort_order shifts — but reads oddly for a one-row drag).

Deferred to follow-up issue #168:
- Drop-precision split by cursor Y (above/below halves) — current "drop on row → land above it" is intuitive moving up, less so moving down.
- Tighter "Save reorder" copy vs counting every shifted sort_order as a change.

Out of scope (called out in plan): touch/mobile reorder UX (HTML5 drag is poor on touch — admin mobile is DEC-034 scope); keyboard a11y on the grip.

## Test plan

- [ ] \`npx playwright test tests/admin-inventory.spec.ts --project=desktop\` — all 9 desktop cases pass (mobile case skipped on this project)
- [ ] On preview \`/admin/inventory\`: drag Kale's grip onto Eggs → Kale lands above Eggs, row visually fades during drag, drop target gets a green top border, Save button activates
- [ ] Save → reload → order persists
- [ ] Click into a product-name input (NOT the grip) and try to drag the row — drag should not start (armed-handle pattern)
- [ ] Discard while dirty → order reverts to baseline

closes #143