### PR TITLE
Extract shared SendAction component from send-row (#191)

### DIFF
--- a/src/actions/record-send.ts
+++ b/src/actions/record-send.ts
@@ -12,6 +12,10 @@ export async function recordSend(
   customerId: string,
   weekOf: string,
   mode: SendMode,
+  // Path to revalidate after recording. Defaults to the Send page; the
+  // Orders-page action stack (#192) passes "/admin/orders". Kept optional so
+  // the original 3-arg call sites stay unchanged (#191).
+  revalidate: string = "/admin/send",
 ): Promise<{ error: string | null }> {
   const supabase = await createClient();
 
@@ -35,6 +39,6 @@ export async function recordSend(
 
   if (error) return { error: error.message };
 
-  revalidatePath("/admin/send");
+  revalidatePath(revalidate);
   return { error: null };
 }

--- a/src/components/admin/send-action.tsx
+++ b/src/components/admin/send-action.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState, useTransition, type MouseEvent } from "react";
+
+import { recordSend } from "@/actions/record-send";
+import { buildSmsUrl } from "@/lib/notifications/sms-deep-link";
+import type { SendMode } from "@/lib/admin/send-queue-queries";
+
+type SendActionProps = {
+  customerId: string;
+  phone: string | null;
+  body: string;
+  weekOf: string;
+  mode: SendMode;
+  initialSentAt: string | null;
+  // revalidatePath target after a send is recorded. Send page → /admin/send;
+  // Orders-page action stack (#192) → /admin/orders.
+  revalidate: string;
+  // Lets a layout wrapper (e.g. SendRow's <li data-sent>) mirror sent-state
+  // without owning the send logic.
+  onSentChange?: (sent: boolean) => void;
+};
+
+// Phase 6.7: when the operator is on desktop, `sms:` deep links either no-op
+// or open iMessage on macOS — neither is what Annabel wants when working from
+// her laptop. Detect desktop via the pointer-precision media query (touch-
+// primary devices report "coarse"; trackpad/mouse report "fine") and fall back
+// to copy-body-to-clipboard + the MWS extension bridge.
+function isDesktopOperator(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(pointer: fine)").matches;
+}
+
+function formatSentAt(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+// Shared send mechanics + sent-state display (#191). Extracted from SendRow so
+// the Orders-page action stack (#192) reuses the deep-link / clipboard / MWS
+// bridge and recordSend wiring rather than forking it.
+export function SendAction({
+  customerId,
+  phone,
+  body,
+  weekOf,
+  mode,
+  initialSentAt,
+  revalidate,
+  onSentChange,
+}: SendActionProps) {
+  const [sentAt, setSentAt] = useState<string | null>(initialSentAt);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const smsHref = phone ? buildSmsUrl({ phone, body }) : null;
+  const isSent = sentAt !== null;
+
+  function recordOptimistic() {
+    setError(null);
+    const optimisticTimestamp = new Date().toISOString();
+    setSentAt(optimisticTimestamp);
+    onSentChange?.(true);
+    startTransition(async () => {
+      const result = await recordSend(customerId, weekOf, mode, revalidate);
+      if (result.error) {
+        setSentAt(initialSentAt);
+        onSentChange?.(initialSentAt !== null);
+        setError(result.error);
+      }
+    });
+  }
+
+  async function handleClick(e: MouseEvent<HTMLAnchorElement>) {
+    if (!phone) return;
+
+    if (isDesktopOperator()) {
+      // Desktop path. The Bushel SMS Helper extension (if installed) handles
+      // opening + focusing the MWS tab via chrome.tabs from its service
+      // worker — admin can't manage the tab itself because COOP on
+      // messages.google.com blocks named-target reuse and severs cross-tab
+      // postMessage. We just notify the extension via same-window postMessage
+      // (which the bridge content script picks up) and provide a clipboard
+      // safety net so an operator without the extension can still paste
+      // manually after opening MWS themselves.
+      e.preventDefault();
+      window.postMessage(
+        { type: "bushel-sms-helper:fill", phone, body },
+        window.location.origin,
+      );
+
+      try {
+        await navigator.clipboard.writeText(body);
+      } catch {
+        setError("Clipboard blocked. Copy the message manually, then click Send again.");
+        return;
+      }
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2400);
+    }
+    // Mobile path falls through: the <a href="sms:..."> navigation proceeds
+    // naturally (no preventDefault), and recordOptimistic() runs below.
+    recordOptimistic();
+  }
+
+  return (
+    <>
+      <div className="send-row-status">
+        <span className={"send-status" + (isSent ? " is-sent" : "")}>
+          {isSent ? `Sent · ${formatSentAt(sentAt!)}` : "Unsent"}
+        </span>
+        {copied && (
+          <span className="send-row-copied" role="status">
+            Copied — paste in Messages
+          </span>
+        )}
+        {error && (
+          <span className="send-row-error" role="alert">
+            {error}
+          </span>
+        )}
+      </div>
+      <div className="send-row-action">
+        {smsHref ? (
+          <a
+            href={smsHref}
+            className={"btn" + (isSent ? " btn-secondary" : " btn-primary")}
+            onClick={handleClick}
+            aria-disabled={pending}
+          >
+            {isSent ? "Re-send" : "Send"}
+          </a>
+        ) : (
+          <span className="send-row-disabled">No phone</span>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/admin/send-row.tsx
+++ b/src/components/admin/send-row.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useState, useTransition, type MouseEvent } from "react";
+import { useState } from "react";
 
-import { recordSend } from "@/actions/record-send";
-import { buildSmsUrl } from "@/lib/notifications/sms-deep-link";
+import { SendAction } from "@/components/admin/send-action";
 import type { SendMode } from "@/lib/admin/send-queue-queries";
 
 type SendRowProps = {
@@ -16,26 +15,9 @@ type SendRowProps = {
   initialSentAt: string | null;
 };
 
-// Phase 6.7: when the operator is on desktop, `sms:` deep links either no-op
-// or open iMessage on macOS — neither is what Annabel wants when working from
-// her laptop. Detect desktop via the pointer-precision media query (touch-
-// primary devices report "coarse"; trackpad/mouse report "fine") and fall back
-// to copy-body-to-clipboard + open messages.google.com in a new tab.
-function isDesktopOperator(): boolean {
-  if (typeof window === "undefined") return false;
-  return window.matchMedia("(pointer: fine)").matches;
-}
-
-function formatSentAt(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleString("en-US", {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}
-
+// Send-page queue row. The send mechanics + status/action UI live in the shared
+// SendAction component (#191); this owns the row layout (name/phone) and mirrors
+// SendAction's sent-state onto the <li data-sent> the tests + CSS key off.
 export function SendRow({
   customerId,
   customerName,
@@ -45,58 +27,7 @@ export function SendRow({
   mode,
   initialSentAt,
 }: SendRowProps) {
-  const [sentAt, setSentAt] = useState<string | null>(initialSentAt);
-  const [pending, startTransition] = useTransition();
-  const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
-
-  const smsHref = phone ? buildSmsUrl({ phone, body }) : null;
-  const isSent = sentAt !== null;
-
-  function recordOptimistic() {
-    setError(null);
-    const optimisticTimestamp = new Date().toISOString();
-    setSentAt(optimisticTimestamp);
-    startTransition(async () => {
-      const result = await recordSend(customerId, weekOf, mode);
-      if (result.error) {
-        setSentAt(initialSentAt);
-        setError(result.error);
-      }
-    });
-  }
-
-  async function handleClick(e: MouseEvent<HTMLAnchorElement>) {
-    if (!phone) return;
-
-    if (isDesktopOperator()) {
-      // Desktop path. The Bushel SMS Helper extension (if installed) handles
-      // opening + focusing the MWS tab via chrome.tabs from its service
-      // worker — admin can't manage the tab itself because COOP on
-      // messages.google.com blocks named-target reuse and severs cross-tab
-      // postMessage. We just notify the extension via same-window postMessage
-      // (which the bridge content script picks up) and provide a clipboard
-      // safety net so an operator without the extension can still paste
-      // manually after opening MWS themselves.
-      e.preventDefault();
-      window.postMessage(
-        { type: "bushel-sms-helper:fill", phone, body },
-        window.location.origin,
-      );
-
-      try {
-        await navigator.clipboard.writeText(body);
-      } catch {
-        setError("Clipboard blocked. Copy the message manually, then click Send again.");
-        return;
-      }
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2400);
-    }
-    // Mobile path falls through: the <a href="sms:..."> navigation proceeds
-    // naturally (no preventDefault), and recordOptimistic() runs below.
-    recordOptimistic();
-  }
+  const [isSent, setIsSent] = useState(initialSentAt !== null);
 
   return (
     <li className="send-row" data-customer-id={customerId} data-sent={isSent ? "true" : "false"}>
@@ -104,35 +35,16 @@ export function SendRow({
         <div className="send-row-customer">{customerName}</div>
         <div className="send-row-phone">{phone ?? "no phone on file"}</div>
       </div>
-      <div className="send-row-status">
-        <span className={"send-status" + (isSent ? " is-sent" : "")}>
-          {isSent ? `Sent · ${formatSentAt(sentAt!)}` : "Unsent"}
-        </span>
-        {copied && (
-          <span className="send-row-copied" role="status">
-            Copied — paste in Messages
-          </span>
-        )}
-        {error && (
-          <span className="send-row-error" role="alert">
-            {error}
-          </span>
-        )}
-      </div>
-      <div className="send-row-action">
-        {smsHref ? (
-          <a
-            href={smsHref}
-            className={"btn" + (isSent ? " btn-secondary" : " btn-primary")}
-            onClick={handleClick}
-            aria-disabled={pending}
-          >
-            {isSent ? "Re-send" : "Send"}
-          </a>
-        ) : (
-          <span className="send-row-disabled">No phone</span>
-        )}
-      </div>
+      <SendAction
+        customerId={customerId}
+        phone={phone}
+        body={body}
+        weekOf={weekOf}
+        mode={mode}
+        initialSentAt={initialSentAt}
+        revalidate="/admin/send"
+        onSentChange={setIsSent}
+      />
     </li>
   );
 }


### PR DESCRIPTION
## Summary
Refactor-only: pull the send mechanics out of `send-row.tsx` into a reusable `SendAction` so the Orders-page action stack (#192) reuses the logic instead of forking it. Closes #191. No behavior change.

## Files changed
- `src/components/admin/send-action.tsx` (new) — `SendAction`: `sms:` deep-link, MWS extension bridge postMessage, clipboard fallback, `recordOptimistic`/`recordSend` wiring, Send/Re-send button, status/copied/error display. New props: `revalidate`, `onSentChange`
- `src/components/admin/send-row.tsx` — slimmed to the `<li.send-row data-customer-id data-sent>` row layout (name/phone) + `<SendAction>`; mirrors sent-state for the `data-sent` attribute
- `src/actions/record-send.ts` — optional 4th `revalidate` param (default `/admin/send`)

## Code review
@code-review — clean bill of health. All four parity claims verified: (1) DOM byte-identical — `SendAction` returns the status+action blocks via a React fragment, so they stay direct grid children of `.send-row` (a wrapper would've broken the `grid-template-areas` layout); (2) `onSentChange` mirrors correctly on both optimistic-set and rollback (restores to original sent-state, not hardcoded false); (3) optional `revalidate` keeps existing call sites working; (4) no state desync between `SendAction.sentAt` and `SendRow.isSent`.

## Test plan
- Parity gate (no new behavior): `/admin/send` Send/Re-send still records the send, flips the status pill + `data-sent`, desktop path postMessages the MWS bridge + copies to clipboard, mobile path follows the `sms:` deep link.
- `npx playwright test tests/admin-send.spec.ts tests/notifications-flow.spec.ts --project=desktop` → 8/8 (1 mobile-only skipped). Mobile send path green; the one flaky mobile test is the pre-existing IntroNoteCard WebKit flake (untouched, passes on retry).
- No migration / schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)