### PR TITLE
Harvest sheet: exclude picked-up / delivered orders (#200)

### DIFF
--- a/src/lib/fulfillment/report.ts
+++ b/src/lib/fulfillment/report.ts
@@ -45,7 +45,12 @@ function round2(n: number): number {
 export async function buildFulfillmentReport(
   weekOf: string,
 ): Promise<FulfillmentReport> {
-  const orders = await listOrders(weekOf);
+  // Fulfilled orders are already out the door — exclude picked-up/delivered so
+  // the sheet only shows what's still to harvest and pack. Negation keeps new,
+  // confirmed (DEC-035), and ready.
+  const orders = (await listOrders(weekOf)).filter(
+    (o) => o.status !== "picked-up" && o.status !== "delivered",
+  );
 
   // ── consolidated harvest list ──────────────────────────────────────────
   const byProduct = new Map<

--- a/tests/fulfillment-report.spec.ts
+++ b/tests/fulfillment-report.spec.ts
@@ -87,3 +87,38 @@ test("invalid token 404s", async ({ page }) => {
   expect(res?.status()).toBe(404);
   await expect(page.getByText("This link doesn’t work.")).toBeVisible();
 });
+
+test("excludes picked-up / delivered orders (#200)", async ({ page }) => {
+  const ids = await customerIds();
+  const sb = admin();
+  // The restaurant's (delivery) order is fulfilled — out the door.
+  await sb
+    .from("orders")
+    .update({ status: "delivered" })
+    .eq("customer_id", ids.restaurant)
+    .eq("week_of", WEEK);
+
+  try {
+    await page.goto(`/f/${await fulfillmentToken()}`);
+
+    // Restaurant slip is gone; the still-active farm-stand slip remains.
+    await expect(
+      page.locator(".fr-slip", { hasText: TEST_CUSTOMERS.restaurant.name }),
+    ).toHaveCount(0);
+    await expect(
+      page.locator(".fr-slip", { hasText: TEST_CUSTOMERS.farmStand.name }),
+    ).toHaveCount(1);
+
+    // Kale drops 5 → 3 (restaurant's 2 excluded); Honey (restaurant-only) gone.
+    await expect(
+      page.locator(".fr-hv-row", { hasText: "Kale" }).locator(".fr-hv-unit-qty"),
+    ).toHaveText("3");
+    await expect(page.locator(".fr-hv-row", { hasText: "Honey" })).toHaveCount(0);
+  } finally {
+    await sb
+      .from("orders")
+      .update({ status: "new" })
+      .eq("customer_id", ids.restaurant)
+      .eq("week_of", WEEK);
+  }
+});


### PR DESCRIPTION
## Summary
The public Harvest & Pack Sheet (`/f/[token]`) no longer shows fulfilled orders — once an order is picked-up or delivered it's out the door (closes #200).

## Files changed
- `src/lib/fulfillment/report.ts` — `buildFulfillmentReport` filters `listOrders` to drop `picked-up`/`delivered` before the harvest rollup + slips
- `tests/fulfillment-report.spec.ts` — new exclusion test

## Code review
@code-review — clean bill of health. Verified: the negation filter (`!== "picked-up" && !== "delivered"`) is future-proof (keeps new/confirmed/ready, and `narrowStatus` coerces unknowns to `new` → safe over-inclusion); `orderCount` reflects the filtered set; both empty states (harvest `fr-empty`, slips gated on `length > 0`) already render cleanly; the test's `finally` status-restore is sound. Note: the in-code comment references `confirmed`/DEC-035 ahead of #190 merging — forward-correct, cosmetic.

## Test plan
- `/f/<token>`: an order in `picked-up` or `delivered` is absent from both the harvest totals and the packing slips; `new`/`confirmed`/`ready` orders still appear. Verified by `tests/fulfillment-report.spec.ts` — marking the restaurant's delivery order `delivered` drops Kale 5→3, removes Honey entirely, and removes its slip; farm-stand slip remains. Restores status in `finally`.
- Ran `npx playwright test tests/fulfillment-report.spec.ts --project=desktop --project=mobile` → 8/8.
- No migration, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)