### PR TITLE
Inventory qty input: accept fractional values

### DIFF
--- a/design/admin-inventory.jsx
+++ b/design/admin-inventory.jsx
@@ -345,7 +345,7 @@ function InventoryRow({
             value={row.qty}
             onChange={e => {
               const v = parseFloat(e.target.value);
-              onUpdate({ qty: Number.isFinite(v) && v >= 0 ? Math.round(v * 100) / 100 : 0 });
+              onUpdate({ qty: Number.isFinite(v) ? Math.round(v * 100) / 100 : 0 });
             }}
           />
         </td>

--- a/design/admin-inventory.jsx
+++ b/design/admin-inventory.jsx
@@ -339,11 +339,14 @@ function InventoryRow({
         </td>
         <td className="col-qty">
           <input
-            type="number"
-            min="0"
+            type="text"
+            inputMode="decimal"
             className={"inv-cell inv-num" + (row.qty === 0 ? " is-zero" : row.qty <= 3 ? " is-low" : "")}
             value={row.qty}
-            onChange={e => onUpdate({ qty: parseInt(e.target.value) || 0 })}
+            onChange={e => {
+              const v = parseFloat(e.target.value);
+              onUpdate({ qty: Number.isFinite(v) && v >= 0 ? Math.round(v * 100) / 100 : 0 });
+            }}
           />
         </td>
         <td className="col-avail">

--- a/src/actions/save-inventory.ts
+++ b/src/actions/save-inventory.ts
@@ -40,8 +40,10 @@ function validateRow(row: InventoryRowInput, index: number): string | null {
   }
   // qty allows negatives — DEC-012 optimistic oversell. Admin must be able
   // to record an oversold state by direct entry, not only via order placement.
-  if (!Number.isInteger(row.qty_available)) {
-    return `Row ${index + 1}: qty must be a whole number.`;
+  // Fractions are allowed: multi-unit decrement (qty * conversion_to_base)
+  // produces non-integer remainders, and products.qty_available is numeric(10,2).
+  if (!Number.isFinite(row.qty_available)) {
+    return `Row ${index + 1}: qty must be a number.`;
   }
   return null;
 }
@@ -69,7 +71,7 @@ export async function saveInventory(input: SaveInventoryInput): Promise<SaveInve
       description: row.description?.trim() || null,
       unit: row.unit.trim(),
       price_cents: row.price_cents,
-      qty_available: row.qty_available,
+      qty_available: Math.round(row.qty_available * 100) / 100,
       is_available: row.is_available,
       sort_order: row.sort_order,
       updated_at: now,

--- a/src/components/admin/inventory-row.tsx
+++ b/src/components/admin/inventory-row.tsx
@@ -227,7 +227,9 @@ export function InventoryRow({
               setQtyDraft(e.target.value);
               if (e.target.value.trim() === "") return; // don't zero on Backspace-to-empty
               const v = parseFloat(e.target.value);
-              if (Number.isFinite(v) && v >= 0) {
+              // Negatives allowed per DEC-012 (admin records oversold state by
+              // direct entry). Server validator agrees — Number.isFinite only.
+              if (Number.isFinite(v)) {
                 onUpdate({ qty_available: Math.round(v * 100) / 100 });
               }
             }}

--- a/src/components/admin/inventory-row.tsx
+++ b/src/components/admin/inventory-row.tsx
@@ -220,15 +220,15 @@ export function InventoryRow({
         <td>
           <input
             type="text"
-            inputMode="numeric"
+            inputMode="decimal"
             className={"field-input field-num" + qtyClass}
             value={qtyDraft ?? String(row.qty_available)}
             onChange={(e) => {
               setQtyDraft(e.target.value);
               if (e.target.value.trim() === "") return; // don't zero on Backspace-to-empty
-              const v = parseInt(e.target.value, 10);
+              const v = parseFloat(e.target.value);
               if (Number.isFinite(v) && v >= 0) {
-                onUpdate({ qty_available: v });
+                onUpdate({ qty_available: Math.round(v * 100) / 100 });
               }
             }}
             onBlur={() => setQtyDraft(null)}

--- a/tests/admin-inventory.spec.ts
+++ b/tests/admin-inventory.spec.ts
@@ -62,6 +62,27 @@ test.describe("admin inventory", () => {
     await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
   });
 
+  test("qty accepts fractional values (multi-unit decrement leaves fractions in products.qty_available)", async ({ page }) => {
+    await page.goto("/admin/inventory");
+
+    const kale = rowByName(page, TEST_PRODUCTS.kale.name);
+    await kale.getByRole("textbox", { name: /quantity/i }).fill("2.5");
+
+    await expect(saveButton(page, 1)).toBeEnabled();
+    await saveButton(page, 1).click();
+    await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
+
+    await page.reload();
+    await expect(rowByName(page, TEST_PRODUCTS.kale.name).getByRole("textbox", { name: /quantity/i })).toHaveValue("2.5");
+
+    // restore
+    await rowByName(page, TEST_PRODUCTS.kale.name)
+      .getByRole("textbox", { name: /quantity/i })
+      .fill(String(TEST_PRODUCTS.kale.qty_available));
+    await saveButton(page, 1).click();
+    await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
+  });
+
   test("availability switch toggles and saves", async ({ page }) => {
     await page.goto("/admin/inventory");
 


### PR DESCRIPTION
## Summary

`products.qty_available` is `numeric(10,2)` since the 6.5a multi-unit migration, and `place_order` decrements by `qty * conversion_to_base` — so a half-pound order legitimately leaves a fraction. The `/admin/inventory` QTY input was still `parseInt + inputMode=\"numeric\"`, silently stripping the fraction the moment Annabel touched the field. Flip to the same decimal draft pattern the units drawer already uses, round to 2dp on store (matches DB scale), and relax the server-side validator from `Number.isInteger` to `Number.isFinite` (with matching 2dp rounding for defense in depth). Also drops the client-side `v >= 0` guard on qty to align with the server's DEC-012 oversell intent — admin can now record an oversold state by direct entry.

## Files changed

- `design/admin-inventory.jsx`
- `src/actions/save-inventory.ts`
- `src/components/admin/inventory-row.tsx`
- `tests/admin-inventory.spec.ts`

## Code review

One real consistency gap caught and addressed in `7238ce0`: client had `v >= 0` guard on qty while server validator (per DEC-012 comment) allows negatives for admin oversold entry. Removed the guard; client now mirrors server intent. Price + conversion in `units-drawer.tsx` keep their `>= 0` guards (negative price / conversion has no semantic meaning).

## Test plan

- [ ] `/admin/inventory` — type "2.5" into a row's QTY, click Save, reload page → value still "2.5"
- [ ] Same field accepts "0" and integer values unchanged
- [ ] Place a multi-unit order against the dev/preview env that produces a fractional `qty_available` → admin/inventory now displays + saves it without truncation
- [ ] Targeted Playwright run: `npx playwright test tests/admin-inventory.spec.ts --project=desktop` — all green