### PR TITLE
Orders page: per-order action stack in expanded detail (#192)

### DIFF
--- a/src/components/admin/order-actions.tsx
+++ b/src/components/admin/order-actions.tsx
@@ -18,7 +18,7 @@ export function OrderActions({
   pending,
 }: {
   order: OrderRowData;
-  onAdvance: (next: OrderStatus) => void;
+  onAdvance: (next: OrderStatus, quiet?: boolean) => void;
   pending: boolean;
 }) {
   const isPickup = order.fulfillmentType === "pickup";
@@ -49,9 +49,11 @@ export function OrderActions({
         initialSentAt={order.confirmSentAt}
         revalidate="/admin/orders"
         onRecorded={() => {
-          // Auto-advance new → confirmed; never regress a later status.
+          // Auto-advance new → confirmed; never regress a later status. Quiet:
+          // if the order already moved past new (mid-flight Mark / double-tap),
+          // the server rejects new→confirmed — non-actionable, so don't surface it.
           const next = statusAfterConfirmSend(order.status);
-          if (next !== order.status) onAdvance(next);
+          if (next !== order.status) onAdvance(next, true);
         }}
       />
 

--- a/src/components/admin/order-actions.tsx
+++ b/src/components/admin/order-actions.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { SendAction } from "@/components/admin/send-action";
+import type { OrderRow as OrderRowData, OrderStatus } from "@/lib/admin/orders-queries";
+import { statusAfterConfirmSend } from "@/lib/admin/orders-queries";
+import {
+  orderConfirmationBody,
+  pickupReminderBody,
+} from "@/lib/notifications/templates";
+
+// Per-order action stack (#192) — shown under the status chip when a row is
+// expanded. Confirm + (pickup) reminder reuse the shared SendAction mechanics
+// (labeled-button variant); Mark buttons advance status. Plain buttons, no
+// icons (design/admin-orders.jsx).
+export function OrderActions({
+  order,
+  onAdvance,
+  pending,
+}: {
+  order: OrderRowData;
+  onAdvance: (next: OrderStatus) => void;
+  pending: boolean;
+}) {
+  const isPickup = order.fulfillmentType === "pickup";
+  const terminalNext: OrderStatus = isPickup ? "picked-up" : "delivered";
+  const terminalLabel = isPickup ? "Mark picked up" : "Mark delivered";
+
+  const readyDone =
+    order.status === "ready" ||
+    order.status === "picked-up" ||
+    order.status === "delivered";
+  const terminalDone =
+    order.status === "picked-up" || order.status === "delivered";
+
+  return (
+    <div className="ord-actions">
+      <SendAction
+        label="Confirm order"
+        customerId={order.customerId}
+        phone={order.phone}
+        body={orderConfirmationBody({
+          customerName: order.customerName,
+          fulfillmentType: order.fulfillmentType,
+          pickupNote: order.pickupNote,
+          deliveryPreference: order.deliveryPreference,
+        })}
+        weekOf={order.weekOf}
+        mode="order_confirmation"
+        initialSentAt={order.confirmSentAt}
+        revalidate="/admin/orders"
+        onRecorded={() => {
+          // Auto-advance new → confirmed; never regress a later status.
+          const next = statusAfterConfirmSend(order.status);
+          if (next !== order.status) onAdvance(next);
+        }}
+      />
+
+      {isPickup && (
+        <SendAction
+          label="Pickup reminder"
+          customerId={order.customerId}
+          phone={order.phone}
+          body={pickupReminderBody({ customerName: order.customerName })}
+          weekOf={order.weekOf}
+          mode="pickup_reminder"
+          initialSentAt={order.reminderSentAt}
+          revalidate="/admin/orders"
+        />
+      )}
+
+      <button
+        type="button"
+        className="status-advance"
+        disabled={pending || readyDone}
+        onClick={(e) => {
+          e.stopPropagation();
+          onAdvance("ready");
+        }}
+      >
+        Mark ready
+      </button>
+      <button
+        type="button"
+        className="status-advance"
+        disabled={pending || terminalDone}
+        onClick={(e) => {
+          e.stopPropagation();
+          onAdvance(terminalNext);
+        }}
+      >
+        {terminalLabel}
+      </button>
+    </div>
+  );
+}

--- a/src/components/admin/order-row.tsx
+++ b/src/components/admin/order-row.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition, Fragment } from "react";
 
 import { advanceOrderStatus } from "@/actions/advance-order-status";
 import { OrderDetail } from "@/components/admin/order-detail";
+import { OrderActions } from "@/components/admin/order-actions";
 import type { OrderRow as OrderRowData, OrderStatus } from "@/lib/admin/orders-queries";
 import { totalItemCount } from "@/lib/order-items";
 
@@ -37,75 +38,15 @@ function itemsPreview(items: OrderRowData["items"]): string {
   return `${names}${extra}`;
 }
 
-function StatusControl({
-  order,
-  onAdvance,
-  pending,
-}: {
-  order: OrderRowData;
-  onAdvance: (next: OrderStatus) => void;
-  pending: boolean;
-}) {
-  if (order.status === "new") {
-    return (
-      <div className="status-control">
-        <span className="pill pill-new">New</span>
-        <button
-          type="button"
-          className="status-advance"
-          onClick={(e) => {
-            e.stopPropagation();
-            onAdvance("ready");
-          }}
-          disabled={pending}
-        >
-          Mark ready →
-        </button>
-      </div>
-    );
-  }
-  if (order.status === "confirmed") {
-    return (
-      <div className="status-control">
-        <span className="pill pill-confirmed">Confirmed</span>
-        <button
-          type="button"
-          className="status-advance"
-          onClick={(e) => {
-            e.stopPropagation();
-            onAdvance("ready");
-          }}
-          disabled={pending}
-        >
-          Mark ready →
-        </button>
-      </div>
-    );
-  }
-  if (order.status === "ready") {
-    const terminal: OrderStatus =
-      order.fulfillmentType === "pickup" ? "picked-up" : "delivered";
-    const label = terminal === "picked-up" ? "Picked up ✓" : "Delivered ✓";
-    return (
-      <div className="status-control">
-        <span className="pill pill-ready">Ready</span>
-        <button
-          type="button"
-          className="status-advance"
-          onClick={(e) => {
-            e.stopPropagation();
-            onAdvance(terminal);
-          }}
-          disabled={pending}
-        >
-          {label}
-        </button>
-      </div>
-    );
-  }
-  if (order.status === "picked-up") {
+// Collapsed rows show only the chip (#192). The advance + send controls live
+// in OrderActions, rendered under the chip when the row is expanded.
+function StatusChip({ status }: { status: OrderStatus }) {
+  if (status === "new") return <span className="pill pill-new">New</span>;
+  if (status === "confirmed")
+    return <span className="pill pill-confirmed">Confirmed</span>;
+  if (status === "ready") return <span className="pill pill-ready">Ready</span>;
+  if (status === "picked-up")
     return <span className="pill pill-done">Picked up</span>;
-  }
   return <span className="pill pill-done">Delivered</span>;
 }
 
@@ -170,12 +111,21 @@ export function OrderRow({ order, isOpen, onToggle }: Props) {
           <div className="ord-total mono">{formatMoney(view.totalCents)}</div>
         </td>
         <td className="col-o-status" onClick={(e) => e.stopPropagation()}>
-          <StatusControl order={view} onAdvance={handleAdvance} pending={pending} />
-          {error && (
-            <div className="ord-row-error" role="alert">
-              {error}
-            </div>
-          )}
+          <div className="status-stack">
+            <StatusChip status={view.status} />
+            {isOpen && (
+              <OrderActions
+                order={view}
+                onAdvance={handleAdvance}
+                pending={pending}
+              />
+            )}
+            {error && (
+              <div className="ord-row-error" role="alert">
+                {error}
+              </div>
+            )}
+          </div>
         </td>
       </tr>
       {isOpen && (

--- a/src/components/admin/order-row.tsx
+++ b/src/components/admin/order-row.tsx
@@ -55,7 +55,11 @@ export function OrderRow({ order, isOpen, onToggle }: Props) {
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
 
-  function handleAdvance(next: OrderStatus) {
+  // `quiet` suppresses the error surface — used by the confirm auto-advance,
+  // where a rejected new→confirmed (because the order already moved past new,
+  // e.g. a mid-flight Mark-ready or double-tap) is non-actionable: the send
+  // still succeeded, so we just roll the optimistic status back silently.
+  function handleAdvance(next: OrderStatus, quiet = false) {
     setError(null);
     const previous = optimisticStatus;
     setOptimisticStatus(next);
@@ -63,7 +67,7 @@ export function OrderRow({ order, isOpen, onToggle }: Props) {
       const result = await advanceOrderStatus(order.id, next);
       if (result.error) {
         setOptimisticStatus(previous);
-        setError(result.error);
+        if (!quiet) setError(result.error);
       }
     });
   }

--- a/src/components/admin/send-action.tsx
+++ b/src/components/admin/send-action.tsx
@@ -19,6 +19,12 @@ type SendActionProps = {
   // Lets a layout wrapper (e.g. SendRow's <li data-sent>) mirror sent-state
   // without owning the send logic.
   onSentChange?: (sent: boolean) => void;
+  // When set, renders the compact labeled-button "stack" presentation used by
+  // the Orders-page action stack (#192) instead of the Send-page row markup.
+  label?: string;
+  // Fires after a send is successfully recorded (server round-trip OK). The
+  // Orders confirm action uses this to auto-advance new → confirmed.
+  onRecorded?: () => void;
 };
 
 // Phase 6.7: when the operator is on desktop, `sms:` deep links either no-op
@@ -53,6 +59,8 @@ export function SendAction({
   initialSentAt,
   revalidate,
   onSentChange,
+  label,
+  onRecorded,
 }: SendActionProps) {
   const [sentAt, setSentAt] = useState<string | null>(initialSentAt);
   const [pending, startTransition] = useTransition();
@@ -73,6 +81,8 @@ export function SendAction({
         setSentAt(initialSentAt);
         onSentChange?.(initialSentAt !== null);
         setError(result.error);
+      } else {
+        onRecorded?.();
       }
     });
   }
@@ -107,6 +117,34 @@ export function SendAction({
     // Mobile path falls through: the <a href="sms:..."> navigation proceeds
     // naturally (no preventDefault), and recordOptimistic() runs below.
     recordOptimistic();
+  }
+
+  // Orders-page action-stack presentation: a labeled row with an inline Send
+  // button (design/admin-orders.jsx `.send-action`).
+  if (label !== undefined) {
+    return (
+      <div className="send-action">
+        <span className="send-action-label">{label}</span>
+        {isSent && <span className="send-action-sent">Sent</span>}
+        {smsHref ? (
+          <a
+            href={smsHref}
+            className="btn-send"
+            onClick={handleClick}
+            aria-disabled={pending}
+          >
+            {isSent ? "Re-send" : "Send"}
+          </a>
+        ) : (
+          <span className="send-row-disabled">No phone</span>
+        )}
+        {error && (
+          <span className="send-row-error" role="alert">
+            {error}
+          </span>
+        )}
+      </div>
+    );
   }
 
   return (

--- a/src/lib/admin/orders-queries.ts
+++ b/src/lib/admin/orders-queries.ts
@@ -72,6 +72,8 @@ export type OrderRow = {
   id: string;
   customerId: string;
   customerName: string;
+  // Drives the per-order Send actions (#192). Null → "No phone" disabled state.
+  phone: string | null;
   placedAt: string;
   weekOf: string;
   fulfillmentType: "pickup" | "delivery";
@@ -83,6 +85,10 @@ export type OrderRow = {
   needsReconciliation: boolean;
   items: OrderItem[];
   totalCents: number;
+  // Per-mode sent timestamps for this customer's current-week sends (#192).
+  // Null = not yet sent. Drives the Send/Re-send state in the action stack.
+  confirmSentAt: string | null;
+  reminderSentAt: string | null;
 };
 
 function narrowStatus(s: string): OrderStatus {
@@ -103,26 +109,46 @@ export function currentWeekOf(): string {
 export async function listOrders(weekOf: string): Promise<OrderRow[]> {
   const supabase = createAdminClient();
 
-  const { data, error } = await supabase
-    .from("orders")
-    .select(
-      `id, customer_id, created_at, week_of, fulfillment_type,
-       delivery_address, delivery_preference, pickup_note, notes,
-       status, needs_reconciliation,
-       customers(id, name),
-       order_items(product_id, qty, unit_price_cents,
-         products(name, description, unit, qty_available),
-         product_units(label, conversion_to_base))`,
-    )
-    .eq("week_of", weekOf)
-    .order("created_at", { ascending: false });
+  // Orders + the week's customer_sends (for per-order Send state, #192) in
+  // parallel. customer_sends is keyed (customer_id, week_of, mode); since
+  // there's one order per customer per week, customer_id maps 1:1 to an order.
+  const [{ data, error }, sendsResult] = await Promise.all([
+    supabase
+      .from("orders")
+      .select(
+        `id, customer_id, created_at, week_of, fulfillment_type,
+         delivery_address, delivery_preference, pickup_note, notes,
+         status, needs_reconciliation,
+         customers(id, name, phone),
+         order_items(product_id, qty, unit_price_cents,
+           products(name, description, unit, qty_available),
+           product_units(label, conversion_to_base))`,
+      )
+      .eq("week_of", weekOf)
+      .order("created_at", { ascending: false }),
+    supabase
+      .from("customer_sends")
+      .select("customer_id, mode, sent_at")
+      .eq("week_of", weekOf),
+  ]);
 
   if (error) throw new Error(`listOrders: ${error.message}`);
+  if (sendsResult.error)
+    throw new Error(`listOrders(sends): ${sendsResult.error.message}`);
+
+  const sentByCustomer = new Map<string, { confirm: string | null; reminder: string | null }>();
+  for (const s of sendsResult.data ?? []) {
+    const entry = sentByCustomer.get(s.customer_id) ?? { confirm: null, reminder: null };
+    if (s.mode === "order_confirmation") entry.confirm = s.sent_at;
+    else if (s.mode === "pickup_reminder") entry.reminder = s.sent_at;
+    sentByCustomer.set(s.customer_id, entry);
+  }
 
   return (data ?? [])
     .filter((o) => o.customers !== null)
     .map((o) => {
-      const c = o.customers as { id: string; name: string };
+      const c = o.customers as { id: string; name: string; phone: string | null };
+      const sent = sentByCustomer.get(c.id) ?? { confirm: null, reminder: null };
       const items: OrderItem[] = ((o.order_items ?? []) as Array<{
         product_id: string;
         qty: number;
@@ -162,6 +188,7 @@ export async function listOrders(weekOf: string): Promise<OrderRow[]> {
         id: o.id,
         customerId: c.id,
         customerName: c.name,
+        phone: c.phone,
         placedAt: o.created_at,
         weekOf: o.week_of,
         fulfillmentType: narrowFulfillment(o.fulfillment_type),
@@ -173,6 +200,8 @@ export async function listOrders(weekOf: string): Promise<OrderRow[]> {
         needsReconciliation: o.needs_reconciliation,
         items,
         totalCents,
+        confirmSentAt: sent.confirm,
+        reminderSentAt: sent.reminder,
       };
     });
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2449,7 +2449,26 @@
   text-align: right;
 }
 
-.status-control { display: flex; flex-direction: column; align-items: flex-start; gap: 6px; }
+/* Per-order status cell (#192): chip always; action stack under it when the
+   row is expanded. Design: design/admin-orders.{jsx,css}. */
+.status-stack { display: flex; flex-direction: column; align-items: stretch; gap: 8px; width: 100%; }
+.status-stack > .pill { align-self: flex-start; }
+
+.ord-actions { display: flex; flex-direction: column; gap: 6px; width: 100%; }
+.ord-actions .status-advance { width: 100%; justify-content: center; }
+
+.send-action { display: flex; align-items: center; gap: 8px; width: 100%; }
+.send-action-label { flex: 1; font-size: 0.82rem; color: var(--ink-700); white-space: nowrap; }
+.send-action-sent { font-size: 0.7rem; font-weight: 600; letter-spacing: 0.02em; color: var(--leaf-700); }
+.btn-send {
+  background: var(--leaf-600); color: var(--paper); border: none;
+  border-radius: var(--r-sm); padding: 4px 12px;
+  font-family: var(--sans); font-size: 0.78rem; font-weight: 600;
+  cursor: pointer; white-space: nowrap; transition: background 0.1s;
+}
+.btn-send:hover { background: var(--leaf-700); }
+.btn-send[aria-disabled="true"] { opacity: 0.5; cursor: default; }
+
 .pill {
   display: inline-flex; align-items: center;
   padding: 3px 10px;
@@ -2731,20 +2750,17 @@
   .ord-items-prev { -webkit-line-clamp: 2; }
   .ord-ful { flex-direction: row; align-items: center; gap: 8px; }
 
-  /* Status row: pill + advance button on a single line, button is full-width
-     and ≥44px tall (WCAG 2.5.5). */
-  .status-control {
-    flex-direction: row;
-    align-items: center;
-    gap: 10px;
-    margin-top: 4px;
-  }
-  .status-advance {
-    flex: 1;
+  /* Action stack (#192): full-width, touch-sized controls (≥44px, WCAG 2.5.5). */
+  .ord-actions { gap: 8px; margin-top: 4px; }
+  .ord-actions .status-advance {
     min-height: 44px;
     padding: 0 16px;
     font-size: 0.9rem;
-    justify-content: center;
+  }
+  .send-action .btn-send {
+    min-height: 44px;
+    padding: 0 16px;
+    font-size: 0.88rem;
   }
 
   /* Detail panel: collapse to single column, tighten padding. */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2467,7 +2467,7 @@
   cursor: pointer; white-space: nowrap; transition: background 0.1s;
 }
 .btn-send:hover { background: var(--leaf-700); }
-.btn-send[aria-disabled="true"] { opacity: 0.5; cursor: default; }
+.btn-send[aria-disabled="true"] { opacity: 0.5; cursor: default; pointer-events: none; }
 
 .pill {
   display: inline-flex; align-items: center;

--- a/tests/admin-orders.spec.ts
+++ b/tests/admin-orders.spec.ts
@@ -11,14 +11,31 @@ import {
   setProductQty,
 } from "./helpers";
 import { weekOfMondayNY } from "@/lib/week";
+import type { Locator } from "@playwright/test";
+
+// #192: the per-order action stack (Mark/Confirm/Send buttons) renders only
+// when the row is expanded. Click a non-status cell to toggle it open.
+async function expandRow(row: Locator): Promise<void> {
+  await row.locator(".col-o-cust").click();
+}
 
 test.describe("admin orders list", () => {
   test.use({ storageState: ADMIN_STORAGE_STATE });
 
   const thisWeek = weekOfMondayNY();
 
-  test.beforeEach(async () => {
+  test.beforeEach(async ({ context, browserName }) => {
+    // The desktop Confirm/Send path writes the SMS body to the clipboard before
+    // recording (Phase 6.7). Grant the permission so the action-stack send tests
+    // don't error on clipboard-write. WebKit doesn't support the permission name
+    // and goes down the sms: deep-link path instead, so it's chromium-only.
+    if (browserName === "chromium") {
+      await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    }
     await clearOrdersForWeek(thisWeek);
+    // Clear the week's sends so the action-stack Send buttons start at "Send"
+    // (not "Re-send") regardless of prior-test/prior-run send state.
+    await admin().from("customer_sends").delete().eq("week_of", thisWeek);
   });
 
   test.afterAll(async () => {
@@ -101,6 +118,7 @@ test.describe("admin orders list", () => {
     await page.goto("/admin/orders");
     const row = page.locator(`tr.ord-row[data-order-id="${orderId}"]`);
     await expect(row).toHaveAttribute("data-status", "new");
+    await expandRow(row);
 
     const sb = admin();
 
@@ -156,6 +174,7 @@ test.describe("admin orders list", () => {
     await expect(row).toHaveAttribute("data-status", "confirmed");
     // Renders the Confirmed pill — not a fallthrough "Delivered" done-pill.
     await expect(row.locator(".pill-confirmed")).toHaveText("Confirmed");
+    await expandRow(row);
 
     await row.getByRole("button", { name: /mark ready/i }).click();
     await expect(row).toHaveAttribute("data-status", "ready", { timeout: 5000 });
@@ -175,8 +194,9 @@ test.describe("admin orders list", () => {
     await page.goto("/admin/orders");
     const row = page.locator(`tr.ord-row[data-order-id="${orderId}"]`);
     await expect(row).toHaveAttribute("data-status", "ready");
+    await expandRow(row);
 
-    // Pickup orders show the "Picked up" advance button, not "Delivered".
+    // Pickup orders show the "Mark picked up" advance button, not "Delivered".
     await expect(row.getByRole("button", { name: /delivered/i })).toHaveCount(0);
     await row.getByRole("button", { name: /picked up/i }).click();
     await expect(row).toHaveAttribute("data-status", "picked-up", { timeout: 5000 });
@@ -196,6 +216,57 @@ test.describe("admin orders list", () => {
         { timeout: 5000 },
       )
       .toBe("picked-up");
+  });
+
+  test("action stack: collapsed shows only the chip; expanded Confirm+Send advances new → confirmed; reminder is pickup-only (#192)", async ({ page }, testInfo) => {
+    const ids = await customerIds();
+    const pickupId = await seedOrder({
+      customerId: ids.farmStand,
+      weekOf: thisWeek,
+      fulfillmentType: "pickup",
+      items: [{ productId: TEST_PRODUCTS.honey.id, qty: 1, unitPriceCents: 1200 }],
+    });
+    const deliveryId = await seedOrder({
+      customerId: ids.restaurant,
+      weekOf: thisWeek,
+      fulfillmentType: "delivery",
+      items: [{ productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 }],
+    });
+    // The Confirm/Send link only renders with a phone on file (else "No phone").
+    await admin()
+      .from("customers")
+      .update({ phone: "2165550100" })
+      .eq("id", ids.restaurant);
+
+    await page.goto("/admin/orders");
+
+    // Collapsed: chip only, no action stack.
+    const pickupRow = page.locator(`tr.ord-row[data-order-id="${pickupId}"]`);
+    await expect(pickupRow.locator(".pill-new")).toHaveText("New");
+    await expect(pickupRow.locator(".ord-actions")).toHaveCount(0);
+
+    // Pickup order expanded → has a Pickup reminder send action.
+    await expandRow(pickupRow);
+    const pickupActions = pickupRow.locator(".ord-actions");
+    await expect(pickupActions).toBeVisible();
+    await expect(pickupActions.getByText("Pickup reminder")).toBeVisible();
+
+    // Delivery order expanded → Confirm but NO reminder (DEC-014 / #193).
+    const deliveryRow = page.locator(`tr.ord-row[data-order-id="${deliveryId}"]`);
+    await expandRow(deliveryRow);
+    const deliveryActions = deliveryRow.locator(".ord-actions");
+    await expect(deliveryActions.getByText("Confirm order")).toBeVisible();
+    await expect(deliveryActions.getByText(/reminder/i)).toHaveCount(0);
+
+    // Confirm + Send records the send and auto-advances new → confirmed.
+    // Desktop-only: WebKit navigates to sms:… on click and clears the page.
+    if (testInfo.project.name === "mobile") return;
+    await deliveryActions
+      .locator(".send-action", { hasText: "Confirm order" })
+      .getByRole("link", { name: /^send$/i })
+      .click();
+    await expect(deliveryRow).toHaveAttribute("data-status", "confirmed", { timeout: 5000 });
+    await expect(deliveryRow.locator(".pill-confirmed")).toHaveText("Confirmed");
   });
 
   test("mobile (375px): page fits viewport; cards stack; status-advance is touch-sized; recon-pin renders; expand works", async ({ page, viewport }, testInfo) => {
@@ -231,17 +302,17 @@ test.describe("admin orders list", () => {
     await expect(firstRow).toHaveAttribute("data-order-id", reconId);
     await expect(firstRow.locator(".badge-recon")).toBeVisible();
 
-    // (c) Status-advance is ≥44px tall (Apple HIG / WCAG 2.5.5).
-    const advanceBtn = firstRow.getByRole("button", { name: /mark ready/i });
-    const box = await advanceBtn.boundingBox();
-    expect(box, "Status-advance button should be visible").not.toBeNull();
-    expect(box!.height).toBeGreaterThanOrEqual(44);
-
-    // (d) Tapping the card opens the detail; line items render in the stacked layout.
+    // (c) Tapping the card opens the detail; the action stack appears (#192).
     await firstRow.click();
     const detail = page.locator("tr.ord-detail-row .ord-detail");
     await expect(detail).toBeVisible();
     await expect(detail.locator(".ord-li-name")).toContainText("Honey");
+
+    // (d) The expanded action stack's advance button is ≥44px tall (WCAG 2.5.5).
+    const advanceBtn = firstRow.getByRole("button", { name: /mark ready/i });
+    const box = await advanceBtn.boundingBox();
+    expect(box, "Status-advance button should be visible").not.toBeNull();
+    expect(box!.height).toBeGreaterThanOrEqual(44);
   });
 
   test("line-level oversold badge gates on order.needsReconciliation (orders that fit at placement stay clean once inventory hits zero)", async ({ page }) => {

--- a/tests/orders-flow.spec.ts
+++ b/tests/orders-flow.spec.ts
@@ -92,6 +92,8 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
 
     const row = adminPage.locator(`tr.ord-row[data-order-id="${orderId}"]`);
     await expect(row).toHaveAttribute("data-status", "new");
+    // #192: advance buttons live in the expanded row — open it first.
+    await row.locator(".col-o-cust").click();
 
     // new → ready
     await row.getByRole("button", { name: /mark ready/i }).click();


### PR DESCRIPTION
## Summary
Build the approved `design/admin-orders.jsx` action stack (closes #192). Collapsed rows show only the status chip; expanding reveals a vertical action stack. Stacked on #191 (merged) and #190's confirmed flow.

## Files changed
- `src/components/admin/order-actions.tsx` (new) — Confirm+Send, Pickup reminder+Send (pickup-only), Mark ready, Mark picked up/delivered
- `src/components/admin/order-row.tsx` — chip-only collapsed; `OrderActions` when expanded; `handleAdvance` gains a `quiet` flag
- `src/components/admin/send-action.tsx` — `label` variant (`.send-action` labeled button) + `onRecorded` callback
- `src/lib/admin/orders-queries.ts` — `listOrders` adds `phone` + `confirmSentAt`/`reminderSentAt` (parallel `customer_sends` query)
- `src/styles/app.css` — `.status-stack` / `.ord-actions` / `.send-action*` / `.btn-send`
- `tests/admin-orders.spec.ts`, `tests/orders-flow.spec.ts`

## Behavior / decisions
- **Confirm + Send** records `order_confirmation` and auto-advances `new→confirmed` via `statusAfterConfirmSend` (no-regress, DEC-035).
- **Reminder is pickup-only** (DEC-014; delivery reminder is #193).
- Mark buttons disable at-state; terminal pinned to fulfillment type.
- `.ord-actions` namespaced to avoid the customer-side `.status-actions`.

## Code review
@code-review found one real issue: the confirm auto-advance read stale optimistic status via its closure, so a mid-flight Mark-ready or a double-tapped Send could fire `new→confirmed` against an already-advanced order and surface a confusing (server-rejected, harmless) error. Fixed in 4b7a127 — `handleAdvance(quiet)` rolls back silently for the non-actionable auto-advance rejection, and `.btn-send[aria-disabled="true"]` gets `pointer-events:none` to kill the double-tap. Everything else verified clean (listOrders query correctness/no-N+1, no-label SendAction path byte-identical, Mark-button logic, CSS namespacing).

## Test plan
- `/admin/orders`: collapsed row shows only the status chip. Expand → action stack: Confirm+Send, Pickup reminder+Send (pickup orders only — delivery has none), Mark ready, Mark picked up/delivered.
- Confirm+Send on a `new` order → records the send and flips the chip New→Confirmed; on an already-`ready` order the chip doesn't regress.
- Mark buttons advance and disable at-state; pickup → "Mark picked up", delivery → "Mark delivered".
- `npx playwright test tests/admin-orders.spec.ts tests/orders-flow.spec.ts --project=desktop` and `--project=mobile` → green (the confirm-Send click is desktop-only; WebKit clears the page on `sms:`). Send-page parity (`admin-send`/`notifications-flow`) unaffected by the SendAction `label` variant.
- No migration / schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)