### PR TITLE
Order page UX fixes: greeting, fulfillment copy, stepper corners

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -80,9 +80,7 @@
       "Bash(rm tests/_screenshot-temp.spec.ts)",
       "Bash(kill 734383)",
       "Bash(kill 822521)",
-      "Bash(kill 829354)",
-      "Bash(awk 'NR>=79 && NR<=82' src/components/customer/OrderForm.tsx)",
-      "Bash(cd *)"
+      "Bash(kill 829354)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -80,7 +80,9 @@
       "Bash(rm tests/_screenshot-temp.spec.ts)",
       "Bash(kill 734383)",
       "Bash(kill 822521)",
-      "Bash(kill 829354)"
+      "Bash(kill 829354)",
+      "Bash(awk 'NR>=79 && NR<=82' src/components/customer/OrderForm.tsx)",
+      "Bash(cd *)"
     ]
   }
 }

--- a/design/order-page.css
+++ b/design/order-page.css
@@ -212,9 +212,7 @@
   background: var(--leaf-50);
   box-shadow: inset 0 0 0 1px var(--leaf-600);
 }
-.fulfill-tab-label { font-weight: 600; font-size: 1rem; color: var(--ink-900); margin-bottom: 2px; }
-.fulfill-tab-sub { font-size: 0.82rem; color: var(--ink-500); }
-.fulfill-tab.is-active .fulfill-tab-sub { color: var(--leaf-700); }
+.fulfill-tab-label { font-weight: 600; font-size: 1rem; color: var(--ink-900); }
 
 .fulfill-detail {
   background: var(--paper);

--- a/design/order-page.jsx
+++ b/design/order-page.jsx
@@ -140,7 +140,6 @@ function FulfillmentTab({ active, onClick, label }) {
       onClick={onClick}>
       
       <div className="fulfill-tab-label">{label}</div>
-      <div className="fulfill-tab-sub">{sublabel}</div>
     </button>);
 
 }

--- a/design/order-page.jsx
+++ b/design/order-page.jsx
@@ -133,7 +133,7 @@ function ItemRow({ item, qty, onQty, soldOut, selectedUnitId, onUnitChange }) {
 
 }
 
-function FulfillmentTab({ active, onClick, label, sublabel }) {
+function FulfillmentTab({ active, onClick, label }) {
   return (
     <button
       className={"fulfill-tab" + (active ? " is-active" : "")}

--- a/design/order-page.jsx
+++ b/design/order-page.jsx
@@ -211,8 +211,7 @@ function OrderPage({ tweaks }) {
           <Eyebrow>this week · may 3 – may 9</Eyebrow>
           <h1 className="page-title">What's available</h1>
           <p className="page-greet">
-            Hi, {CUSTOMER.contact} at <span className="customer-name">{CUSTOMER.name}</span>.
-            Order by Tuesday 9pm.
+            <span className="customer-name">{CUSTOMER.name}</span>
           </p>
 
           {tweaks.showNote &&
@@ -261,14 +260,12 @@ function OrderPage({ tweaks }) {
                 <FulfillmentTab
                   active={mode === "delivery"}
                   onClick={() => setMode("delivery")}
-                  label="Delivery"
-                  sublabel="Wednesday morning" />
-                
+                  label="Delivery" />
+
                 <FulfillmentTab
                   active={mode === "pickup"}
                   onClick={() => setMode("pickup")}
-                  label="Pickup at farm"
-                  sublabel="3612 W 114th, Cleveland" />
+                  label="Pickup at farm" />
                 
               </div>
 

--- a/src/components/customer/AllSoldOutShell.tsx
+++ b/src/components/customer/AllSoldOutShell.tsx
@@ -7,7 +7,7 @@ export function AllSoldOutShell({ customerName }: { customerName: string }) {
       <div className="status-eyebrow eyebrow">this week · {weekOfLabel()}</div>
       <h1 className="status-title">Everything is sold out for this week.</h1>
       <p className="status-lede">
-        Hi, {customerName}. Check back next week — Annabel re-stocks Sunday and
+        {customerName}. Check back next week — Annabel re-stocks Sunday and
         Monday. Text 216-202-5718 with any questions.
       </p>
     </StatusShell>

--- a/src/components/customer/ClosedShell.tsx
+++ b/src/components/customer/ClosedShell.tsx
@@ -7,7 +7,7 @@ export function ClosedShell({ customerName }: { customerName: string }) {
       <div className="status-eyebrow eyebrow">this week · {weekOfLabel()}</div>
       <h1 className="status-title">Orders are closed this week.</h1>
       <p className="status-lede">
-        Hi, {customerName}. Annabel will text you when we re-open. Text
+        {customerName}. Annabel will text you when we re-open. Text
         216-202-5718 with any questions.
       </p>
     </StatusShell>

--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -320,7 +320,7 @@ export function OrderForm({
           <h1 className="page-title">What&rsquo;s available</h1>
           <div className="eyebrow page-head-week">this week · {weekLabel}</div>
           <p className="page-greet">
-            Hi, <span className="customer-name">{customer.name}</span>.
+            <span className="customer-name">{customer.name}</span>
           </p>
         </header>
 
@@ -450,7 +450,6 @@ export function OrderForm({
                   onClick={() => setMode("delivery")}
                 >
                   <div className="fulfill-tab-label">Delivery</div>
-                  <div className="fulfill-tab-sub">Wednesday morning</div>
                 </button>
                 <button
                   type="button"
@@ -460,7 +459,6 @@ export function OrderForm({
                   onClick={() => setMode("pickup")}
                 >
                   <div className="fulfill-tab-label">Pickup at farm</div>
-                  <div className="fulfill-tab-sub">3612 W 114th, Cleveland</div>
                 </button>
               </div>
 
@@ -479,7 +477,6 @@ export function OrderForm({
                     id="delivery-pref"
                     className="textarea"
                     rows={3}
-                    placeholder="e.g. Leave at back door, gate code 4321."
                     value={deliveryPreference}
                     onChange={(e) => setDeliveryPreference(e.target.value)}
                   />
@@ -496,12 +493,12 @@ export function OrderForm({
                     id="pickup-note"
                     className="textarea"
                     rows={3}
-                    placeholder="e.g. Wednesday afternoon, around 3."
                     value={pickupNote}
                     onChange={(e) => setPickupNote(e.target.value)}
                   />
                   <div className="fulfill-help">
-                    Pick up at the farm. Annabel will text you the morning of.
+                    Pickup at the farm (3612 W 114th St, Cleveland). Annabel will
+                    text you the morning of.
                   </div>
                 </div>
               )}

--- a/src/components/customer/PausedShell.tsx
+++ b/src/components/customer/PausedShell.tsx
@@ -16,8 +16,8 @@ export function PausedShell({
       : "Your weekly order link is paused.";
   const lede =
     reason === "closed"
-      ? `Hi, ${customerName}. Text Annabel at 216-202-5718 if you'd like to come back.`
-      : `Hi, ${customerName}. Text Annabel at 216-202-5718 to resume.`;
+      ? `${customerName}. Text Annabel at 216-202-5718 if you'd like to come back.`
+      : `${customerName}. Text Annabel at 216-202-5718 to resume.`;
   return (
     <StatusShell>
       <div className="status-eyebrow eyebrow">account</div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1233,6 +1233,10 @@
   font-size: 1.1rem; font-weight: 600; color: var(--ink-700);
   cursor: pointer;
 }
+/* Round the outer corners to the pill radius so the hover/active background
+   can't paint a square over the curved stepper border. */
+.stepper-btn:first-of-type { border-radius: var(--r-pill, 999px) 0 0 var(--r-pill, 999px); }
+.stepper-btn:last-of-type { border-radius: 0 var(--r-pill, 999px) var(--r-pill, 999px) 0; }
 .stepper-btn:hover:not(:disabled) { background: var(--leaf-50); }
 .stepper-btn:disabled { color: var(--ink-300); cursor: default; }
 .stepper-val {
@@ -1277,9 +1281,7 @@
   border-color: var(--leaf-600);
   box-shadow: 0 0 0 2px rgba(79,138,27,0.12);
 }
-.fulfill-tab-label { font-weight: 600; font-size: 1rem; color: var(--ink-900); margin-bottom: 2px; }
-.fulfill-tab-sub { font-size: 0.82rem; color: var(--ink-500); }
-.fulfill-tab.is-active .fulfill-tab-sub { color: var(--leaf-700); }
+.fulfill-tab-label { font-weight: 600; font-size: 1rem; color: var(--ink-900); }
 
 .fulfill-detail {
   background: var(--paper);


### PR DESCRIPTION
Small customer-side UX fixes for the order page (`/c/[token]`), all matched against the `design/order-page.{jsx,css}` spec.

## Changes
- **Greeting** — drop the "Hi," prefix on the order page and the three status shells (Closed / AllSoldOut / Paused); display the customer name plainly. Confirmed page's "Order received, {name}." left intact.
- **Fulfillment tabs** — remove the sublabels ("Wednesday morning", "3612 W 114th, Cleveland") and the now-dead `.fulfill-tab-sub` CSS.
- **Textareas** — remove placeholder text from delivery-preference and pickup-note.
- **Pickup help copy** → "Pickup at the farm (3612 W 114th St, Cleveland). Annabel will text you the morning of."
- **Stepper** — round the +/- buttons' outer corners (`:first-of-type`/`:last-of-type`) to the pill radius so the hover/active background stops painting a green square over the curved border.
- design/ mirror updated for all of the above.

## Test plan
- `customer-order-form.spec.ts` + `customer-order-units.spec.ts` — **30 passed, 2 skipped** on desktop + mobile (the 2 skips are mobile-only admin/sticky-bar cases that don't apply). No assertions referenced the changed strings.
- 375px screenshot confirmed: stepper hover background follows the pill curve (square gone), tabs have no sublabels, pickup copy correct, greeting has no "Hi,".
- `npm run build` green.

## Review notes
@code-review flagged a real bug in the design mirror — `design/order-page.jsx` still referenced the removed `sublabel` prop. Fixed in 4f3c9c2. Advisory remainder: placeholder removal intentional (labels convey intent); `:first/last-of-type` correct today, slightly fragile if a third `.stepper` button is ever added; bare-name shell greetings read slightly abrupt — left per explicit request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)