### PR TITLE
Customer order page: drop item thumbnail, add product description

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -76,7 +76,9 @@
       "Bash(kill 2777394 2777433)",
       "Bash(pkill -f \"next-server\")",
       "Bash(pkill -f next-server)",
-      "Bash(pkill -9 -f \"next-server\")"
+      "Bash(pkill -9 -f \"next-server\")",
+      "Bash(rm tests/_screenshot-temp.spec.ts)",
+      "Bash(kill 734383)"
     ]
   }
 }

--- a/design/order-page.css
+++ b/design/order-page.css
@@ -69,10 +69,10 @@
 }
 .item-row {
   display: grid;
-  grid-template-columns: 44px minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 12px;
-  /* Top-align so the name + meta + picker stack grows downward and the
-     stepper stays paired with the price. 6.5c restructure (#144). */
+  /* Top-align so the name + desc + meta + picker stack grows downward and
+     the stepper stays paired with the price. 6.5c restructure (#144). */
   align-items: start;
   padding: 12px 14px;
   border-top: 1px solid var(--ink-200);
@@ -80,26 +80,6 @@
 .item-row:first-child { border-top: 0; }
 .item-row.is-sold-out { background: var(--leaf-50); opacity: 0.78; }
 .item-row.is-sold-out .item-name { color: var(--ink-500); }
-
-.item-thumb {
-  width: 44px; height: 44px; border-radius: 8px;
-  background: var(--leaf-50);
-  border: 1px solid var(--leaf-100);
-  position: relative; overflow: hidden;
-  display: flex; align-items: center; justify-content: center;
-}
-.item-thumb-inner {
-  width: 100%; height: 100%;
-  background-image:
-    repeating-linear-gradient(
-      45deg,
-      transparent 0,
-      transparent 6px,
-      rgba(59,109,17,0.08) 6px,
-      rgba(59,109,17,0.08) 7px
-    );
-}
-.item-row.is-sold-out .item-thumb { opacity: 0.55; }
 
 .item-body {
   min-width: 0;
@@ -109,6 +89,13 @@
   font-weight: 600; font-size: 1rem; color: var(--ink-900);
   line-height: 1.25;
   /* Wraps freely now that price has moved below — closes #144. */
+  overflow-wrap: anywhere;
+}
+.item-desc {
+  font-weight: 400;
+  font-size: 0.82rem;
+  color: var(--ink-500);
+  line-height: 1.35;
   overflow-wrap: anywhere;
 }
 .item-meta-row {
@@ -384,8 +371,7 @@
 .order-page.vp-desktop .sticky-bar { display: none; }
 .order-page.vp-desktop .submit-block { display: none; }
 
-.order-page.vp-desktop .item-row { padding: 18px 20px; grid-template-columns: 64px 1fr auto; gap: 18px; }
-.order-page.vp-desktop .item-thumb { width: 64px; height: 64px; }
+.order-page.vp-desktop .item-row { padding: 18px 20px; grid-template-columns: 1fr auto; gap: 18px; }
 .order-page.vp-desktop .item-name { font-size: 1.05rem; }
 
 /* Desktop two-column only when the host viewport actually has room for it */

--- a/design/order-page.jsx
+++ b/design/order-page.jsx
@@ -78,11 +78,9 @@ function ItemRow({ item, qty, onQty, soldOut, selectedUnitId, onUnitChange }) {
   const remaining = out ? 0 : perUnitMax - qty;
   return (
     <div className={"item-row" + (out ? " is-sold-out" : "") + (hasPicker ? " has-picker" : "")}>
-      <div className="item-thumb" aria-hidden="true">
-        <div className="item-thumb-inner"></div>
-      </div>
       <div className="item-body">
         <div className="item-name">{item.name}</div>
+        {item.description && <div className="item-desc">{item.description}</div>}
         <div className="item-meta-row">
           <span className="item-price">
             <span className="mono">${selected.price.toFixed(2)}</span>

--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -362,11 +362,11 @@ export function OrderForm({
                         (showPicker ? " has-picker" : "")
                       }
                     >
-                      <div className="item-thumb" aria-hidden="true">
-                        <div className="item-thumb-inner"></div>
-                      </div>
                       <div className="item-body">
                         <div className="item-name">{p.name}</div>
+                        {p.description ? (
+                          <div className="item-desc">{p.description}</div>
+                        ) : null}
                         <div className="item-meta-row">
                           <span className="item-price">
                             <span className="mono">${formatPrice(priceCents)}</span>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1083,12 +1083,12 @@
 }
 .item-row {
   display: grid;
-  grid-template-columns: 44px minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 12px;
-  /* align-items: start gives the name + meta + picker stack room to grow
-     while keeping the thumb pinned to the top. Stepper top-aligns too so
-     it sits next to the price (visually paired) instead of drifting down
-     when a long name wraps. 6.5c restructure (#144). */
+  /* align-items: start gives the name + desc + meta + picker stack room to
+     grow while the stepper top-aligns next to the price (visually paired)
+     instead of drifting down when a long name wraps. 6.5c restructure
+     (#144). */
   align-items: start;
   padding: 12px 14px;
   border-top: 1px solid var(--ink-200);
@@ -1104,25 +1104,6 @@
 }
 .item-row.is-sold-out { background: var(--leaf-50); opacity: 0.78; }
 .item-row.is-sold-out .item-name { color: var(--ink-500); }
-.item-row.is-sold-out .item-thumb { opacity: 0.55; }
-
-.item-thumb {
-  width: 44px; height: 44px; border-radius: 8px;
-  background: var(--leaf-50);
-  border: 1px solid var(--leaf-100);
-  overflow: hidden;
-}
-.item-thumb-inner {
-  width: 100%; height: 100%;
-  background-image:
-    repeating-linear-gradient(
-      45deg,
-      transparent 0,
-      transparent 6px,
-      rgba(59,109,17,0.08) 6px,
-      rgba(59,109,17,0.08) 7px
-    );
-}
 
 .item-body {
   min-width: 0;
@@ -1134,6 +1115,13 @@
   line-height: 1.25;
   /* Wrap freely — name owns its row now, no longer competing with the
      price for horizontal space. Closes #144. */
+  overflow-wrap: anywhere;
+}
+.item-desc {
+  font-weight: 400;
+  font-size: 0.82rem;
+  color: var(--ink-500);
+  line-height: 1.35;
   overflow-wrap: anywhere;
 }
 .item-meta-row {


### PR DESCRIPTION
## Summary

Two small `/c/[token]` fixes: remove the decorative image placeholder on each item row, and surface `products.description` under the (still-bold) product name.

## Files changed

- `src/components/customer/OrderForm.tsx` — drop `.item-thumb` markup; add `.item-desc` line under the name, rendered only when `p.description` is set
- `src/styles/app.css` — `.item-row` grid `44px minmax(0,1fr) auto` → `minmax(0,1fr) auto`; delete `.item-thumb` / `.item-thumb-inner` / sold-out thumb rule; add `.item-desc` (0.82rem, weight 400, `--ink-500`, wraps)
- `design/order-page.jsx` + `design/order-page.css` — mockup mirror, including the `vp-desktop` grid override

## Code review

@code-review: clean bill of health. No orphaned `.item-thumb` references in either CSS file; the desktop 3-column override was reduced to 2 columns; the `p.description` ternary correctly renders nothing for null/empty; the only thumb-targeted opacity rule was deleted with the thumb; design/src structure matched.

## Test plan

- [x] `npm run build` clean
- [x] `tests/customer-order-form.spec.ts --project=mobile` — 9/9 pass
- [x] 375px screenshot: no placeholder on any row; product with a description shows it in smaller grey wrapping text between name and price; products without a description show no extra line
- [ ] On preview `/c/[token]`: confirm rows render flush-left with no placeholder gap
- [ ] Set a description on a real product in admin inventory → confirm it appears under the name on the customer page
- [ ] Confirm sold-out rows still dim correctly (row-level opacity, not thumb)