### PR TITLE
Admin customers — show + reactivate deactivated rows (closes #61)

### DIFF
--- a/design/admin-customers.css
+++ b/design/admin-customers.css
@@ -41,6 +41,21 @@
 .cust-table tbody tr.cust-row:first-child td { border-top: 0; }
 .cust-table tbody tr.cust-row.is-unsub td { background: var(--ink-100); color: var(--ink-500); }
 .cust-table tbody tr.cust-row.is-unsub .cust-name { color: var(--ink-700); }
+/* #61 — deactivated rows. Distinct from is-unsub so "deactivated" (account
+   gone) reads differently from "unsubscribed" (paused for the week). */
+.cust-table tbody tr.cust-row.is-inactive td {
+  background: repeating-linear-gradient(
+    -45deg,
+    var(--ink-100) 0 6px,
+    transparent 6px 12px
+  );
+  color: var(--ink-500);
+}
+.cust-table tbody tr.cust-row.is-inactive .cust-name {
+  color: var(--ink-500);
+  text-decoration: line-through;
+  text-decoration-color: var(--ink-300);
+}
 
 .col-c-name     { width: 22%; min-width: 180px; }
 .col-c-contact  { width: 200px; }

--- a/design/admin-customers.jsx
+++ b/design/admin-customers.jsx
@@ -60,8 +60,16 @@ const SEED_CUSTOMERS = [
     business_name: null,
     email: "chef@saucybrewworks.com", phone: "216-555-0273",
     address: "2885 Detroit Ave, Cleveland, OH 44113",
-    priority: 200, subscribed: false,
+    priority: 200, subscribed: false, is_active: true,
     token: "d4k1n8-sbw",
+  },
+  {
+    id: "c08", name: "Old Pickup Stand",
+    business_name: null,
+    email: null, phone: "216-555-0301",
+    address: "5921 Detroit Ave, Cleveland, OH 44102",
+    priority: 100, subscribed: false, is_active: false,
+    token: "x9p3v6-ops",
   },
 ];
 
@@ -70,11 +78,17 @@ function CustomersPage() {
   const [drawer, setDrawer] = useState(null); // null | customer object (id: null = new)
   const [confirmRegen, setConfirmRegen] = useState(null);
   const [copiedId, setCopiedId] = useState(null);
+  const [showDeactivated, setShowDeactivated] = useState(false);
+
+  const isActive = (c) => c.is_active !== false;
+  const activeRows = rows.filter(isActive);
+  const deactivatedCount = rows.length - activeRows.length;
+  const visibleRows = showDeactivated ? rows : activeRows;
 
   const openEdit = (c) => setDrawer(c);
   const openNew  = () => setDrawer({
     id: null, name: "", business_name: "", email: "", phone: "",
-    address: "", priority: "100", subscribed: true, token: "",
+    address: "", priority: "100", subscribed: true, is_active: true, token: "",
   });
 
   const saveDrawer = (data) => {
@@ -107,10 +121,22 @@ function CustomersPage() {
     <div className="cust-page">
       <div className="admin-page-head">
         <div>
-          <div className="eyebrow" style={{marginBottom: 6}}>{rows.length} accounts · {rows.filter(r=>r.subscribed).length} subscribed</div>
+          <div className="eyebrow" style={{marginBottom: 6}}>{activeRows.length} accounts · {activeRows.filter(r=>r.subscribed).length} subscribed</div>
           <h1 className="admin-page-title">Customers</h1>
         </div>
         <div className="admin-page-actions">
+          {deactivatedCount > 0 && (
+            <button
+              type="button"
+              className="btn btn-secondary"
+              aria-pressed={showDeactivated}
+              onClick={() => setShowDeactivated(v => !v)}
+            >
+              {showDeactivated
+                ? `Hide deactivated (${deactivatedCount})`
+                : `Show deactivated (${deactivatedCount})`}
+            </button>
+          )}
           <button type="button" className="btn btn-secondary" disabled title="Coming later">Export CSV</button>
           <button type="button" className="btn btn-primary" onClick={openNew}>+ Add customer</button>
         </div>
@@ -130,8 +156,16 @@ function CustomersPage() {
             </tr>
           </thead>
           <tbody>
-            {rows.map(c => (
-              <tr key={c.id} className={"cust-row" + (!c.subscribed ? " is-unsub" : "")} onClick={() => openEdit(c)}>
+            {visibleRows.map(c => (
+              <tr
+                key={c.id}
+                className={
+                  "cust-row" +
+                  (!isActive(c) ? " is-inactive" : "") +
+                  (!c.subscribed ? " is-unsub" : "")
+                }
+                onClick={() => openEdit(c)}
+              >
                 <td className="col-c-name">
                   <div className="cust-name">{c.name}</div>
                   {c.business_name && <div className="cust-biz">{c.business_name}</div>}

--- a/src/actions/reactivate-customer.ts
+++ b/src/actions/reactivate-customer.ts
@@ -1,0 +1,19 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+
+// #61 — counterpart to deactivateCustomer. Flips is_active back to true.
+// Revalidates /admin/customers (the row jumps back into the default view)
+// and /admin/inventory (subscribed pill is a consumer of the count).
+export async function reactivateCustomer(id: string): Promise<{ error: string | null }> {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("customers")
+    .update({ is_active: true, updated_at: new Date().toISOString() })
+    .eq("id", id);
+  if (error) return { error: error.message };
+  revalidatePath("/admin/customers");
+  revalidatePath("/admin/inventory");
+  return { error: null };
+}

--- a/src/app/(admin)/admin/customers/page.tsx
+++ b/src/app/(admin)/admin/customers/page.tsx
@@ -3,10 +3,12 @@ import { CustomersPage, type CustomerRow } from "@/components/admin/customers-pa
 
 export default async function AdminCustomersPage() {
   const supabase = await createClient();
+  // #61: fetch all customers (active + deactivated). Default view filters
+  // to active client-side; the page-header toggle reveals the rest.
   const { data, error } = await supabase
     .from("customers")
-    .select("id, name, business_name, email, phone, delivery_address, priority, send_weekly_link, token")
-    .eq("is_active", true)
+    .select("id, name, business_name, email, phone, delivery_address, priority, send_weekly_link, token, is_active")
+    .order("is_active", { ascending: false })
     .order("priority", { ascending: true })
     .order("name", { ascending: true });
 

--- a/src/components/admin/customer-drawer.tsx
+++ b/src/components/admin/customer-drawer.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { saveCustomer } from "@/actions/save-customer";
 import { deactivateCustomer } from "@/actions/deactivate-customer";
+import { reactivateCustomer } from "@/actions/reactivate-customer";
 
 export type CustomerDrawerState = {
   id: string | null;
@@ -18,6 +19,8 @@ export type CustomerDrawerState = {
   priority: string;
   send_weekly_link: boolean;
   token: string;
+  // #61 — when false, the drawer swaps "Delete customer" for "Reactivate".
+  is_active: boolean;
 };
 
 type Props = {
@@ -31,7 +34,9 @@ export function CustomerDrawer({ initial, onClose, onSaved }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [saving, startSaving] = useTransition();
   const [deleting, startDeleting] = useTransition();
+  const [reactivating, startReactivating] = useTransition();
   const isNew = !initial.id;
+  const isInactive = !isNew && !initial.is_active;
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -96,6 +101,24 @@ export function CustomerDrawer({ initial, onClose, onSaved }: Props) {
     });
   }
 
+  function handleReactivate() {
+    if (!c.id) return;
+    startReactivating(async () => {
+      let result;
+      try {
+        result = await reactivateCustomer(c.id!);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Reactivate failed. Try again.");
+        return;
+      }
+      if (result.error) {
+        setError(result.error);
+        return;
+      }
+      onSaved();
+    });
+  }
+
   return (
     <>
       <div className="drawer-scrim" onClick={onClose} aria-hidden="true" />
@@ -107,7 +130,9 @@ export function CustomerDrawer({ initial, onClose, onSaved }: Props) {
       >
         <header className="drawer-head">
           <div>
-            <div className="eyebrow">{isNew ? "new customer" : "edit customer"}</div>
+            <div className="eyebrow">
+              {isNew ? "new customer" : isInactive ? "deactivated customer" : "edit customer"}
+            </div>
             <h2 className="drawer-title">
               {isNew ? "Add a new customer" : initial.name || "—"}
             </h2>
@@ -205,7 +230,7 @@ export function CustomerDrawer({ initial, onClose, onSaved }: Props) {
         </div>
 
         <footer className="drawer-foot">
-          {!isNew && (
+          {!isNew && !isInactive && (
             <Button
               variant="destructive"
               onClick={handleDelete}
@@ -214,11 +239,20 @@ export function CustomerDrawer({ initial, onClose, onSaved }: Props) {
               {deleting ? "Deactivating…" : "Delete customer"}
             </Button>
           )}
+          {isInactive && (
+            <Button
+              variant="primary"
+              onClick={handleReactivate}
+              disabled={reactivating || saving}
+            >
+              {reactivating ? "Reactivating…" : "Reactivate customer"}
+            </Button>
+          )}
           <div style={{ flex: 1 }} />
-          <Button variant="ghost" onClick={onClose} disabled={saving || deleting}>
+          <Button variant="ghost" onClick={onClose} disabled={saving || deleting || reactivating}>
             Cancel
           </Button>
-          <Button variant="primary" onClick={handleSave} disabled={saving || deleting}>
+          <Button variant="primary" onClick={handleSave} disabled={saving || deleting || reactivating}>
             {saving ? "Saving…" : isNew ? "Add customer" : "Save changes"}
           </Button>
         </footer>

--- a/src/components/admin/customer-drawer.tsx
+++ b/src/components/admin/customer-drawer.tsx
@@ -243,7 +243,7 @@ export function CustomerDrawer({ initial, onClose, onSaved }: Props) {
             <Button
               variant="primary"
               onClick={handleReactivate}
-              disabled={reactivating || saving}
+              disabled={reactivating || saving || deleting}
             >
               {reactivating ? "Reactivating…" : "Reactivate customer"}
             </Button>

--- a/src/components/admin/customers-page.tsx
+++ b/src/components/admin/customers-page.tsx
@@ -20,6 +20,7 @@ export type CustomerRow = {
   priority: number;
   send_weekly_link: boolean;
   token: string;
+  is_active: boolean;
 };
 
 type Props = { customers: CustomerRow[] };
@@ -35,6 +36,7 @@ function emptyDrawerState(): CustomerDrawerState {
     priority: "100",
     send_weekly_link: true,
     token: "",
+    is_active: true,
   };
 }
 
@@ -49,6 +51,7 @@ function rowToDrawerState(row: CustomerRow): CustomerDrawerState {
     priority: String(row.priority),
     send_weekly_link: row.send_weekly_link,
     token: row.token,
+    is_active: row.is_active,
   };
 }
 
@@ -62,7 +65,12 @@ export function CustomersPage({ customers }: Props) {
   const [regenBusy, setRegenBusy] = useState(false);
   const [, startToggle] = useTransition();
 
-  const subscribedCount = customers.filter((c) => c.send_weekly_link).length;
+  const [showDeactivated, setShowDeactivated] = useState(false);
+
+  const activeCustomers = customers.filter((c) => c.is_active);
+  const subscribedCount = activeCustomers.filter((c) => c.send_weekly_link).length;
+  const deactivatedCount = customers.length - activeCustomers.length;
+  const visibleCustomers = showDeactivated ? customers : activeCustomers;
 
   function handleSaved() {
     setDrawer(null);
@@ -120,9 +128,20 @@ export function CustomersPage({ customers }: Props) {
   return (
     <main style={{ padding: "28px 32px 60px", maxWidth: 1200, width: "100%" }}>
       <PageHeader
-        eyebrow={`${customers.length} account${customers.length === 1 ? "" : "s"} · ${subscribedCount} subscribed`}
+        eyebrow={`${activeCustomers.length} account${activeCustomers.length === 1 ? "" : "s"} · ${subscribedCount} subscribed`}
         title="Customers"
       >
+        {deactivatedCount > 0 && (
+          <Button
+            variant="secondary"
+            onClick={() => setShowDeactivated((v) => !v)}
+            aria-pressed={showDeactivated}
+          >
+            {showDeactivated
+              ? `Hide deactivated (${deactivatedCount})`
+              : `Show deactivated (${deactivatedCount})`}
+          </Button>
+        )}
         <Button variant="secondary" disabled title="Coming later">
           Export CSV
         </Button>
@@ -156,19 +175,24 @@ export function CustomersPage({ customers }: Props) {
             </tr>
           </thead>
           <tbody>
-            {customers.length === 0 && (
+            {visibleCustomers.length === 0 && (
               <tr>
                 <td colSpan={7} style={{ padding: 32, textAlign: "center", color: "var(--ink-500)" }}>
                   No active customers. Add one to get started.
                 </td>
               </tr>
             )}
-            {customers.map((c) => (
+            {visibleCustomers.map((c) => (
               <tr
                 key={c.id}
-                className={"cust-row" + (!c.send_weekly_link ? " is-unsub" : "")}
+                className={
+                  "cust-row" +
+                  (!c.is_active ? " is-inactive" : "") +
+                  (!c.send_weekly_link ? " is-unsub" : "")
+                }
                 data-row-id={c.id}
                 data-row-name={c.name}
+                data-row-state={c.is_active ? "active" : "inactive"}
                 onClick={() => setDrawer(rowToDrawerState(c))}
               >
                 <td className="col-c-name">
@@ -217,6 +241,7 @@ export function CustomersPage({ customers }: Props) {
                     checked={c.send_weekly_link}
                     onChange={() => handleToggle(c)}
                     ariaLabel={`Subscribed: ${c.name}`}
+                    disabled={!c.is_active}
                   />
                 </td>
                 <td className="col-c-actions">

--- a/src/components/admin/customers-page.tsx
+++ b/src/components/admin/customers-page.tsx
@@ -178,7 +178,9 @@ export function CustomersPage({ customers }: Props) {
             {visibleCustomers.length === 0 && (
               <tr>
                 <td colSpan={7} style={{ padding: 32, textAlign: "center", color: "var(--ink-500)" }}>
-                  No active customers. Add one to get started.
+                  {showDeactivated
+                    ? "No customers."
+                    : "No active customers. Add one to get started."}
                 </td>
               </tr>
             )}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -4,17 +4,19 @@ type Props = {
   checked: boolean;
   onChange: (v: boolean) => void;
   ariaLabel?: string;
+  disabled?: boolean;
 };
 
-export function Switch({ checked, onChange, ariaLabel }: Props) {
+export function Switch({ checked, onChange, ariaLabel, disabled = false }: Props) {
   return (
     <button
       type="button"
       role="switch"
       aria-checked={checked}
       aria-label={ariaLabel}
+      disabled={disabled}
       onClick={() => onChange(!checked)}
-      className={"switch" + (checked ? " is-on" : "")}
+      className={"switch" + (checked ? " is-on" : "") + (disabled ? " is-disabled" : "")}
     >
       <span className="switch-thumb" />
     </button>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -338,6 +338,7 @@
   box-shadow: 0 1px 2px rgba(0,0,0,0.2);
 }
 .switch.is-on .switch-thumb { transform: translateX(16px); }
+.switch.is-disabled { opacity: 0.45; cursor: not-allowed; }
 
 /* ── Sticky save bar ─────────────────────────────────────── */
 .save-bar {
@@ -712,6 +713,22 @@
 .cust-table tbody tr.cust-row:first-child td { border-top: 0; }
 .cust-table tbody tr.cust-row.is-unsub td { background: var(--ink-100); color: var(--ink-500); }
 .cust-table tbody tr.cust-row.is-unsub .cust-name { color: var(--ink-700); }
+/* #61 — deactivated rows. Distinct from is-unsub so Annabel reads
+   "deactivated" (the account is gone) differently from "unsubscribed"
+   (the customer is still active, just paused for this week). */
+.cust-table tbody tr.cust-row.is-inactive td {
+  background: repeating-linear-gradient(
+    -45deg,
+    var(--ink-100) 0 6px,
+    transparent 6px 12px
+  );
+  color: var(--ink-500);
+}
+.cust-table tbody tr.cust-row.is-inactive .cust-name {
+  color: var(--ink-500);
+  text-decoration: line-through;
+  text-decoration-color: var(--ink-300);
+}
 
 .col-c-name     { width: 22%; min-width: 180px; }
 .col-c-contact  { width: 200px; }

--- a/tests/admin-customers.spec.ts
+++ b/tests/admin-customers.spec.ts
@@ -198,4 +198,52 @@ test.describe("admin customers", () => {
       .getAttribute("aria-checked");
     expect(flipped).not.toBe(initial);
   });
+
+  // #61 — deactivated customers are hidden by default; a header toggle reveals
+  // them with a distinct "is-inactive" treatment, and the drawer swaps
+  // "Delete customer" for "Reactivate customer". The afterEach in this
+  // describe (resetTestCustomers) restores is_active=true on both seed rows
+  // so the bare deactivate doesn't leak.
+  test("Show deactivated reveals inactive rows; drawer Reactivate restores them", async ({ page }) => {
+    const supabase = admin();
+    await supabase
+      .from("customers")
+      .update({ is_active: false })
+      .eq("token", TEST_CUSTOMERS.restaurant.token);
+
+    await page.goto("/admin/customers");
+
+    // Default view: restaurant is hidden.
+    await expect(rowByName(page, TEST_CUSTOMERS.farmStand.name)).toBeVisible();
+    await expect(rowByName(page, TEST_CUSTOMERS.restaurant.name)).toHaveCount(0);
+
+    // Eyebrow reflects active count only — 1 active row, not 2 accounts.
+    await expect(page.getByText(/1 account · /)).toBeVisible();
+
+    // Toggle appears with the deactivated count.
+    const toggle = page.getByRole("button", { name: /show deactivated \(1\)/i });
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+
+    const restaurantRow = rowByName(page, TEST_CUSTOMERS.restaurant.name);
+    await expect(restaurantRow).toBeVisible();
+    await expect(restaurantRow).toHaveClass(/is-inactive/);
+    await expect(restaurantRow).toHaveAttribute("data-row-state", "inactive");
+    // Subscribed switch is disabled on a deactivated row.
+    await expect(restaurantRow.getByRole("switch")).toBeDisabled();
+
+    // Drawer on the inactive row swaps Delete → Reactivate.
+    await restaurantRow.locator(".cust-name").click();
+    await expect(drawer(page)).toBeVisible();
+    await expect(drawer(page).getByText(/deactivated customer/i)).toBeVisible();
+    await expect(drawer(page).getByRole("button", { name: /^delete customer$/i })).toHaveCount(0);
+
+    await drawer(page).getByRole("button", { name: /^reactivate customer$/i }).click();
+    await expect(drawer(page)).toHaveCount(0);
+
+    // Row is back in the default view; toggle is gone (no more deactivated).
+    await expect(rowByName(page, TEST_CUSTOMERS.restaurant.name)).toBeVisible();
+    await expect(rowByName(page, TEST_CUSTOMERS.restaurant.name)).not.toHaveClass(/is-inactive/);
+    await expect(page.getByRole("button", { name: /show deactivated/i })).toHaveCount(0);
+  });
 });

--- a/tests/admin-customers.spec.ts
+++ b/tests/admin-customers.spec.ts
@@ -201,9 +201,9 @@ test.describe("admin customers", () => {
 
   // #61 — deactivated customers are hidden by default; a header toggle reveals
   // them with a distinct "is-inactive" treatment, and the drawer swaps
-  // "Delete customer" for "Reactivate customer". The afterEach in this
-  // describe (resetTestCustomers) restores is_active=true on both seed rows
-  // so the bare deactivate doesn't leak.
+  // "Delete customer" for "Reactivate customer". The next test's beforeEach
+  // (resetTestCustomers) restores is_active=true on both seed rows so the
+  // bare deactivate doesn't leak.
   test("Show deactivated reveals inactive rows; drawer Reactivate restores them", async ({ page }) => {
     const supabase = admin();
     await supabase


### PR DESCRIPTION
## Summary

Soft-deleted customers (\`is_active=false\`) are no longer invisible. A header toggle reveals them with a distinct \`is-inactive\` treatment, and the drawer swaps "Delete customer" for "Reactivate customer". Hard-delete remains out of scope (service-role SQL is the right path).

## Files changed

- \`design/admin-customers.{jsx,css}\` — mockup mirror: one seeded \`is_active: false\` row, header toggle, \`is-inactive\` styling
- \`src/actions/reactivate-customer.ts\` — new server action: flips \`is_active=true\`, revalidates \`/admin/customers\` + \`/admin/inventory\`
- \`src/app/(admin)/admin/customers/page.tsx\` — drops the \`is_active=true\` filter, includes the flag, adds \`order("is_active", desc)\` so active rows lead
- \`src/components/admin/customer-drawer.tsx\` — \`isInactive\` snapshot from \`initial.is_active\`; eyebrow switches to "deactivated customer"; Delete button hidden when inactive, Reactivate button shown instead
- \`src/components/admin/customers-page.tsx\` — \`showDeactivated\` state, header toggle, filter, \`is-inactive\` row class, \`data-row-state\` test hook, Subscribed switch disabled on inactive
- \`src/components/ui/switch.tsx\` — gained \`disabled\` prop
- \`src/styles/app.css\` — \`.cust-row.is-inactive\` (diagonal-stripe background + strike-through name, distinct from \`.is-unsub\`'s solid muted bg) + \`.switch.is-disabled\`
- \`tests/admin-customers.spec.ts\` — new spec deactivates restaurant fixture, asserts hidden by default → toggle reveals with is-inactive + disabled switch → drawer shows Reactivate (not Delete) → reactivate restores

## Code review

Findings from \`@code-review\` (medium effort). Addressed in commit \`fad12b1\`:
- **cleanup** — Reactivate button's disabled prop now matches Cancel/Save (\`reactivating || saving || deleting\`). Cosmetic today, kills the asymmetry.
- **cleanup** — empty-state copy branches on \`showDeactivated\` so "No active customers" doesn't lie when the deactivated view is empty.
- **cleanup** — test comment said "afterEach" but the contract is the next test's \`beforeEach\`. Fixed.

Confirmed sound: \`isInactive\` snapshot pattern (drawer closes on reactivate; reopen is a fresh prop), multi-key sort applies within each \`is_active\` group, \`.is-inactive\` wins specificity over \`.is-unsub\` by declaration order, saving edits on a deactivated customer preserves \`is_active=false\` (saveCustomer doesn't touch it), test fixture leak window is closed by the existing \`beforeEach\` reset.

Deferred: eyebrow accuracy when \`showDeactivated\` is on (toggle text surfaces the deactivated count separately; not blocking for a 7-customer tool).

## Test plan

- [ ] \`npx playwright test tests/admin-customers.spec.ts --project=desktop\` — 8/8 (1 mobile-only skipped)
- [ ] \`npx playwright test tests/admin-inventory.spec.ts --project=desktop\` — 8/8 (no regression on the subscribed-pill revalidate path)
- [ ] On preview \`/admin/customers\`:
  - Default view: no deactivated rows; if any exist, "Show deactivated (N)" button is visible in the header
  - Click toggle → deactivated rows render with diagonal-stripe background + strike-through name + disabled Subscribed switch
  - Click a deactivated row → drawer eyebrow says "deactivated customer", footer shows "Reactivate customer" (no Delete button)
  - Click Reactivate → drawer closes, row moves back into the default view, toggle disappears once count hits 0
- [ ] Confirm that reactivating a customer with \`send_weekly_link=true\` immediately bumps \`/admin/inventory\` subscribed-pill count

closes #61