### PR TITLE
Design: Orders status section redesign (mockup)

### DIFF
--- a/design/admin-orders.css
+++ b/design/admin-orders.css
@@ -100,7 +100,7 @@
 .col-o-items  { width: 26%; min-width: 220px; }
 .col-o-ful    { width: 180px; }
 .col-o-total  { width: 90px; text-align: right; }
-.col-o-status { width: 240px; }
+.col-o-status { width: 130px; }
 
 .ord-num { font-size: 0.82rem; color: var(--ink-700); font-weight: 600; }
 .badge-recon {
@@ -177,10 +177,13 @@
 }
 .status-advance:hover { background: #2c2b27; }
 
-/* 6.x: per-order action stack — status chip + Confirm/Reminder sends + advance */
-.status-stack { display: flex; flex-direction: column; align-items: flex-start; gap: 8px; width: 100%; }
-.status-actions { display: flex; flex-direction: column; gap: 6px; width: 100%; }
-.status-advance-block { width: 100%; margin-top: 2px; }
+.status-advance:disabled { background: var(--ink-200); color: var(--ink-500); cursor: default; }
+
+/* 6.x: order-detail action block — Confirm/Reminder sends + advance buttons */
+.ord-actions { margin-top: 22px; padding-top: 18px; border-top: 1px dashed var(--leaf-100); }
+.ord-actions-panel { display: flex; flex-direction: column; gap: 10px; max-width: 380px; }
+.ord-actions-btns { display: flex; gap: 10px; margin-top: 4px; }
+.ord-actions-btns .status-advance { flex: 1; padding: 8px 12px; }
 
 .send-action {
   display: flex; align-items: center; gap: 8px;

--- a/design/admin-orders.css
+++ b/design/admin-orders.css
@@ -100,7 +100,7 @@
 .col-o-items  { width: 26%; min-width: 220px; }
 .col-o-ful    { width: 180px; }
 .col-o-total  { width: 90px; text-align: right; }
-.col-o-status { width: 200px; }
+.col-o-status { width: 240px; }
 
 .ord-num { font-size: 0.82rem; color: var(--ink-700); font-weight: 600; }
 .badge-recon {
@@ -156,12 +156,13 @@
   letter-spacing: 0.02em;
   white-space: nowrap;
 }
-.pill-new   { background: rgba(178,59,46,0.1); color: var(--rose-600); }
-.pill-ready { background: var(--leaf-50); color: var(--leaf-700); border: 1px solid var(--leaf-100); }
-.pill-done  { background: var(--ink-100); color: var(--ink-700); }
+.pill-new       { background: rgba(178,59,46,0.1); color: var(--rose-600); }
+.pill-confirmed { background: var(--amber-50); color: #8A6210; border: 1px solid #EFD89A; }
+.pill-ready     { background: var(--leaf-50); color: var(--leaf-700); border: 1px solid var(--leaf-100); }
+.pill-done      { background: var(--ink-100); color: var(--ink-700); }
 
 .status-advance {
-  display: inline-flex; align-items: center; gap: 6px;
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
   background: var(--ink-900);
   color: var(--paper);
   border: none;
@@ -175,6 +176,42 @@
   transition: background 0.1s;
 }
 .status-advance:hover { background: #2c2b27; }
+
+/* 6.x: per-order action stack — status chip + Confirm/Reminder sends + advance */
+.status-stack { display: flex; flex-direction: column; align-items: flex-start; gap: 8px; width: 100%; }
+.status-actions { display: flex; flex-direction: column; gap: 6px; width: 100%; }
+.status-advance-block { width: 100%; margin-top: 2px; }
+
+.send-action {
+  display: flex; align-items: center; gap: 8px;
+  width: 100%;
+}
+.send-action-label {
+  flex: 1;
+  font-size: 0.82rem;
+  color: var(--ink-700);
+  white-space: nowrap;
+}
+.send-action-sent {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--leaf-700);
+}
+.btn-send {
+  background: var(--leaf-600);
+  color: var(--paper);
+  border: none;
+  border-radius: var(--r-sm);
+  padding: 4px 12px;
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.1s;
+}
+.btn-send:hover { background: var(--leaf-700); }
 
 /* detail row */
 .ord-detail-row td {

--- a/design/admin-orders.css
+++ b/design/admin-orders.css
@@ -100,7 +100,7 @@
 .col-o-items  { width: 26%; min-width: 220px; }
 .col-o-ful    { width: 180px; }
 .col-o-total  { width: 90px; text-align: right; }
-.col-o-status { width: 130px; }
+.col-o-status { width: 220px; }
 
 .ord-num { font-size: 0.82rem; color: var(--ink-700); font-weight: 600; }
 .badge-recon {
@@ -179,11 +179,11 @@
 
 .status-advance:disabled { background: var(--ink-200); color: var(--ink-500); cursor: default; }
 
-/* 6.x: order-detail action block — Confirm/Reminder sends + advance buttons */
-.ord-actions { margin-top: 22px; padding-top: 18px; border-top: 1px dashed var(--leaf-100); }
-.ord-actions-panel { display: flex; flex-direction: column; gap: 10px; max-width: 380px; }
-.ord-actions-btns { display: flex; gap: 10px; margin-top: 4px; }
-.ord-actions-btns .status-advance { flex: 1; padding: 8px 12px; }
+/* 6.x: per-order action stack — below the chip, only when row is expanded */
+.status-stack { display: flex; flex-direction: column; align-items: stretch; gap: 8px; width: 100%; }
+.status-stack > .pill { align-self: flex-start; }
+.status-actions { display: flex; flex-direction: column; gap: 6px; width: 100%; }
+.status-actions .status-advance { width: 100%; }
 
 .send-action {
   display: flex; align-items: center; gap: 8px;

--- a/design/admin-orders.jsx
+++ b/design/admin-orders.jsx
@@ -181,13 +181,13 @@ function OrdersPage() {
                       <div className="ord-total mono">${total.toFixed(2)}</div>
                     </td>
                     <td className="col-o-status" onClick={e => e.stopPropagation()}>
-                      <StatusControl order={o} onAdvance={advance} onSend={send}/>
+                      <StatusChip status={o.status}/>
                     </td>
                   </tr>
                   {isOpen && (
                     <tr className="ord-detail-row">
                       <td colSpan={7}>
-                        <OrderDetail order={o} total={total}/>
+                        <OrderDetail order={o} total={total} onAdvance={advance} onSend={send}/>
                       </td>
                     </tr>
                   )}
@@ -222,48 +222,54 @@ function SendAction({ label, sent, onSend }) {
   );
 }
 
-function StatusControl({ order, onAdvance, onSend }) {
+function OrderActions({ order, onAdvance, onSend }) {
   const s = order.status;
   const isPickup = order.fulfillment.type === "pickup";
-
-  // Terminal states: chip only.
-  if (s === "picked-up" || s === "delivered") {
-    return <div className="status-stack"><StatusChip status={s}/></div>;
-  }
-
   const reminderLabel = isPickup ? "Pickup reminder" : "Delivery reminder";
-  const advanceLabel  = s === "ready" ? (isPickup ? "Mark picked up" : "Mark delivered") : "Mark ready";
-  const advanceNext   = s === "ready" ? (isPickup ? "picked-up" : "delivered") : "ready";
+  const terminalLabel = isPickup ? "Mark picked up" : "Mark delivered";
+  const terminalNext  = isPickup ? "picked-up" : "delivered";
+
+  const readyDone    = s === "ready" || s === "picked-up" || s === "delivered";
+  const terminalDone = s === "picked-up" || s === "delivered";
 
   return (
-    <div className="status-stack">
-      <StatusChip status={s}/>
-      <div className="status-actions">
-        {s !== "ready" && (
-          <SendAction
-            label="Confirm order"
-            sent={order.confirmSent}
-            onSend={() => onSend(order.id, "confirm")}
-          />
-        )}
+    <div className="ord-actions">
+      <div className="ord-detail-label">Actions</div>
+      <div className="ord-actions-panel">
+        <SendAction
+          label="Confirm order"
+          sent={order.confirmSent}
+          onSend={() => onSend(order.id, "confirm")}
+        />
         <SendAction
           label={reminderLabel}
           sent={order.reminderSent}
           onSend={() => onSend(order.id, "reminder")}
         />
-        <button
-          type="button"
-          className="status-advance status-advance-block"
-          onClick={() => onAdvance(order.id, advanceNext)}
-        >
-          {advanceLabel}
-        </button>
+        <div className="ord-actions-btns">
+          <button
+            type="button"
+            className="status-advance"
+            disabled={readyDone}
+            onClick={() => onAdvance(order.id, "ready")}
+          >
+            Mark ready
+          </button>
+          <button
+            type="button"
+            className="status-advance"
+            disabled={terminalDone}
+            onClick={() => onAdvance(order.id, terminalNext)}
+          >
+            {terminalLabel}
+          </button>
+        </div>
       </div>
     </div>
   );
 }
 
-function OrderDetail({ order, total }) {
+function OrderDetail({ order, total, onAdvance, onSend }) {
   return (
     <div className="ord-detail">
       <div className="ord-detail-grid">
@@ -317,6 +323,8 @@ function OrderDetail({ order, total }) {
           )}
         </div>
       </div>
+
+      <OrderActions order={order} onAdvance={onAdvance} onSend={onSend}/>
     </div>
   );
 }

--- a/design/admin-orders.jsx
+++ b/design/admin-orders.jsx
@@ -181,13 +181,16 @@ function OrdersPage() {
                       <div className="ord-total mono">${total.toFixed(2)}</div>
                     </td>
                     <td className="col-o-status" onClick={e => e.stopPropagation()}>
-                      <StatusChip status={o.status}/>
+                      <div className="status-stack">
+                        <StatusChip status={o.status}/>
+                        {isOpen && <OrderActions order={o} onAdvance={advance} onSend={send}/>}
+                      </div>
                     </td>
                   </tr>
                   {isOpen && (
                     <tr className="ord-detail-row">
                       <td colSpan={7}>
-                        <OrderDetail order={o} total={total} onAdvance={advance} onSend={send}/>
+                        <OrderDetail order={o} total={total}/>
                       </td>
                     </tr>
                   )}
@@ -233,43 +236,38 @@ function OrderActions({ order, onAdvance, onSend }) {
   const terminalDone = s === "picked-up" || s === "delivered";
 
   return (
-    <div className="ord-actions">
-      <div className="ord-detail-label">Actions</div>
-      <div className="ord-actions-panel">
-        <SendAction
-          label="Confirm order"
-          sent={order.confirmSent}
-          onSend={() => onSend(order.id, "confirm")}
-        />
-        <SendAction
-          label={reminderLabel}
-          sent={order.reminderSent}
-          onSend={() => onSend(order.id, "reminder")}
-        />
-        <div className="ord-actions-btns">
-          <button
-            type="button"
-            className="status-advance"
-            disabled={readyDone}
-            onClick={() => onAdvance(order.id, "ready")}
-          >
-            Mark ready
-          </button>
-          <button
-            type="button"
-            className="status-advance"
-            disabled={terminalDone}
-            onClick={() => onAdvance(order.id, terminalNext)}
-          >
-            {terminalLabel}
-          </button>
-        </div>
-      </div>
+    <div className="status-actions">
+      <SendAction
+        label="Confirm order"
+        sent={order.confirmSent}
+        onSend={() => onSend(order.id, "confirm")}
+      />
+      <SendAction
+        label={reminderLabel}
+        sent={order.reminderSent}
+        onSend={() => onSend(order.id, "reminder")}
+      />
+      <button
+        type="button"
+        className="status-advance"
+        disabled={readyDone}
+        onClick={() => onAdvance(order.id, "ready")}
+      >
+        Mark ready
+      </button>
+      <button
+        type="button"
+        className="status-advance"
+        disabled={terminalDone}
+        onClick={() => onAdvance(order.id, terminalNext)}
+      >
+        {terminalLabel}
+      </button>
     </div>
   );
 }
 
-function OrderDetail({ order, total, onAdvance, onSend }) {
+function OrderDetail({ order, total }) {
   return (
     <div className="ord-detail">
       <div className="ord-detail-grid">
@@ -323,8 +321,6 @@ function OrderDetail({ order, total, onAdvance, onSend }) {
           )}
         </div>
       </div>
-
-      <OrderActions order={order} onAdvance={onAdvance} onSend={onSend}/>
     </div>
   );
 }

--- a/design/admin-orders.jsx
+++ b/design/admin-orders.jsx
@@ -26,7 +26,7 @@ const SEED_ORDERS = [
     ],
     fulfillment: { type: "delivery", when: "Wed 8am – noon", address: "1948 W 25th St, Cleveland" },
     notes: "",
-    status: "ready", needsReconciliation: false,
+    status: "confirmed", needsReconciliation: false, confirmSent: true,
   },
   {
     id: "ord-0503-02", customer: "West Side Market — Bay Stand",
@@ -88,6 +88,15 @@ function OrdersPage() {
 
   const advance = (id, next) =>
     setOrders(os => os.map(o => o.id === id ? { ...o, status: next } : o));
+
+  const send = (id, kind) =>
+    setOrders(os => os.map(o => {
+      if (o.id !== id) return o;
+      if (kind === "confirm") {
+        return { ...o, confirmSent: true, status: o.status === "new" ? "confirmed" : o.status };
+      }
+      return { ...o, reminderSent: true };
+    }));
 
   const totals = (o) => o.items.reduce((s, i) => s + i.qty * i.price, 0);
 
@@ -172,7 +181,7 @@ function OrdersPage() {
                       <div className="ord-total mono">${total.toFixed(2)}</div>
                     </td>
                     <td className="col-o-status" onClick={e => e.stopPropagation()}>
-                      <StatusControl order={o} onAdvance={s => advance(o.id, s)}/>
+                      <StatusControl order={o} onAdvance={advance} onSend={send}/>
                     </td>
                   </tr>
                   {isOpen && (
@@ -192,35 +201,66 @@ function OrdersPage() {
   );
 }
 
-function StatusControl({ order, onAdvance }) {
+function StatusChip({ status }) {
+  if (status === "new")       return <span className="pill pill-new">New</span>;
+  if (status === "confirmed") return <span className="pill pill-confirmed">Confirmed</span>;
+  if (status === "ready")     return <span className="pill pill-ready">Ready</span>;
+  if (status === "picked-up") return <span className="pill pill-done">Picked up</span>;
+  if (status === "delivered") return <span className="pill pill-done">Delivered</span>;
+  return null;
+}
+
+function SendAction({ label, sent, onSend }) {
+  return (
+    <div className="send-action">
+      <span className="send-action-label">{label}</span>
+      {sent && <span className="send-action-sent">Sent</span>}
+      <button type="button" className="btn-send" onClick={onSend}>
+        {sent ? "Re-send" : "Send"}
+      </button>
+    </div>
+  );
+}
+
+function StatusControl({ order, onAdvance, onSend }) {
   const s = order.status;
-  if (s === "new") {
-    return (
-      <div className="status-control">
-        <span className="pill pill-new">New</span>
-        <button type="button" className="status-advance" onClick={() => onAdvance("ready")}>
-          Mark ready <IconArrow/>
+  const isPickup = order.fulfillment.type === "pickup";
+
+  // Terminal states: chip only.
+  if (s === "picked-up" || s === "delivered") {
+    return <div className="status-stack"><StatusChip status={s}/></div>;
+  }
+
+  const reminderLabel = isPickup ? "Pickup reminder" : "Delivery reminder";
+  const advanceLabel  = s === "ready" ? (isPickup ? "Mark picked up" : "Mark delivered") : "Mark ready";
+  const advanceNext   = s === "ready" ? (isPickup ? "picked-up" : "delivered") : "ready";
+
+  return (
+    <div className="status-stack">
+      <StatusChip status={s}/>
+      <div className="status-actions">
+        {s !== "ready" && (
+          <SendAction
+            label="Confirm order"
+            sent={order.confirmSent}
+            onSend={() => onSend(order.id, "confirm")}
+          />
+        )}
+        <SendAction
+          label={reminderLabel}
+          sent={order.reminderSent}
+          onSend={() => onSend(order.id, "reminder")}
+        />
+        <button
+          type="button"
+          className="status-advance status-advance-block"
+          onClick={() => onAdvance(order.id, advanceNext)}
+        >
+          {advanceLabel}
         </button>
       </div>
-    );
-  }
-  if (s === "ready") {
-    return (
-      <div className="status-control">
-        <span className="pill pill-ready">Ready</span>
-        <div className="status-split">
-          {order.fulfillment.type === "pickup" ? (
-            <button type="button" className="status-advance" onClick={() => onAdvance("picked-up")}>Picked up <IconCheck/></button>
-          ) : (
-            <button type="button" className="status-advance" onClick={() => onAdvance("delivered")}>Delivered <IconCheck/></button>
-          )}
-        </div>
-      </div>
-    );
-  }
-  if (s === "picked-up") return <span className="pill pill-done">Picked up · {order.fulfillment.when.split(" ")[0]}</span>;
-  if (s === "delivered") return <span className="pill pill-done">Delivered · Wed</span>;
-  return null;
+    </div>
+  );
 }
 
 function OrderDetail({ order, total }) {

--- a/design/preview-orders.html
+++ b/design/preview-orders.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Admin · Orders — design preview</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="tokens.css">
+  <link rel="stylesheet" href="admin-shell.css">
+  <link rel="stylesheet" href="admin-orders.css">
+  <style>
+    body { margin: 0; background: var(--cream); font-family: var(--sans); color: var(--ink-900); }
+    .preview-shell { max-width: 1180px; margin: 0 auto; padding: 28px 28px 80px; }
+    .preview-banner {
+      margin-bottom: 18px;
+      padding: 10px 14px;
+      background: var(--leaf-50);
+      border: 1px solid var(--leaf-100);
+      border-radius: var(--r-sm);
+      font-size: 0.82rem;
+      color: var(--leaf-700);
+    }
+  </style>
+</head>
+<body>
+  <div class="preview-shell">
+    <div class="preview-banner">
+      <strong>Design preview · admin-orders.jsx</strong>
+      — click any order row to expand its detail.
+    </div>
+    <div id="root"></div>
+  </div>
+
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script>
+    (async () => {
+      const src = await fetch("admin-orders.jsx").then(r => r.text());
+      const out = Babel.transform(src, { presets: ["react"] }).code;
+      // eslint-disable-next-line no-new-func
+      new Function(out)();
+      const root = ReactDOM.createRoot(document.getElementById("root"));
+      root.render(React.createElement(window.OrdersPage));
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Design-folder mockup for the Orders-page per-order Status redesign Annabel approved this session. Authoritative `design/admin-orders.jsx` + `.css` updated; adds `design/preview-orders.html` harness (mirrors `preview-inventory.html`).

The approved interaction:
- Collapsed order row shows **only the status chip**.
- Expanding a row reveals a vertical action stack under the chip: **Confirm order + Send**, **Pickup/Delivery reminder + Send** (wording per fulfillment type), **Mark ready**, and **Mark picked up/delivered** (per fulfillment type).
- New **Confirmed** status in the flow (New → Confirmed → Ready → Done); sending the confirm text flips the chip to Confirmed.
- Plain buttons — no checkmark/arrow icons (they read as done-states, not actions).

## Notes
- This is **design-only** — no `src/` changes. Implementation tracked in follow-up issues (nav rename, Send Texts page, Orders status build).
- `preview-orders.html` is a dev-only harness (CDN React + Babel, served statically). Not shipped code.

## Test plan
- [ ] `cd design && python3 -m http.server 8000`, open `preview-orders.html`
- [ ] Collapsed rows show chip only; expand reveals stacked actions
- [ ] Confirm Send flips New → Confirmed; Mark ready / Mark delivered advance + disable
- [ ] Reminder + terminal button wording follows pickup vs delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)