### PR TITLE
Add "Confirmed" order status + flow (#190, DEC-035)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -403,6 +403,33 @@ PWA push notification remains the stretch upgrade per DEC-027's framing.
 
 ---
 
+## DEC-034 — Admin is mobile-responsive (amends DEC-019)
+
+*Reserved.* Referenced across `PROJECT_PLAN.md`, `RETROSPECTIVES.md`, `app.css`, and `playwright.config.ts` (Phase 6.4–6.7): `/admin/*` is mobile-responsive because operator-sent `sms:` deep links only resolve on a phone — Annabel runs ops from her phone. The full write-up is still pending a retro pass; the number is held here so the log stays contiguous and DEC-035 doesn't collide.
+
+---
+
+## DEC-035 — "Confirmed" order status (amends DEC-010)
+
+**Decision:** "Confirmed" is a real order status between New and Ready. The flow is **new → [confirmed] → ready → (picked-up | delivered)**, where `confirmed` is **optional**:
+- `new → confirmed` — set when Annabel sends the order-confirmation text (auto-advance), or manually.
+- `new → ready` — kept. Annabel may pack an order before texting, so confirmed can be skipped.
+- `confirmed → ready`, then `ready → picked-up | delivered` (fulfillment-pinned terminal).
+
+**No-regress guard:** sending the confirmation text auto-advances a `new` order to `confirmed`, but must **never** regress a `ready`/terminal order. The rule is the pure helper `statusAfterConfirmSend(s) = s === "new" ? "confirmed" : s` (`src/lib/admin/orders-queries.ts`), wired to the confirm-send button in the Orders-page action stack (#192).
+
+**Why:**
+- The order-status redesign (design PR #187) needs a confirmation state distinct from "packed and ready." Confirmed = "we've acknowledged the order to the customer"; ready = "it's physically packed."
+- Optional, not mandatory, because the farm's real workflow sometimes packs first. Forcing confirm-before-ready would fight how Annabel works.
+
+**Implementation:**
+- `codes` gains `('order_status','confirmed','Confirmed',2)`; `ready`/`picked_up`/`delivered` renumber to 3/4/5 (migration `20260604200000_order_status_confirmed.sql`).
+- `orders.status` stays app-enforced text (no FK/constraint) per DEC-010. The transition table lives in TS (`isValidTransition`, `orders-queries.ts`), not the DB.
+
+**Foundation for:** the Orders redesign — #191 (shared SendAction), #192 (per-order action stack), #193 (delivery reminder) build on this status.
+
+---
+
 ## Open / Pending Product Owner Discussion
 
 - **Minimum delivery amount (in dollars).** Threshold below which delivery is unavailable, or above which delivery is free. Phase 7+ candidate.

--- a/src/actions/advance-order-status.ts
+++ b/src/actions/advance-order-status.ts
@@ -3,20 +3,7 @@
 import { revalidatePath } from "next/cache";
 
 import { createClient } from "@/lib/supabase/server";
-import type { OrderStatus } from "@/lib/admin/orders-queries";
-
-// DEC-010: new → ready → (picked-up | delivered).
-// Fulfillment type pins which terminal state is valid.
-function isValidTransition(
-  from: OrderStatus,
-  to: OrderStatus,
-  fulfillmentType: "pickup" | "delivery",
-): boolean {
-  if (from === "new" && to === "ready") return true;
-  if (from === "ready" && to === "picked-up") return fulfillmentType === "pickup";
-  if (from === "ready" && to === "delivered") return fulfillmentType === "delivery";
-  return false;
-}
+import { isValidTransition, type OrderStatus } from "@/lib/admin/orders-queries";
 
 // Uses cookie-bound client (not admin) — the admin_all_orders RLS policy
 // (migration 20260508014838) is the gate on writes here. Matches the

--- a/src/components/admin/order-row.tsx
+++ b/src/components/admin/order-row.tsx
@@ -64,6 +64,24 @@ function StatusControl({
       </div>
     );
   }
+  if (order.status === "confirmed") {
+    return (
+      <div className="status-control">
+        <span className="pill pill-confirmed">Confirmed</span>
+        <button
+          type="button"
+          className="status-advance"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAdvance("ready");
+          }}
+          disabled={pending}
+        >
+          Mark ready →
+        </button>
+      </div>
+    );
+  }
   if (order.status === "ready") {
     const terminal: OrderStatus =
       order.fulfillmentType === "pickup" ? "picked-up" : "delivered";

--- a/src/lib/admin/orders-queries.ts
+++ b/src/lib/admin/orders-queries.ts
@@ -2,14 +2,48 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { weekOfMondayNY } from "@/lib/week";
 
-export type OrderStatus = "new" | "ready" | "picked-up" | "delivered";
+// DEC-035 (amends DEC-010): new → [confirmed] → ready → (picked-up | delivered).
+// Confirmed is optional. Ordering matches codes.sort_order.
+export type OrderStatus =
+  | "new"
+  | "confirmed"
+  | "ready"
+  | "picked-up"
+  | "delivered";
 
 export const ORDER_STATUSES: OrderStatus[] = [
   "new",
+  "confirmed",
   "ready",
   "picked-up",
   "delivered",
 ];
+
+// The no-regress auto-advance rule for confirm-sends (DEC-035): sending the
+// confirmation text moves a new order to confirmed, but must never regress a
+// ready/terminal order. Wired to the confirm-send action in the Orders-page
+// action stack (#192); lives here as a pure, testable helper.
+export function statusAfterConfirmSend(current: OrderStatus): OrderStatus {
+  return current === "new" ? "confirmed" : current;
+}
+
+// DEC-035 (amends DEC-010): new → [confirmed] → ready → (picked-up | delivered).
+// Confirmed is optional — new → ready stays valid (Annabel may pack before
+// texting). Fulfillment type pins which terminal state is valid. Pure +
+// exported so advance-order-status.ts (a "use server" module, which can only
+// export async actions) can import it and tests can exercise the table.
+export function isValidTransition(
+  from: OrderStatus,
+  to: OrderStatus,
+  fulfillmentType: "pickup" | "delivery",
+): boolean {
+  if (from === "new" && to === "confirmed") return true;
+  if (from === "new" && to === "ready") return true;
+  if (from === "confirmed" && to === "ready") return true;
+  if (from === "ready" && to === "picked-up") return fulfillmentType === "pickup";
+  if (from === "ready" && to === "delivered") return fulfillmentType === "delivery";
+  return false;
+}
 
 export type OrderItem = {
   productId: string;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2459,9 +2459,10 @@
   letter-spacing: 0.02em;
   white-space: nowrap;
 }
-.pill-new   { background: rgba(178,59,46,0.1); color: var(--rose-600); }
-.pill-ready { background: var(--leaf-50); color: var(--leaf-700); border: 1px solid var(--leaf-100); }
-.pill-done  { background: var(--ink-100); color: var(--ink-700); }
+.pill-new       { background: rgba(178,59,46,0.1); color: var(--rose-600); }
+.pill-confirmed { background: var(--amber-50); color: #8A6210; border: 1px solid #EFD89A; }
+.pill-ready     { background: var(--leaf-50); color: var(--leaf-700); border: 1px solid var(--leaf-100); }
+.pill-done      { background: var(--ink-100); color: var(--ink-700); }
 
 .status-advance {
   display: inline-flex; align-items: center; gap: 6px;

--- a/supabase/migrations/20260604200000_order_status_confirmed.sql
+++ b/supabase/migrations/20260604200000_order_status_confirmed.sql
@@ -1,0 +1,15 @@
+-- "Confirmed" order status (#190, DEC-035 — amends DEC-010).
+--
+-- Flow: new → [confirmed] → ready → (picked_up | delivered). Confirmed is
+-- optional (Annabel may pack before texting, so new → ready stays valid).
+-- orders.status remains app-enforced text (no FK/constraint); codes is the
+-- lookup that drives ordinals + labels.
+
+-- Insert the new status between New (1) and Ready, then renumber the rest.
+insert into public.codes (type, code, label, sort_order) values
+  ('order_status', 'confirmed', 'Confirmed', 2)
+on conflict (type, code) do nothing;
+
+update public.codes set sort_order = 3 where type = 'order_status' and code = 'ready';
+update public.codes set sort_order = 4 where type = 'order_status' and code = 'picked_up';
+update public.codes set sort_order = 5 where type = 'order_status' and code = 'delivered';

--- a/supabase/tests/order_status_codes.sql
+++ b/supabase/tests/order_status_codes.sql
@@ -1,0 +1,24 @@
+begin;
+select plan(6);
+
+-- #190 / DEC-035: confirmed inserted at ordinal 2; the rest renumber to 3/4/5.
+select results_eq(
+  $$ select code, sort_order from public.codes
+       where type = 'order_status' order by sort_order $$,
+  $$ values ('new', 1), ('confirmed', 2), ('ready', 3),
+            ('picked_up', 4), ('delivered', 5) $$,
+  'order_status codes: new,confirmed,ready,picked_up,delivered at ordinals 1..5'
+);
+
+select is(
+  (select label from public.codes where type = 'order_status' and code = 'confirmed'),
+  'Confirmed',
+  'confirmed has label "Confirmed"'
+);
+select is((select sort_order from public.codes where type='order_status' and code='confirmed'), 2, 'confirmed = 2');
+select is((select sort_order from public.codes where type='order_status' and code='ready'), 3, 'ready = 3');
+select is((select sort_order from public.codes where type='order_status' and code='picked_up'), 4, 'picked_up = 4');
+select is((select sort_order from public.codes where type='order_status' and code='delivered'), 5, 'delivered = 5');
+
+select * from finish();
+rollback;

--- a/tests/admin-orders.spec.ts
+++ b/tests/admin-orders.spec.ts
@@ -141,6 +141,27 @@ test.describe("admin orders list", () => {
     await expect(reloadedRow.locator(".pill-done")).toHaveText("Delivered");
   });
 
+  test("confirmed order renders the Confirmed pill and advances confirmed → ready (#190)", async ({ page }) => {
+    const ids = await customerIds();
+    const orderId = await seedOrder({
+      customerId: ids.restaurant,
+      weekOf: thisWeek,
+      fulfillmentType: "delivery",
+      status: "confirmed",
+      items: [{ productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 }],
+    });
+
+    await page.goto("/admin/orders");
+    const row = page.locator(`tr.ord-row[data-order-id="${orderId}"]`);
+    await expect(row).toHaveAttribute("data-status", "confirmed");
+    // Renders the Confirmed pill — not a fallthrough "Delivered" done-pill.
+    await expect(row.locator(".pill-confirmed")).toHaveText("Confirmed");
+
+    await row.getByRole("button", { name: /mark ready/i }).click();
+    await expect(row).toHaveAttribute("data-status", "ready", { timeout: 5000 });
+    await expect(row.locator(".pill-ready")).toHaveText("Ready");
+  });
+
   test("pickup order: ready advances to picked-up (not delivered)", async ({ page }) => {
     const ids = await customerIds();
     const orderId = await seedOrder({

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -73,7 +73,7 @@ export type SeedOrderInput = {
   customerId: string;
   weekOf: string;
   fulfillmentType: "pickup" | "delivery";
-  status?: "new" | "ready" | "picked-up" | "delivered";
+  status?: "new" | "confirmed" | "ready" | "picked-up" | "delivered";
   needsReconciliation?: boolean;
   // Opt-in for delivery orders. Defaults to null — matches admin-orders-export
   // and orders-flow specs' pre-refactor behavior. admin-orders.spec passes

--- a/tests/order-status-transitions.spec.ts
+++ b/tests/order-status-transitions.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+
+import {
+  ORDER_STATUSES,
+  isValidTransition,
+  statusAfterConfirmSend,
+} from "@/lib/admin/orders-queries";
+
+// #190 / DEC-035 — pure transition-table coverage. The valid-transition logic
+// lives in TS (orders.status is app-enforced text, no DB constraint), so it's
+// unit-tested here rather than in pgTAP.
+
+test.describe("order status flow (DEC-035)", () => {
+  test("ORDER_STATUSES matches the codes ordinal order", () => {
+    expect(ORDER_STATUSES).toEqual([
+      "new",
+      "confirmed",
+      "ready",
+      "picked-up",
+      "delivered",
+    ]);
+  });
+
+  test("every valid path is allowed", () => {
+    expect(isValidTransition("new", "confirmed", "pickup")).toBe(true);
+    expect(isValidTransition("new", "confirmed", "delivery")).toBe(true);
+    // confirmed is optional — new → ready stays valid
+    expect(isValidTransition("new", "ready", "pickup")).toBe(true);
+    expect(isValidTransition("confirmed", "ready", "delivery")).toBe(true);
+    expect(isValidTransition("ready", "picked-up", "pickup")).toBe(true);
+    expect(isValidTransition("ready", "delivered", "delivery")).toBe(true);
+  });
+
+  test("terminal state is pinned to fulfillment type", () => {
+    expect(isValidTransition("ready", "picked-up", "delivery")).toBe(false);
+    expect(isValidTransition("ready", "delivered", "pickup")).toBe(false);
+  });
+
+  test("skips, regressions, and nonsense transitions are rejected", () => {
+    expect(isValidTransition("new", "picked-up", "pickup")).toBe(false);
+    expect(isValidTransition("new", "delivered", "delivery")).toBe(false);
+    expect(isValidTransition("confirmed", "new", "pickup")).toBe(false);
+    expect(isValidTransition("ready", "confirmed", "pickup")).toBe(false);
+    expect(isValidTransition("picked-up", "ready", "pickup")).toBe(false);
+    expect(isValidTransition("delivered", "ready", "delivery")).toBe(false);
+  });
+
+  test("confirm-send auto-advance never regresses (no-regress guard)", () => {
+    expect(statusAfterConfirmSend("new")).toBe("confirmed");
+    expect(statusAfterConfirmSend("confirmed")).toBe("confirmed");
+    expect(statusAfterConfirmSend("ready")).toBe("ready");
+    expect(statusAfterConfirmSend("picked-up")).toBe("picked-up");
+    expect(statusAfterConfirmSend("delivered")).toBe("delivered");
+  });
+});


### PR DESCRIPTION
## Summary
Foundation for the Orders redesign: add a "Confirmed" order status. Flow **new → [confirmed] → ready → (picked-up | delivered)**, confirmed optional (closes #190).

## Files changed
- `supabase/migrations/20260604200000_order_status_confirmed.sql` — `codes` row `('order_status','confirmed','Confirmed',2)`; renumber ready/picked_up/delivered → 3/4/5
- `src/lib/admin/orders-queries.ts` — `OrderStatus` += confirmed; `ORDER_STATUSES` reordered; exported pure `isValidTransition` + `statusAfterConfirmSend`
- `src/actions/advance-order-status.ts` — imports `isValidTransition` (kept out of the `"use server"` module)
- `src/components/admin/order-row.tsx` + `src/styles/app.css` — Confirmed pill + "Mark ready →"; `.pill-confirmed`
- `docs/DECISIONS.md` — DEC-035 + reserved DEC-034 line (mobile-admin)
- `supabase/tests/order_status_codes.sql`, `tests/order-status-transitions.spec.ts`, `tests/admin-orders.spec.ts`, `tests/helpers.ts`

## DEC numbering
Issue asked for DEC-034, but DEC-034 is already referenced across docs/code for the mobile-admin decision (amends DEC-019, never formally written). Per owner call: confirmed-status is **DEC-035**; added a one-line reserved DEC-034 entry so the log stays contiguous.

## Code review
@code-review — clean bill of health. Verified: no client-bundle leak (`order-row.tsx` imports `OrderStatus` type-only; `isValidTransition` is a value only in the `"use server"` action); the `confirmed` switch branch is exhaustive; migration is re-run safe (`on conflict do nothing` + set-to-constant updates); the pre-existing hyphen(`orders.status`)/underscore(`codes.code`) split is untouched and harmless (nothing joins them).

## Test plan
- **Migration:** `supabase db push` to dev/preview, then prod. `supabase test db` → `order_status_codes` asserts ordinals new=1…delivered=5 + Confirmed label.
- **`/admin/orders`:** a confirmed order shows the **Confirmed** pill (amber) and a "Mark ready →" button → advances to Ready (not a fallthrough "Delivered"). new→ready still works (confirmed skippable); ready→picked-up/delivered fulfillment-pinned.
- **Transition logic:** `tests/order-status-transitions.spec.ts` covers all valid paths, fulfillment-pinned terminals, rejected skips/regressions, and the no-regress `statusAfterConfirmSend`.
- Verified locally: `db reset` applies, pgTAP green, build + lint clean, 17/17 desktop (units + confirmed integration + orders-flow regression), confirmed test green on mobile.

⚠️ Migration is local-only until `supabase db push` to dev/preview (data-only, no schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)