### PR TITLE
Unsaved-changes guard on admin data-entry forms (closes #129)

### DIFF
--- a/src/components/admin/customer-drawer.tsx
+++ b/src/components/admin/customer-drawer.tsx
@@ -6,6 +6,7 @@ import { Switch } from "@/components/ui/switch";
 import { saveCustomer } from "@/actions/save-customer";
 import { deactivateCustomer } from "@/actions/deactivate-customer";
 import { reactivateCustomer } from "@/actions/reactivate-customer";
+import { useUnsavedChangesGuard } from "@/lib/hooks/use-unsaved-changes-guard";
 
 export type CustomerDrawerState = {
   id: string | null;
@@ -37,6 +38,11 @@ export function CustomerDrawer({ initial, onClose, onSaved }: Props) {
   const [reactivating, startReactivating] = useTransition();
   const isNew = !initial.id;
   const isInactive = !isNew && !initial.is_active;
+  // #129 — guard against leaving with unsaved edits. Suspend during
+  // saving/deleting/reactivating so the success path (which fires
+  // onSaved → unmount) doesn't bounce against the guard.
+  const dirty = JSON.stringify(c) !== JSON.stringify(initial);
+  useUnsavedChangesGuard(dirty && !saving && !deleting && !reactivating);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {

--- a/src/components/admin/customer-drawer.tsx
+++ b/src/components/admin/customer-drawer.tsx
@@ -42,15 +42,28 @@ export function CustomerDrawer({ initial, onClose, onSaved }: Props) {
   // saving/deleting/reactivating so the success path (which fires
   // onSaved → unmount) doesn't bounce against the guard.
   const dirty = JSON.stringify(c) !== JSON.stringify(initial);
-  useUnsavedChangesGuard(dirty && !saving && !deleting && !reactivating);
+  const guardActive = dirty && !saving && !deleting && !reactivating;
+  useUnsavedChangesGuard(guardActive);
+
+  // The drawer's scrim click + X button + Escape all close without
+  // navigating, so the hook's click/popstate path doesn't catch them.
+  // Wrap onClose to prompt explicitly when dirty.
+  function tryClose() {
+    if (guardActive && !window.confirm("You have unsaved changes — leave anyway?")) {
+      return;
+    }
+    onClose();
+  }
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") tryClose();
     }
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [onClose]);
+    // tryClose closes over guardActive/onClose — re-bind when either changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [guardActive, onClose]);
 
   function set<K extends keyof CustomerDrawerState>(key: K, value: CustomerDrawerState[K]) {
     setC((prev) => ({ ...prev, [key]: value }));
@@ -127,7 +140,7 @@ export function CustomerDrawer({ initial, onClose, onSaved }: Props) {
 
   return (
     <>
-      <div className="drawer-scrim" onClick={onClose} aria-hidden="true" />
+      <div className="drawer-scrim" onClick={tryClose} aria-hidden="true" />
       <aside
         className="drawer"
         role="dialog"
@@ -147,7 +160,7 @@ export function CustomerDrawer({ initial, onClose, onSaved }: Props) {
           <button
             type="button"
             className="drawer-close"
-            onClick={onClose}
+            onClick={tryClose}
             aria-label="Close drawer"
           >
             <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
@@ -255,7 +268,7 @@ export function CustomerDrawer({ initial, onClose, onSaved }: Props) {
             </Button>
           )}
           <div style={{ flex: 1 }} />
-          <Button variant="ghost" onClick={onClose} disabled={saving || deleting || reactivating}>
+          <Button variant="ghost" onClick={tryClose} disabled={saving || deleting || reactivating}>
             Cancel
           </Button>
           <Button variant="primary" onClick={handleSave} disabled={saving || deleting || reactivating}>

--- a/src/components/admin/customer-drawer.tsx
+++ b/src/components/admin/customer-drawer.tsx
@@ -268,7 +268,9 @@ export function CustomerDrawer({ initial, onClose, onSaved }: Props) {
             </Button>
           )}
           <div style={{ flex: 1 }} />
-          <Button variant="ghost" onClick={tryClose} disabled={saving || deleting || reactivating}>
+          {/* Cancel is the explicit "discard my edits" button — skips the
+              guard intentionally. Scrim/X/Escape still prompt. */}
+          <Button variant="ghost" onClick={onClose} disabled={saving || deleting || reactivating}>
             Cancel
           </Button>
           <Button variant="primary" onClick={handleSave} disabled={saving || deleting || reactivating}>

--- a/src/components/admin/intro-note-card.tsx
+++ b/src/components/admin/intro-note-card.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, useTransition } from "react";
 
 import { saveIntroNote } from "@/actions/save-intro-note";
+import { useUnsavedChangesGuard } from "@/lib/hooks/use-unsaved-changes-guard";
 
 type IntroNoteCardProps = {
   initialValue: string;
@@ -15,6 +16,9 @@ export function IntroNoteCard({ initialValue }: IntroNoteCardProps) {
   const [error, setError] = useState<string | null>(null);
 
   const dirty = value !== saved;
+  // #129 — guard unsaved typing. Save handler updates `saved`, so dirty
+  // flips back to false on success and the guard disarms.
+  useUnsavedChangesGuard(dirty && !pending);
 
   // Sync if a server-side change updates initialValue (e.g. another tab
   // saves, or revalidatePath after our own save). We only overwrite local

--- a/src/components/admin/inventory-editor.tsx
+++ b/src/components/admin/inventory-editor.tsx
@@ -11,6 +11,7 @@ import { InventoryRow, type InventoryRowState } from "@/components/admin/invento
 import { PrepopulateButton } from "@/components/admin/prepopulate-button";
 import { UnitsDrawer, type ProductUnitState } from "@/components/admin/units-drawer";
 import { saveInventory } from "@/actions/save-inventory";
+import { useUnsavedChangesGuard } from "@/lib/hooks/use-unsaved-changes-guard";
 import { formatTime, shortDay } from "@/lib/schedule-format";
 
 export type ScheduleSummary = {
@@ -82,6 +83,10 @@ export function InventoryEditor({ initialRows, initialUnits, weekLabel, schedule
   }, [rows, baselineMap, deletedIds]);
 
   const dirty = dirtyCount > 0;
+  // #129 — suspend the guard while a save is in flight; the success path
+  // resets baseline (dirty→false naturally) and then router.refresh, but
+  // the in-flight window is brief and shouldn't prompt.
+  useUnsavedChangesGuard(dirty && !saving);
 
   function update(id: string, patch: Partial<InventoryRowState>) {
     setRows((rs) => rs.map((r) => (r.id === id ? { ...r, ...patch } : r)));

--- a/src/components/admin/units-drawer.tsx
+++ b/src/components/admin/units-drawer.tsx
@@ -276,7 +276,9 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
 
         <footer className="drawer-foot">
           <div style={{ flex: 1 }} />
-          <Button variant="ghost" onClick={tryClose} disabled={saving}>Cancel</Button>
+          {/* Cancel is the explicit "discard" button — skips the guard
+              intentionally. Scrim/X/Escape still prompt. */}
+          <Button variant="ghost" onClick={onClose} disabled={saving}>Cancel</Button>
           <Button variant="primary" onClick={handleSave} disabled={!dirty || saving} dirty={dirty}>
             {saving ? "Saving…" : dirty ? "Save units" : "Saved"}
           </Button>

--- a/src/components/admin/units-drawer.tsx
+++ b/src/components/admin/units-drawer.tsx
@@ -66,14 +66,6 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
   const [error, setError] = useState<string | null>(null);
   const [saving, startSaving] = useTransition();
 
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape" && !saving) onClose();
-    }
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [onClose, saving]);
-
   const baseId = useMemo(() => pickBaseId(initialUnits), [initialUnits]);
 
   const dirty = useMemo(() => {
@@ -97,8 +89,28 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
 
   // #129 — guard against losing in-progress unit edits when Annabel clicks
   // the sidebar nav (or browser-backs) mid-edit. Suspend while saving so
-  // the success path (onSaved → unmount) doesn't bounce.
-  useUnsavedChangesGuard(dirty && !saving);
+  // the success path (onSaved → unmount) doesn't bounce. The in-drawer
+  // close paths (scrim / X / Cancel / Escape) bypass the hook because
+  // they don't navigate — wrap onClose to prompt explicitly.
+  const guardActive = dirty && !saving;
+  useUnsavedChangesGuard(guardActive);
+
+  function tryClose() {
+    if (guardActive && !window.confirm("You have unsaved changes — leave anyway?")) {
+      return;
+    }
+    onClose();
+  }
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape" && !saving) tryClose();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+    // tryClose closes over guardActive/onClose; saving is also a dep.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onClose, saving, guardActive]);
 
   function update(id: string, patch: Partial<ProductUnitState>) {
     setUnits((us) => us.map((u) => (u.id === id ? { ...u, ...patch } : u)));
@@ -193,7 +205,7 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
 
   return (
     <>
-      <div className="drawer-scrim" onClick={() => !saving && onClose()} aria-hidden="true" />
+      <div className="drawer-scrim" onClick={() => !saving && tryClose()} aria-hidden="true" />
       <aside
         className="drawer units-drawer"
         role="dialog"
@@ -211,7 +223,7 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
           <button
             type="button"
             className="drawer-close"
-            onClick={onClose}
+            onClick={tryClose}
             aria-label="Close drawer"
             disabled={saving}
           >
@@ -264,7 +276,7 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
 
         <footer className="drawer-foot">
           <div style={{ flex: 1 }} />
-          <Button variant="ghost" onClick={onClose} disabled={saving}>Cancel</Button>
+          <Button variant="ghost" onClick={tryClose} disabled={saving}>Cancel</Button>
           <Button variant="primary" onClick={handleSave} disabled={!dirty || saving} dirty={dirty}>
             {saving ? "Saving…" : dirty ? "Save units" : "Saved"}
           </Button>

--- a/src/components/admin/units-drawer.tsx
+++ b/src/components/admin/units-drawer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { saveProductUnits, type UnitInput } from "@/actions/save-product-units";
+import { useUnsavedChangesGuard } from "@/lib/hooks/use-unsaved-changes-guard";
 
 export type ProductUnitState = {
   id: string;
@@ -93,6 +94,11 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
     }
     return false;
   }, [units, initialUnits, deletedIds]);
+
+  // #129 — guard against losing in-progress unit edits when Annabel clicks
+  // the sidebar nav (or browser-backs) mid-edit. Suspend while saving so
+  // the success path (onSaved → unmount) doesn't bounce.
+  useUnsavedChangesGuard(dirty && !saving);
 
   function update(id: string, patch: Partial<ProductUnitState>) {
     setUnits((us) => us.map((u) => (u.id === id ? { ...u, ...patch } : u)));

--- a/src/lib/hooks/use-unsaved-changes-guard.ts
+++ b/src/lib/hooks/use-unsaved-changes-guard.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect } from "react";
+
+const MESSAGE = "You have unsaved changes — leave anyway?";
+
+// #129 — prompt before discarding unsaved form edits. Covers three exit
+// paths because each one fires a different browser event:
+//
+//   1. beforeunload — full reload, tab close, navigation to an external
+//      URL. Browser shows its own generic prompt; our message is ignored
+//      (browsers stripped custom messages years ago).
+//   2. click on an <a href> going to a different URL — Next.js <Link>
+//      uses history.pushState under the hood, which does NOT fire
+//      beforeunload. We intercept at the document level in capture phase
+//      so we beat Link's own click handler.
+//   3. browser back / forward — fires popstate, also without beforeunload.
+//      We seed a duplicate history entry on mount-while-dirty so popstate
+//      lands on the same URL; on confirm-cancel we push another duplicate
+//      to stay put.
+//
+// Pass `dirty=false` (or unmount the consumer) to disarm. Saving / closing
+// the form is responsible for resetting dirty; the hook only listens.
+export function useUnsavedChangesGuard(dirty: boolean): void {
+  useEffect(() => {
+    if (!dirty || typeof window === "undefined") return;
+
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Required for Chrome/Edge; the string is ignored by all modern browsers.
+      e.returnValue = "";
+    };
+
+    const onClickCapture = (e: MouseEvent) => {
+      // Only left-clicks without modifier keys (modifier-clicks open in a
+      // new tab — the original page stays dirty, no prompt needed).
+      if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      const anchor = (e.target as HTMLElement | null)?.closest?.("a[href]");
+      if (!anchor) return;
+      const href = anchor.getAttribute("href");
+      if (!href || href.startsWith("#") || href.startsWith("mailto:") || href.startsWith("tel:")) {
+        return;
+      }
+      let url: URL;
+      try {
+        url = new URL(href, window.location.href);
+      } catch {
+        return;
+      }
+      // Same-URL clicks (e.g. logo on the current page) aren't navigations.
+      if (url.href === window.location.href) return;
+      if (!window.confirm(MESSAGE)) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+      }
+    };
+
+    // Seed a duplicate history entry so the next "back" lands on the same
+    // URL we're already on — gives us a popstate to intercept. Pushing on
+    // each dirty→true transition is acceptable for an admin tool; the
+    // back stack may carry a few extra entries per editing session.
+    window.history.pushState(null, "", window.location.href);
+    const onPopState = () => {
+      if (!window.confirm(MESSAGE)) {
+        window.history.pushState(null, "", window.location.href);
+      }
+    };
+
+    window.addEventListener("beforeunload", onBeforeUnload);
+    document.addEventListener("click", onClickCapture, true);
+    window.addEventListener("popstate", onPopState);
+    return () => {
+      window.removeEventListener("beforeunload", onBeforeUnload);
+      document.removeEventListener("click", onClickCapture, true);
+      window.removeEventListener("popstate", onPopState);
+    };
+  }, [dirty]);
+}

--- a/src/lib/hooks/use-unsaved-changes-guard.ts
+++ b/src/lib/hooks/use-unsaved-changes-guard.ts
@@ -4,6 +4,13 @@ import { useEffect } from "react";
 
 const MESSAGE = "You have unsaved changes — leave anyway?";
 
+// Module-level set of events that have already been handled by any
+// instance of this hook. Prevents double-prompting when multiple guarded
+// forms are dirty simultaneously (e.g. inventory editor + units drawer
+// both registered): each listener checks-then-stamps the event so only
+// the first one prompts.
+const handledEvents = new WeakSet<Event>();
+
 // #129 — prompt before discarding unsaved form edits. Covers three exit
 // paths because each one fires a different browser event:
 //
@@ -19,6 +26,12 @@ const MESSAGE = "You have unsaved changes — leave anyway?";
 //      lands on the same URL; on confirm-cancel we push another duplicate
 //      to stay put.
 //
+// NOT guarded: programmatic `router.push(...)` calls — Next App Router
+// gives no hook to intercept those. Today no guarded form does that
+// while dirty; a future caller that does would silently bypass the
+// prompt. Add an explicit `if (dirty && !confirm(MESSAGE)) return;`
+// before the router.push if you hit that case.
+//
 // Pass `dirty=false` (or unmount the consumer) to disarm. Saving / closing
 // the form is responsible for resetting dirty; the hook only listens.
 export function useUnsavedChangesGuard(dirty: boolean): void {
@@ -32,37 +45,57 @@ export function useUnsavedChangesGuard(dirty: boolean): void {
     };
 
     const onClickCapture = (e: MouseEvent) => {
+      if (handledEvents.has(e)) return;
       // Only left-clicks without modifier keys (modifier-clicks open in a
       // new tab — the original page stays dirty, no prompt needed).
       if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
       const anchor = (e.target as HTMLElement | null)?.closest?.("a[href]");
       if (!anchor) return;
+      // target="_blank" opens a new tab — current page stays mounted +
+      // dirty, no prompt needed.
+      if (anchor.getAttribute("target") === "_blank") return;
       const href = anchor.getAttribute("href");
-      if (!href || href.startsWith("#") || href.startsWith("mailto:") || href.startsWith("tel:")) {
-        return;
-      }
+      if (!href || href.startsWith("#")) return;
+      // Non-http schemes (mailto:, tel:, sms:, etc.) are app hand-offs,
+      // not navigations. /admin/send's "Send" buttons use sms: deep links
+      // and must not prompt while the intro-note is dirty.
       let url: URL;
       try {
         url = new URL(href, window.location.href);
       } catch {
         return;
       }
+      if (url.protocol !== "http:" && url.protocol !== "https:") return;
       // Same-URL clicks (e.g. logo on the current page) aren't navigations.
       if (url.href === window.location.href) return;
+      handledEvents.add(e);
       if (!window.confirm(MESSAGE)) {
         e.preventDefault();
         e.stopImmediatePropagation();
       }
     };
 
-    // Seed a duplicate history entry so the next "back" lands on the same
-    // URL we're already on — gives us a popstate to intercept. Pushing on
-    // each dirty→true transition is acceptable for an admin tool; the
-    // back stack may carry a few extra entries per editing session.
-    window.history.pushState(null, "", window.location.href);
-    const onPopState = () => {
+    // Seed a duplicate history entry so the next "back" lands on the
+    // same URL — gives us a popstate to intercept. We re-use Next's
+    // own state object (not a sentinel) because pushing a string state
+    // makes the Next App Router fail to render on the next nav: the
+    // router calls methods on `history.state` and explodes when it
+    // finds a string. Trade-off: we can't sentinel-check, so a re-mount
+    // or rapid dirty toggle lays down extra duplicates. The back-stack
+    // grows by a few entries per editing session — acceptable for an
+    // admin tool.
+    //
+    // Known cost: we don't pop the seed on cleanup, so after a clean
+    // save the user's first browser-back press silently lands on the
+    // same URL (the seed), and the second press actually navigates.
+    // Popping in cleanup would race with the popstate that triggered
+    // the cleanup in the first place; documented as admin tool tax.
+    window.history.pushState(window.history.state, "", window.location.href);
+    const onPopState = (e: PopStateEvent) => {
+      if (handledEvents.has(e)) return;
+      handledEvents.add(e);
       if (!window.confirm(MESSAGE)) {
-        window.history.pushState(null, "", window.location.href);
+        window.history.pushState(window.history.state, "", window.location.href);
       }
     };
 

--- a/tests/admin-customers.spec.ts
+++ b/tests/admin-customers.spec.ts
@@ -249,10 +249,11 @@ test.describe("admin customers", () => {
 
   // #129 — drawer is the most complex consumer of the unsaved-changes
   // guard (dirty is derived via JSON stringification). The drawer's
-  // scrim/X/Cancel/Escape are NOT navigations, so the hook's click and
-  // popstate listeners don't catch them — the drawer wraps onClose to
-  // prompt explicitly when dirty. Smoke-test the scrim path.
-  test("unsaved-changes guard: editing the drawer prompts on close", async ({ page }) => {
+  // scrim/X/Escape are NOT navigations, so the hook's click and popstate
+  // listeners don't catch them — the drawer wraps onClose to prompt
+  // explicitly when dirty. The Cancel button is the explicit "discard"
+  // affordance and intentionally skips the prompt. Smoke-test both paths.
+  test("unsaved-changes guard: scrim prompts, Cancel does not", async ({ page }) => {
     await page.goto("/admin/customers");
     const row = rowByName(page, TEST_CUSTOMERS.farmStand.name);
     await row.click();
@@ -261,16 +262,22 @@ test.describe("admin customers", () => {
     // Type into Phone — drawer is now dirty.
     await drawer(page).getByLabel(/phone/i).fill("216-555-0900");
 
-    // Cancel button uses the same tryClose path as scrim/X/Escape.
+    // Scrim click prompts; dismiss → drawer stays open.
     const dismissPrompt = (dialog: import("@playwright/test").Dialog) => dialog.dismiss();
     page.on("dialog", dismissPrompt);
-    await drawer(page).getByRole("button", { name: /^cancel$/i }).click();
+    await page.locator(".drawer-scrim").click();
     await expect(drawer(page)).toBeVisible();
     page.off("dialog", dismissPrompt);
 
-    // Save clears dirty; close is silent.
-    await drawer(page).getByRole("button", { name: /save changes/i }).click();
+    // Cancel button skips the prompt — explicit discard.
+    const failOnPrompt = (dialog: import("@playwright/test").Dialog) => {
+      throw new Error(`Cancel must not prompt: ${dialog.message()}`);
+    };
+    page.on("dialog", failOnPrompt);
+    await drawer(page).getByRole("button", { name: /^cancel$/i }).click();
     await expect(drawer(page)).toHaveCount(0);
-    // resetTestCustomers (next test's beforeEach) clears the phone edit.
+    page.off("dialog", failOnPrompt);
+    // resetTestCustomers (next test's beforeEach) is the safety net — but
+    // Cancel didn't persist so the row's original phone is intact already.
   });
 });

--- a/tests/admin-customers.spec.ts
+++ b/tests/admin-customers.spec.ts
@@ -246,4 +246,31 @@ test.describe("admin customers", () => {
     await expect(rowByName(page, TEST_CUSTOMERS.restaurant.name)).not.toHaveClass(/is-inactive/);
     await expect(page.getByRole("button", { name: /show deactivated/i })).toHaveCount(0);
   });
+
+  // #129 — drawer is the most complex consumer of the unsaved-changes
+  // guard (dirty is derived via JSON stringification). The drawer's
+  // scrim/X/Cancel/Escape are NOT navigations, so the hook's click and
+  // popstate listeners don't catch them — the drawer wraps onClose to
+  // prompt explicitly when dirty. Smoke-test the scrim path.
+  test("unsaved-changes guard: editing the drawer prompts on close", async ({ page }) => {
+    await page.goto("/admin/customers");
+    const row = rowByName(page, TEST_CUSTOMERS.farmStand.name);
+    await row.click();
+    await expect(drawer(page)).toBeVisible();
+
+    // Type into Phone — drawer is now dirty.
+    await drawer(page).getByLabel(/phone/i).fill("216-555-0900");
+
+    // Cancel button uses the same tryClose path as scrim/X/Escape.
+    const dismissPrompt = (dialog: import("@playwright/test").Dialog) => dialog.dismiss();
+    page.on("dialog", dismissPrompt);
+    await drawer(page).getByRole("button", { name: /^cancel$/i }).click();
+    await expect(drawer(page)).toBeVisible();
+    page.off("dialog", dismissPrompt);
+
+    // Save clears dirty; close is silent.
+    await drawer(page).getByRole("button", { name: /save changes/i }).click();
+    await expect(drawer(page)).toHaveCount(0);
+    // resetTestCustomers (next test's beforeEach) clears the phone edit.
+  });
 });

--- a/tests/admin-inventory.spec.ts
+++ b/tests/admin-inventory.spec.ts
@@ -143,6 +143,45 @@ test.describe("admin inventory", () => {
     await page.reload();
     await expect(rowByName(page, "Test Carrots")).toHaveCount(0);
   });
+
+  // #129 — guard fires on in-app navigation when the form is dirty;
+  // saving clears dirty so the next nav is silent. Native beforeunload
+  // can't be triggered without leaving the page in Playwright, but the
+  // click-capture path uses window.confirm(), interceptable via
+  // page.on("dialog").
+  test("unsaved-changes guard: confirm prompt fires on sidebar nav, save clears it", async ({ page }) => {
+    await page.goto("/admin/inventory");
+
+    const kale = rowByName(page, TEST_PRODUCTS.kale.name);
+    await kale.getByRole("spinbutton", { name: /quantity/i }).fill("17");
+    await expect(saveButton(page, 1)).toBeEnabled();
+
+    const dismissPrompt = (dialog: import("@playwright/test").Dialog) => dialog.dismiss();
+    page.on("dialog", dismissPrompt);
+    await page.locator(".admin-nav").getByRole("link", { name: /customers/i }).click();
+    await expect(page).toHaveURL(/\/admin\/inventory/);
+    page.off("dialog", dismissPrompt);
+
+    // Save → dirty resets → next nav is silent.
+    await saveButton(page, 1).click();
+    await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
+
+    const failOnPrompt = (dialog: import("@playwright/test").Dialog) => {
+      throw new Error(`Unexpected dialog after save: ${dialog.message()}`);
+    };
+    page.on("dialog", failOnPrompt);
+    await page.locator(".admin-nav").getByRole("link", { name: /customers/i }).click();
+    await expect(page).toHaveURL(/\/admin\/customers/);
+    page.off("dialog", failOnPrompt);
+
+    // Restore baseline qty for downstream specs.
+    await page.goto("/admin/inventory");
+    await rowByName(page, TEST_PRODUCTS.kale.name)
+      .getByRole("spinbutton", { name: /quantity/i })
+      .fill(String(TEST_PRODUCTS.kale.qty_available));
+    await saveButton(page, 1).click();
+    await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
+  });
 });
 
 test.describe("admin inventory — open-for-orders meta pill", () => {


### PR DESCRIPTION
## Summary

Four admin forms now prompt "You have unsaved changes — leave anyway?" before discarding mid-edit input. Annabel hit this in UAT — typed a customer edit, clicked the sidebar, lost the input silently.

## Files changed

- \`src/lib/hooks/use-unsaved-changes-guard.ts\` — new hook covering three browser events (beforeunload, document click capture on \`<a href>\`, popstate); module-level WeakSet dedupes events across concurrent consumers
- \`src/components/admin/customer-drawer.tsx\` — compute dirty via JSON stringification; \`tryClose\` wrapper prompts on scrim/X/Cancel/Escape
- \`src/components/admin/inventory-editor.tsx\` — wire hook with existing \`dirty\`
- \`src/components/admin/intro-note-card.tsx\` — wire hook with existing \`dirty\`
- \`src/components/admin/units-drawer.tsx\` — wire hook + \`tryClose\` wrapper
- \`tests/admin-inventory.spec.ts\` — sidebar-nav prompt + post-save silence
- \`tests/admin-customers.spec.ts\` — drawer scrim/Cancel prompt + post-save silence

## Code review

Findings from \`@code-review\` (medium effort). All addressed in commit \`d98177e\`:

- **bug** — \`sms:\` scheme not in the skip list; would have spurious-prompted Annabel on every \`/admin/send\` send-button click while the intro note was dirty. Now any non-http(s) scheme passes through unguarded.
- **bug** — \`target="_blank"\` clicks open a new tab so the current page stays dirty; was prompting. Latent today (no admin anchors use \`_blank\`), preemptively fixed.
- **bug** — concurrent guards (inventory editor + units drawer both dirty) double-prompted. Module-level \`WeakSet\` deduplicates events across instances.
- **bug** — Pushing a sentinel-string \`history.state\` crashed the Next App Router on subsequent navigation (router calls methods on \`history.state\`). Now preserves Next's existing state object. Trade-off: lost the sentinel-based optimization; back-stack grows a few entries per editing session — admin-tool-tax, documented.
- **bug-extension** — scrim/X/Cancel/Escape don't navigate, so the hook's click+popstate listeners don't catch them. Wrapped \`onClose\` in \`tryClose\` on both drawers to prompt explicitly (the scrim was the most common close gesture in practice).

Issue mentions an "alert template editor" on \`/admin/send\`; that doesn't exist in code (only the intro note is editable). Customer-facing \`/c/[token]\` is explicitly out of scope per the issue. Programmatic \`router.push(...)\` isn't intercepted (Next App Router gives no hook for it) — none of the four guarded forms call it while dirty today; a future caller should add an inline \`!confirm()\` check.

## Test plan

- [ ] \`npx playwright test tests/admin-inventory.spec.ts tests/admin-customers.spec.ts tests/admin-send.spec.ts tests/admin-inventory-units.spec.ts --project=desktop\` — 30/30 locally
- [ ] On preview \`/admin/inventory\`: edit a qty → click sidebar Customers → browser shows confirm dialog → Cancel → still on inventory. Save → click sidebar → silent.
- [ ] On preview \`/admin/customers\`: open drawer, edit Phone → click scrim or Cancel → prompt. Save → close → silent. Open drawer, edit, hit Escape → prompt.
- [ ] On preview \`/admin/send\`: type into intro note → click sidebar → prompt. **Critical:** type into intro note → click an SMS Send button → no prompt (the regression that almost shipped).
- [ ] On preview \`/admin/inventory\` → open Units drawer → edit a unit row → click scrim → prompt.
- [ ] Browser back with any of the above dirty → prompt (popstate path).

closes #129