### PR TITLE
auto-sync downstream — 2026-05-26

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Roles:
 ## Key Docs
 
 | File | Purpose |
-|------|---------|
+|------|-------|
 | `docs/SPEC.md` | What we're building — scope, V1 vs V1.5 vs V2 |
 | `docs/DECISIONS.md` | Architectural decisions (DEC-001…DEC-032) |
 | `docs/SCHEMA.md` | Finalized table shapes; gates migrations + RLS |
@@ -95,7 +95,7 @@ Schema details land in Phase 1.1 (sketched in plan; finalize at execution).
 Bushel runs against **two Supabase projects** under the bushel-billed org:
 
 | Role | Project ref | Used by |
-|------|------------|---------|
+|------|------------|-------|
 | dev/preview | `nnmfubmlvnkouxxfxxlh` | `.env.local`, Vercel Development + Preview environments, local Playwright runs |
 | production | `piaobrnrmoxnfrpnpixw` | Vercel Production environment only — `order.baybranchfarm.com` |
 
@@ -271,10 +271,12 @@ npx supabase gen types typescript --local > src/lib/supabase/types.ts
 
 **Dev identity:** `~/.claude/devname` (one-line file with handle, e.g. `eric`). Set once per machine.
 
+**Task model:** PROJECT_PLAN.md is read at planning, written at retro. Untouched mid-phase. Current-phase tasks live as GitHub Issues. The phase ends when its issues close.
+
 ## Agents
 
 | Agent | Model | When | Purpose |
-|-------|-------|------|---------|
+|-------|-------|------|-------|
 | @architect | Opus | Before design decisions, new dependencies, scope creep | Coherence vs SPEC + DECISIONS |
 | @code-review | Sonnet | After every commit (wired into `/kill-this`) | Catch issues early |
 | @pm | Sonnet | Start/end of sessions via skills | Track progress, flag risks |


### PR DESCRIPTION
## sync-config pull: seeds → bushel (seeds v3, 2026-05-26)

**Direction:** pull (seeds → project) | **Mode:** auto | **Seeds HEAD:** f5b8e3f2855cabeb01ec05c42834bedfe7b5c781

### Classification table

| File | Hunk | Provenance | Classification | Action |
|------|------|------------|----------------|--------|
| `CLAUDE.md` | `**Task model:**` paragraph (after Dev identity in Session Skills) | Template-only | Forward-port | Forward-ported — paragraph added |

### Files changed

- `CLAUDE.md` — added `**Task model:**` paragraph after `**Dev identity:**` in the Session Skills section

### Change detail

Seeds template has this paragraph immediately after `**Dev identity:**`:

> **Task model:** PROJECT_PLAN.md is read at planning, written at retro. Untouched mid-phase. Current-phase tasks live as GitHub Issues. The phase ends when its issues close.

Bushel was missing this paragraph — the section jumped directly from Dev identity to `## Agents`. Insertion point is unambiguous and non-conflicting.

### Step 6 — Skip summary

- All 13 skills (logic class): hash-equal — no action
- `agents/sync-config.md`, `agents/tape-reader.md` (logic): hash-equal — no action
- `agents/doc-consistency.md`, `agents/pm.md`: hash-equal (SHA 78730af2, dc9853aa) — no action
- `agents/architect.md`, `agents/code-review.md`: hash-equal — no action
- `agents/ui-reviewer.md`: diffs are `[Project]` → project-name substitutions (Project-only); structural content identical — skip
- `CLAUDE.md` — `### Production write protection`: seeds has `safe-supabase.sh` wrapper; bushel uses two-project split — architecturally diverged, skip
- `CLAUDE.md` — PR Workflow mobile section, Workflow Notes: Both-modified — skip per mode:auto

### Duplicate-PR check (Step 1.5)

One open PR (#172, unsaved-changes guard on admin forms). No overlap with `.claude/` or `CLAUDE.md`.

### Base: main

No staging branch in this repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtbfwKysN96KzEpJZZvBhy)_