### PR TITLE
auto-sync downstream — 2026-05-27

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -208,6 +208,9 @@ Slash commands manage session lifecycle. Time tracking is automatic.
 | /bump-major | — | Breaking change | Manual major version bump |
 | /promote-staging | — | Ship staging to prod | ff-merge `staging` → `main`, tag, push |
 | /doc-consistency-check | — | Mid-project, before phase boundaries | Invokes @doc-consistency; cross-refs `docs/*.md` + root `CLAUDE.md` |
+| /push-seeds | — | After workflow improvements | Backport project-side improvements to seeds templates |
+| /pull-seeds | — | After seeds gets new improvements | Pull template changes into this project |
+| /read-the-tape | — | After a session worth learning from | Audit session JSONL for anti-patterns |
 
 **Per-session files:** the workflow uses `sessions/YYYY-MM-DD-HHMM-<dev>-<slug>.md` (one file per session) instead of a single monolithic `session-log.md`. `<dev>` comes from `~/.claude/devname` (one-line file, falls back to `$USER`). The slug is derived from the branch name (`task/X-foo` → `X-foo`, `main` → `main`, etc.). The active JSONL transcript path is captured in the file's frontmatter for later `/read-the-tape` audits.
 


### PR DESCRIPTION
Automated downstream sync from seeds on 2026-05-27.

**Direction:** downstream (seeds → bushel)
**Mode:** auto

## Step 3 — Action rows

| File | Hunk | Provenance | Classification | Action |
|------|------|------------|----------------|--------|
| `docs/AGENTS.md` | 3 rows missing from Agent Summary table: `/push-seeds`, `/pull-seeds`, `/read-the-tape` | Template-only | Forward-port | Forward-ported |

## Step 6 — Summary

**Files updated:**
- `docs/AGENTS.md` — appended 3 missing skill rows to the Agent Summary table (`/push-seeds`, `/pull-seeds`, `/read-the-tape`).

**Skip summary:**
- Skipped (class:context, 5 files): docs/SPEC.md, docs/BRAND.md, docs/DECISIONS.md, docs/PROJECT_PLAN.md, docs/RETROSPECTIVES.md
- Skipped (logic, hash-equal, 3 files): dev/claude/skills/its-dead/SKILL.md, dev/claude/skills/retro/SKILL.md, dev/claude/agents/sync-config.md
- agents/architect.md, agents/code-review.md, agents/pm.md, agents/ui-reviewer.md, agents/sync-config.md, CLAUDE.md: all diffs are project-name substitutions (Bushel → [Project]) and stack-specific content — no structural backports found

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ta5UFJ9kn73HWdFvHB59XA)_