### PR TITLE
Rename "Send Update" → "Send Texts" nav item, reorder (#188)

### DIFF
--- a/design/admin-shell.jsx
+++ b/design/admin-shell.jsx
@@ -63,8 +63,8 @@ function AdminShell({ initialPage }) {
   const nav = [
     { id: "inventory", label: "Inventory", icon: <IconLeaf/>,    badge: "12 listed" },
     { id: "customers", label: "Customers", icon: <IconUsers/>,   badge: null },
+    { id: "broadcast", label: "Send Texts", icon: <IconSend/>,   badge: null },
     { id: "orders",    label: "Orders",    icon: <IconBag/>,     badge: "4 new" },
-    { id: "broadcast", label: "Send Update", icon: <IconSend/>,  badge: null },
     { id: "settings",  label: "Settings",  icon: <IconCog/>,     badge: null },
   ];
 

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -34,22 +34,22 @@ const NAV_ITEMS = [
     ),
   },
   {
+    href: "/admin/send",
+    label: "Send Texts",
+    icon: (
+      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M21 4 3 11l7 2 2 7z"/>
+        <path d="m10 13 5-5"/>
+      </svg>
+    ),
+  },
+  {
     href: "/admin/orders",
     label: "Orders",
     icon: (
       <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
         <path d="M5 8h14l-1 12H6z"/>
         <path d="M9 8V6a3 3 0 0 1 6 0v2"/>
-      </svg>
-    ),
-  },
-  {
-    href: "/admin/send",
-    label: "Send Update",
-    icon: (
-      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M21 4 3 11l7 2 2 7z"/>
-        <path d="m10 13 5-5"/>
       </svg>
     ),
   },

--- a/tests/admin-shell.spec.ts
+++ b/tests/admin-shell.spec.ts
@@ -24,6 +24,18 @@ test.describe("admin shell — authenticated", () => {
     await expect(page.getByRole("link", { name: /customers/i })).toBeVisible();
   });
 
+  test("send nav reads 'Send Texts' and sits between Customers and Orders (#188)", async ({ page }) => {
+    await page.goto("/admin");
+    const nav = page.getByRole("navigation", { name: /admin navigation/i });
+    await expect(nav.getByRole("link", { name: /send texts/i })).toBeVisible();
+    // Old label is gone from the nav.
+    await expect(nav.getByText("Send Update")).toHaveCount(0);
+    // DOM order: Customers → Send Texts → Orders.
+    const labels = await nav.locator(".admin-nav-label").allTextContents();
+    expect(labels.indexOf("Customers")).toBeLessThan(labels.indexOf("Send Texts"));
+    expect(labels.indexOf("Send Texts")).toBeLessThan(labels.indexOf("Orders"));
+  });
+
   test("nav link marks active page with aria-current", async ({ page }) => {
     await page.goto("/admin/inventory");
     const inventoryLink = page.getByRole("link", { name: /inventory/i });


### PR DESCRIPTION
## Summary
Admin nav: rename "Send Update" → "Send Texts" and move it between Customers and Orders (closes #188). Label + ordering only.

## Files changed
- `src/app/(admin)/admin/layout.tsx` — NAV_ITEMS: relabel + reorder
- `design/admin-shell.jsx` — mirror rename + reorder (design parity)
- `tests/admin-shell.spec.ts` — assert label, old-label absence, and DOM order

## Scope
Route stays `/admin/send`. Breadcrumb, page `<title>`, and page heading still read "Send Update" — those belong to sibling **#189**. So nav reads "Send Texts" while the page header still says "Send Update" until #189 lands; intentional split.

## Code review
@code-review — clean bill of health. Verified: active-state highlight and unsent-count badge both key off the unchanged `href="/admin/send"`, so neither broke; mobile drawer derives from the same `NAV_ITEMS`, so label/order propagate automatically (no second hardcoded list); no stray old labels in the nav. Test is non-flaky (mirrors the proven sibling locator, asserts rendered DOM order).

## Test plan
- `/admin` (authenticated): sidebar nav reads **Inventory → Customers → Send Texts → Orders → Settings**. The "Send Texts" item carries the "N to send" badge when there's unsent weekly work.
- Navigate to `/admin/send`: the **Send Texts** nav item shows active-state (aria-current). (Breadcrumb/heading still say "Send Update" — #189.)
- Mobile drawer (≤680px): same label + order.
- `npx playwright test tests/admin-shell.spec.ts --project=desktop` → 10/10 (incl. the #188 assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)