### PR TITLE
Order-detail oversold gate + Sold-this-week column on /admin/inventory

### DIFF
--- a/design/admin-inventory.css
+++ b/design/admin-inventory.css
@@ -96,6 +96,7 @@
 .col-price   { width: 110px; }
 .col-unit    { width: 130px; }
 .col-qty     { width: 80px; }
+.col-sold    { width: 80px; }
 .col-avail   { width: 90px; text-align: center; }
 .col-actions { width: 44px; text-align: right; padding-right: 12px !important; }
 
@@ -139,6 +140,11 @@
 }
 .inv-num.is-low { color: var(--gold-600, #E6A817); font-weight: 600; }
 .inv-num.is-zero { color: var(--ink-500); font-weight: 600; }
+
+/* Sold-this-week cell is read-only display — needs block layout to honor
+   right-align from inv-num. is-zero renders an em-dash. */
+.inv-sold { display: block; padding: 6px 10px; color: var(--ink-700); }
+.inv-sold.is-zero { color: var(--ink-400); }
 
 .inv-priceWrap {
   display: flex; align-items: center;

--- a/design/admin-inventory.jsx
+++ b/design/admin-inventory.jsx
@@ -152,6 +152,7 @@ function InventoryPage() {
               <th className="col-price">Price</th>
               <th className="col-unit">Unit</th>
               <th className="col-qty">Qty</th>
+              <th className="col-sold" title="Sold this week (base units)">Sold</th>
               <th className="col-avail">Available</th>
               <th className="col-actions"></th>
             </tr>
@@ -348,6 +349,15 @@ function InventoryRow({
               onUpdate({ qty: Number.isFinite(v) ? Math.round(v * 100) / 100 : 0 });
             }}
           />
+        </td>
+        <td className="col-sold">
+          <span className={"inv-num inv-sold" + ((row.sold ?? 0) === 0 ? " is-zero" : "")}>
+            {((row.sold ?? 0) === 0)
+              ? "—"
+              : Number.isInteger(row.sold)
+                ? row.sold
+                : Number(row.sold).toFixed(2).replace(/\.?0+$/, "")}
+          </span>
         </td>
         <td className="col-avail">
           <Switch checked={row.available} onChange={v => onUpdate({ available: v })}/>

--- a/design/admin-inventory.jsx
+++ b/design/admin-inventory.jsx
@@ -48,6 +48,12 @@ function newUnitId() { return "u" + String(nextUnitId++); }
 let nextId = 11;
 function newRowId() { return "p" + String(nextId++).padStart(2, "0"); }
 
+function fmtSold(n) {
+  if (n === 0) return "—";
+  if (Number.isInteger(n)) return String(n);
+  return Number(n).toFixed(2).replace(/\.?0+$/, "");
+}
+
 function InventoryPage() {
   const [rows, setRows] = useState(SEED_ROWS);
   const [originalRows] = useState(SEED_ROWS);
@@ -352,11 +358,7 @@ function InventoryRow({
         </td>
         <td className="col-sold">
           <span className={"inv-num inv-sold" + ((row.sold ?? 0) === 0 ? " is-zero" : "")}>
-            {((row.sold ?? 0) === 0)
-              ? "—"
-              : Number.isInteger(row.sold)
-                ? row.sold
-                : Number(row.sold).toFixed(2).replace(/\.?0+$/, "")}
+            {fmtSold(row.sold ?? 0)}
           </span>
         </td>
         <td className="col-avail">

--- a/src/app/(admin)/admin/inventory/page.tsx
+++ b/src/app/(admin)/admin/inventory/page.tsx
@@ -36,6 +36,9 @@ export default async function InventoryPage() {
     // than via PostgREST RPC because the multi-unit join (qty * conversion)
     // pushes us past what `.select(..., count: "exact")` can express. Volume
     // is small — single-digit customers × handful of items per order.
+    // No `orders.status` filter today — there's no cancellation flow in V1.
+    // If one lands (DEC-012 reconciliation could grow one), add the filter
+    // here so cancelled items don't count as sold.
     supabase
       .from("order_items")
       .select("product_id, qty, product_units(conversion_to_base), orders!inner(week_of)")

--- a/src/app/(admin)/admin/inventory/page.tsx
+++ b/src/app/(admin)/admin/inventory/page.tsx
@@ -7,7 +7,7 @@ import { weekOfLabel, weekOfMondayNY } from "@/lib/week";
 export default async function InventoryPage() {
   const supabase = await createClient();
   const weekOf = weekOfMondayNY();
-  const [productsRes, unitsRes, scheduleRes, subscribedCustomersRes, weekOrdersRes] = await Promise.all([
+  const [productsRes, unitsRes, scheduleRes, subscribedCustomersRes, weekOrdersRes, weekItemsRes] = await Promise.all([
     supabase
       .from("products")
       .select("*")
@@ -32,6 +32,14 @@ export default async function InventoryPage() {
       .from("orders")
       .select("customer_id", { count: "exact", head: true })
       .eq("week_of", weekOf),
+    // Sold-this-week per product (base units). Aggregated client-side rather
+    // than via PostgREST RPC because the multi-unit join (qty * conversion)
+    // pushes us past what `.select(..., count: "exact")` can express. Volume
+    // is small — single-digit customers × handful of items per order.
+    supabase
+      .from("order_items")
+      .select("product_id, qty, product_units(conversion_to_base), orders!inner(week_of)")
+      .eq("orders.week_of", weekOf),
   ]);
 
   // Every query is load-bearing for the pills / table — failing silently on
@@ -42,7 +50,8 @@ export default async function InventoryPage() {
     unitsRes.error ??
     scheduleRes.error ??
     subscribedCustomersRes.error ??
-    weekOrdersRes.error;
+    weekOrdersRes.error ??
+    weekItemsRes.error;
   if (firstError || !scheduleRes.data) {
     return (
       <main style={{ padding: "28px 32px", maxWidth: 1200 }}>
@@ -80,6 +89,20 @@ export default async function InventoryPage() {
     });
   }
 
+  // Sold this week per product, in base units (qty * conversion_to_base).
+  // Falls back to conv=1 when product_units join is absent — pre-6.5a data
+  // had no unit row attached; the 6.5a safety-net trigger now fills it on
+  // insert, but historical rows remain.
+  const soldByProductId: Record<string, number> = {};
+  for (const row of (weekItemsRes.data ?? []) as Array<{
+    product_id: string;
+    qty: number;
+    product_units: { conversion_to_base: number } | null;
+  }>) {
+    const conv = Number(row.product_units?.conversion_to_base ?? 1);
+    soldByProductId[row.product_id] = (soldByProductId[row.product_id] ?? 0) + row.qty * conv;
+  }
+
   const initialRows: InventoryRowState[] = (productsRes.data ?? []).map((p) => ({
     id: p.id,
     name: p.name,
@@ -97,6 +120,7 @@ export default async function InventoryPage() {
       <InventoryEditor
         initialRows={initialRows}
         initialUnits={unitsByProductId}
+        soldByProductId={soldByProductId}
         weekLabel={weekOfLabel()}
         schedule={schedule}
         customerStats={customerStats}

--- a/src/components/admin/inventory-editor.tsx
+++ b/src/components/admin/inventory-editor.tsx
@@ -30,6 +30,7 @@ export type CustomerStats = {
 type Props = {
   initialRows: InventoryRowState[];
   initialUnits: Record<string, ProductUnitState[]>;
+  soldByProductId: Record<string, number>;
   weekLabel: string;
   schedule: ScheduleSummary;
   customerStats: CustomerStats;
@@ -51,7 +52,7 @@ function newLocalId(): string {
   return `new-${Date.now()}-${nextLocalId++}`;
 }
 
-export function InventoryEditor({ initialRows, initialUnits, weekLabel, schedule, customerStats }: Props) {
+export function InventoryEditor({ initialRows, initialUnits, soldByProductId, weekLabel, schedule, customerStats }: Props) {
   const scheduleDescription = describeSchedule(schedule);
   const router = useRouter();
   const [rows, setRows] = useState<InventoryRowState[]>(initialRows);
@@ -285,6 +286,7 @@ export function InventoryEditor({ initialRows, initialUnits, weekLabel, schedule
               <th style={{ width: 110 }}>Price</th>
               <th style={{ width: 130 }}>Unit</th>
               <th style={{ width: 80 }}>Qty</th>
+              <th style={{ width: 80 }} title="Sold this week (base units)">Sold</th>
               <th style={{ width: 90, textAlign: "center" }}>Available</th>
               <th className="row-actions"></th>
             </tr>
@@ -298,6 +300,7 @@ export function InventoryEditor({ initialRows, initialUnits, weekLabel, schedule
                   row={row}
                   unitsCount={units.length}
                   inactiveExtrasCount={Math.max(0, units.filter((u) => !u.is_active).length)}
+                  soldThisWeek={soldByProductId[row.id] ?? 0}
                   onUpdate={(patch) => update(row.id, patch)}
                   onRemove={() => remove(row.id)}
                   onOpenUnits={row.isNew ? undefined : () => setUnitsOpenFor(row.id)}

--- a/src/components/admin/inventory-row.tsx
+++ b/src/components/admin/inventory-row.tsx
@@ -22,6 +22,7 @@ type Props = {
   row: InventoryRowState;
   unitsCount?: number;
   inactiveExtrasCount?: number;
+  soldThisWeek?: number;
   onUpdate: (patch: Partial<InventoryRowState>) => void;
   onRemove: () => void;
   onOpenUnits?: () => void;
@@ -40,10 +41,21 @@ function priceToString(cents: number): string {
   return (cents / 100).toFixed(2);
 }
 
+// Compact qty render for the Sold cell: integers as-is, fractions trimmed
+// to 2dp with trailing zeros removed ("1.5" not "1.50"). Mirrors the
+// fmtQty in order-detail.tsx — extract to a shared helper if a third
+// consumer appears.
+function fmtSold(n: number): string {
+  if (n === 0) return "—";
+  if (Number.isInteger(n)) return n.toString();
+  return n.toFixed(2).replace(/\.?0+$/, "");
+}
+
 export function InventoryRow({
   row,
   unitsCount = 1,
   inactiveExtrasCount = 0,
+  soldThisWeek = 0,
   onUpdate,
   onRemove,
   onOpenUnits,
@@ -236,6 +248,15 @@ export function InventoryRow({
             onBlur={() => setQtyDraft(null)}
             aria-label="Quantity available"
           />
+        </td>
+        <td>
+          <span
+            className={"field-num field-sold" + (soldThisWeek === 0 ? " is-zero" : "")}
+            aria-label="Sold this week"
+            data-sold-this-week={soldThisWeek}
+          >
+            {fmtSold(soldThisWeek)}
+          </span>
         </td>
         <td style={{ width: 90, textAlign: "center" }}>
           <Switch

--- a/src/components/admin/order-detail.tsx
+++ b/src/components/admin/order-detail.tsx
@@ -27,8 +27,16 @@ export function OrderDetail({ order }: { order: OrderRowData }) {
               // Display is framed in the selected unit (matches the line's
               // qty + unitLabel) so the message reads as a single coherent
               // statement: "2× · lb / Only 0.5 lb available — 1.5 lb oversold".
+              //
+              // Gate on order.needsReconciliation. qtyAvailable is the current
+              // (post-decrement) inventory read at list-load time, so once a
+              // product hits zero every prior order that touched it would
+              // light up as "oversold" without this gate — even orders that
+              // fit at placement. needs_reconciliation is set by place_order
+              // only on the order that actually pushed qty_available negative,
+              // so it's the order-time truth signal.
               const baseRequested = i.qty * i.conversionToBase;
-              const oversold = baseRequested > i.qtyAvailable;
+              const oversold = order.needsReconciliation && baseRequested > i.qtyAvailable;
               // Clamp available to ≥ 0. Under DEC-012's optimistic decrement,
               // qty_available is allowed to go negative after a runaway order —
               // showing "Only -1.5 lb available" is nonsensical to Annabel.

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -259,6 +259,11 @@
 }
 .field-num.is-low { color: var(--amber-600); font-weight: 600; }
 .field-num.is-zero { color: var(--ink-500); font-weight: 600; }
+/* Sold-this-week cell is a read-only display, not an input — needs block
+   layout to inherit field-num right-align. is-zero renders an em-dash via
+   fmtSold(0), and the dim color makes the empty rows recede. */
+.field-sold { display: block; padding: 6px 10px; color: var(--ink-700); }
+.field-sold.is-zero { color: var(--ink-400); }
 
 .field-price {
   display: flex; align-items: center;

--- a/tests/admin-inventory.spec.ts
+++ b/tests/admin-inventory.spec.ts
@@ -2,9 +2,13 @@ import { test, expect, type Page } from "@playwright/test";
 import {
   ADMIN_STORAGE_STATE,
   TEST_PRODUCTS,
+  clearOrdersForWeek,
+  customerIds,
   resetProductSortOrder,
+  seedOrder,
   setOrderingSchedule,
 } from "./helpers";
+import { weekOfMondayNY } from "@/lib/week";
 
 function rowByName(page: Page, name: string) {
   return page.locator(`tr[data-row-name="${name}"]`);
@@ -81,6 +85,47 @@ test.describe("admin inventory", () => {
       .fill(String(TEST_PRODUCTS.kale.qty_available));
     await saveButton(page, 1).click();
     await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
+  });
+
+  test("Sold column renders this week's base-unit total per product", async ({ page }) => {
+    const thisWeek = weekOfMondayNY();
+    try {
+      const ids = await customerIds();
+      // farmStand orders 2 kale, restaurant orders 1 kale + 1 honey. Kale's
+      // base unit has conv=1 (safety-net trigger seeds it), so the column
+      // shows raw qty sums: 3 kale, 1 honey, "—" for eggs and the rest.
+      await seedOrder({
+        customerId: ids.farmStand,
+        weekOf: thisWeek,
+        fulfillmentType: "pickup",
+        items: [{ productId: TEST_PRODUCTS.kale.id, qty: 2, unitPriceCents: 300 }],
+      });
+      await seedOrder({
+        customerId: ids.restaurant,
+        weekOf: thisWeek,
+        fulfillmentType: "delivery",
+        items: [
+          { productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 },
+          { productId: TEST_PRODUCTS.honey.id, qty: 1, unitPriceCents: 1200 },
+        ],
+      });
+
+      await page.goto("/admin/inventory");
+
+      const kaleSold = rowByName(page, TEST_PRODUCTS.kale.name).locator(".field-sold");
+      await expect(kaleSold).toHaveAttribute("data-sold-this-week", "3");
+      await expect(kaleSold).toHaveText("3");
+
+      const honeySold = rowByName(page, TEST_PRODUCTS.honey.name).locator(".field-sold");
+      await expect(honeySold).toHaveText("1");
+
+      // Eggs untouched — em-dash.
+      const eggsSold = rowByName(page, TEST_PRODUCTS.eggs.name).locator(".field-sold");
+      await expect(eggsSold).toHaveText("—");
+      await expect(eggsSold).toHaveClass(/is-zero/);
+    } finally {
+      await clearOrdersForWeek(thisWeek);
+    }
   });
 
   test("availability switch toggles and saves", async ({ page }) => {

--- a/tests/admin-orders.spec.ts
+++ b/tests/admin-orders.spec.ts
@@ -8,6 +8,7 @@ import {
   customerIds,
   clearOrdersForWeek,
   seedOrder,
+  setProductQty,
 } from "./helpers";
 import { weekOfMondayNY } from "@/lib/week";
 
@@ -220,6 +221,55 @@ test.describe("admin orders list", () => {
     const detail = page.locator("tr.ord-detail-row .ord-detail");
     await expect(detail).toBeVisible();
     await expect(detail.locator(".ord-li-name")).toContainText("Honey");
+  });
+
+  test("line-level oversold badge gates on order.needsReconciliation (orders that fit at placement stay clean once inventory hits zero)", async ({ page }) => {
+    const ids = await customerIds();
+    // Simulate the post-decrement steady state Annabel sees once Kale is sold
+    // out: qty_available=0 on the product, two orders in the system — one
+    // that fit at placement (needs_reconciliation=false) and one that
+    // overshot (needs_reconciliation=true). Pre-fix, both would flag every
+    // line as "oversold" because qty > 0 (current) is true for both.
+    try {
+      await setProductQty(TEST_PRODUCTS.kale.id, 0);
+
+      const orderFit = await seedOrder({
+        customerId: ids.farmStand,
+        weekOf: thisWeek,
+        fulfillmentType: "pickup",
+        // Default needsReconciliation=false — this order fit when placed.
+        items: [{ productId: TEST_PRODUCTS.kale.id, qty: 2, unitPriceCents: 300 }],
+      });
+      const orderOvershoot = await seedOrder({
+        customerId: ids.restaurant,
+        weekOf: thisWeek,
+        fulfillmentType: "delivery",
+        needsReconciliation: true,
+        items: [{ productId: TEST_PRODUCTS.kale.id, qty: 3, unitPriceCents: 300 }],
+      });
+
+      await page.goto("/admin/orders");
+
+      // Only one row expands at a time (orders-page tracks a single `expanded`
+      // id), so check each detail in turn. Click the customer-name cell —
+      // bare-row clicks can land on the status column which stops propagation.
+
+      // The fit order: no per-line oversold marker, no order-level callout.
+      await page.locator(`tr.ord-row[data-order-id="${orderFit}"] .ord-cust-name`).click();
+      const fitDetail = page.locator("tr.ord-detail-row .ord-detail");
+      await expect(fitDetail).toBeVisible();
+      await expect(fitDetail.locator("li.is-oversold")).toHaveCount(0);
+      await expect(fitDetail.locator(".callout-warn")).toHaveCount(0);
+
+      // The overshoot order: line marker + order-level callout both present.
+      await page.locator(`tr.ord-row[data-order-id="${orderOvershoot}"] .ord-cust-name`).click();
+      const overDetail = page.locator("tr.ord-detail-row .ord-detail");
+      await expect(overDetail).toBeVisible();
+      await expect(overDetail.locator("li.is-oversold")).toHaveCount(1);
+      await expect(overDetail.locator(".callout-warn")).toBeVisible();
+    } finally {
+      await setProductQty(TEST_PRODUCTS.kale.id, TEST_PRODUCTS.kale.qty_available);
+    }
   });
 
   test("expand row reveals line items, customer note, and reconciliation callout", async ({ page }) => {


### PR DESCRIPTION
Stacked on #177 — base auto-retargets to `main` once that PR merges.

## Summary

Two changes bundled.

### 1. Order-detail oversold gate (bug fix)

`src/components/admin/order-detail.tsx` was computing per-line `oversold = baseRequested > i.qtyAvailable` where `i.qtyAvailable` is the **current** (post-decrement) product qty read at list-load. Once a product hit zero, every prior order touching it lit up red — even orders that legitimately fit at placement. The order-time truth signal already lives in `orders.needs_reconciliation` (set by `place_order` only on the order whose decrement pushed `qty_available` negative). Gate the per-line check with it: line marker now only shows on orders that actually overshot.

### 2. Sold-this-week column on /admin/inventory

New 6th parallel query in the inventory server component sums `qty * conversion_to_base` per product across the current week's `order_items` (aggregated client-side because the multi-unit join pushes past PostgREST's `count: exact`). Renders as a new `Sold` column between Qty and Available, with em-dash on zero so untouched rows recede. Volume is small (≤7 customers × handful of items), so client-side aggregation is fine.

Mobile redesign of /admin/inventory is its own future task — this column is sized for desktop. Existing column widths untouched.

## Files changed

- `design/admin-inventory.css`
- `design/admin-inventory.jsx`
- `src/app/(admin)/admin/inventory/page.tsx`
- `src/components/admin/inventory-editor.tsx`
- `src/components/admin/inventory-row.tsx`
- `src/components/admin/order-detail.tsx`
- `src/styles/app.css`
- `tests/admin-inventory.spec.ts`
- `tests/admin-orders.spec.ts`

## Code review

One latent mockup typo and one optional comment addressed in `ecce85c`:
- design/admin-inventory.jsx had an inline formatter that would have produced \"10.\" (trailing dot) for `10.00` inputs. Shipped code's `Number.isInteger` short-circuit avoids it, but the mockup would have misled the next copy-paste. Extracted to a `fmtSold` helper that matches the shipped code.
- Added a one-liner note on the new `order_items` query: if order cancellation lands (DEC-012 reconciliation could grow one), filter `orders.status` here so cancelled items don't count as sold.

Everything else clean. Server-component error short-circuit covers the new query; no `any`; CSS lives in `src/styles/app.css` only; no new RLS surface.

## Test plan

- [ ] `/admin/orders` — seed two kale orders on a 0-qty kale product, one with `needs_reconciliation=false` and one true → expand both → only the flagged one shows the `li.is-oversold` line marker + `.callout-warn` callout
- [ ] `/admin/inventory` — place real orders against dev/preview env → Sold column shows the per-product base-unit totals; untouched rows show em-dash
- [ ] Targeted Playwright: `npx playwright test tests/admin-orders.spec.ts tests/admin-inventory.spec.ts --project=desktop` — 18/18 green
- [ ] Mobile (375px) regression check: existing admin-inventory mobile card-stack still renders without the Sold column breaking layout (column lives in the desktop table, mobile uses a different layout path)