### PR TITLE
Add delivery reminder send mode + template (#193, amends DEC-014)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -102,6 +102,8 @@ Locked during planning + poker. New decisions append. Superseded notes stay.
 
 **Decision:** Morning-of pickup reminder to pickup customers only. No delivery reminders (B2B locations are staffed).
 
+**Amended 2026-06-04 (#193):** delivery reminders are now sent too — per-order, operator-initiated from the Orders-page action stack, using a distinct `delivery_reminder` send mode + `deliveryReminderBody` template. Annabel wanted parity with pickup reminders. The original "staffed locations don't need it" rationale held until she asked; sending one is cheap (operator-initiated `sms:` deep link, no automation) and harmless.
+
 ---
 
 ## DEC-015 — Order edits/cancellations

--- a/src/components/admin/order-actions.tsx
+++ b/src/components/admin/order-actions.tsx
@@ -4,6 +4,7 @@ import { SendAction } from "@/components/admin/send-action";
 import type { OrderRow as OrderRowData, OrderStatus } from "@/lib/admin/orders-queries";
 import { statusAfterConfirmSend } from "@/lib/admin/orders-queries";
 import {
+  deliveryReminderBody,
   orderConfirmationBody,
   pickupReminderBody,
 } from "@/lib/notifications/templates";
@@ -57,18 +58,20 @@ export function OrderActions({
         }}
       />
 
-      {isPickup && (
-        <SendAction
-          label="Pickup reminder"
-          customerId={order.customerId}
-          phone={order.phone}
-          body={pickupReminderBody({ customerName: order.customerName })}
-          weekOf={order.weekOf}
-          mode="pickup_reminder"
-          initialSentAt={order.reminderSentAt}
-          revalidate="/admin/orders"
-        />
-      )}
+      <SendAction
+        label={isPickup ? "Pickup reminder" : "Delivery reminder"}
+        customerId={order.customerId}
+        phone={order.phone}
+        body={
+          isPickup
+            ? pickupReminderBody({ customerName: order.customerName })
+            : deliveryReminderBody({ customerName: order.customerName })
+        }
+        weekOf={order.weekOf}
+        mode={isPickup ? "pickup_reminder" : "delivery_reminder"}
+        initialSentAt={order.reminderSentAt}
+        revalidate="/admin/orders"
+      />
 
       <button
         type="button"

--- a/src/lib/admin/orders-queries.ts
+++ b/src/lib/admin/orders-queries.ts
@@ -136,11 +136,24 @@ export async function listOrders(weekOf: string): Promise<OrderRow[]> {
   if (sendsResult.error)
     throw new Error(`listOrders(sends): ${sendsResult.error.message}`);
 
-  const sentByCustomer = new Map<string, { confirm: string | null; reminder: string | null }>();
+  // Reminder mode is per-fulfillment (#193): pickup orders use pickup_reminder,
+  // delivery orders use delivery_reminder — tracked separately, resolved per
+  // order below.
+  type SentEntry = {
+    confirm: string | null;
+    pickupReminder: string | null;
+    deliveryReminder: string | null;
+  };
+  const sentByCustomer = new Map<string, SentEntry>();
   for (const s of sendsResult.data ?? []) {
-    const entry = sentByCustomer.get(s.customer_id) ?? { confirm: null, reminder: null };
+    const entry = sentByCustomer.get(s.customer_id) ?? {
+      confirm: null,
+      pickupReminder: null,
+      deliveryReminder: null,
+    };
     if (s.mode === "order_confirmation") entry.confirm = s.sent_at;
-    else if (s.mode === "pickup_reminder") entry.reminder = s.sent_at;
+    else if (s.mode === "pickup_reminder") entry.pickupReminder = s.sent_at;
+    else if (s.mode === "delivery_reminder") entry.deliveryReminder = s.sent_at;
     sentByCustomer.set(s.customer_id, entry);
   }
 
@@ -148,7 +161,12 @@ export async function listOrders(weekOf: string): Promise<OrderRow[]> {
     .filter((o) => o.customers !== null)
     .map((o) => {
       const c = o.customers as { id: string; name: string; phone: string | null };
-      const sent = sentByCustomer.get(c.id) ?? { confirm: null, reminder: null };
+      const sent = sentByCustomer.get(c.id) ?? {
+        confirm: null,
+        pickupReminder: null,
+        deliveryReminder: null,
+      };
+      const fulfillmentType = narrowFulfillment(o.fulfillment_type);
       const items: OrderItem[] = ((o.order_items ?? []) as Array<{
         product_id: string;
         qty: number;
@@ -191,7 +209,7 @@ export async function listOrders(weekOf: string): Promise<OrderRow[]> {
         phone: c.phone,
         placedAt: o.created_at,
         weekOf: o.week_of,
-        fulfillmentType: narrowFulfillment(o.fulfillment_type),
+        fulfillmentType,
         deliveryAddress: o.delivery_address,
         deliveryPreference: o.delivery_preference,
         pickupNote: o.pickup_note,
@@ -201,7 +219,10 @@ export async function listOrders(weekOf: string): Promise<OrderRow[]> {
         items,
         totalCents,
         confirmSentAt: sent.confirm,
-        reminderSentAt: sent.reminder,
+        reminderSentAt:
+          fulfillmentType === "pickup"
+            ? sent.pickupReminder
+            : sent.deliveryReminder,
       };
     });
 }

--- a/src/lib/admin/send-queue-queries.ts
+++ b/src/lib/admin/send-queue-queries.ts
@@ -8,12 +8,14 @@ import { weekOfMondayNY } from "@/lib/week";
 export type SendMode =
   | "weekly_update"
   | "order_confirmation"
-  | "pickup_reminder";
+  | "pickup_reminder"
+  | "delivery_reminder";
 
 export const SEND_MODES: SendMode[] = [
   "weekly_update",
   "order_confirmation",
   "pickup_reminder",
+  "delivery_reminder",
 ];
 
 export type SendQueueRow = {

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -51,3 +51,15 @@ export type PickupReminderInput = {
 export function pickupReminderBody({ customerName }: PickupReminderInput): string {
   return `Hi ${customerName} — reminder that your Bay Branch Farm order is ready for pickup this week. Text back if you need a different time.`;
 }
+
+export type DeliveryReminderInput = {
+  customerName: string;
+};
+
+// #193 (amends DEC-014): delivery reminders are now sent, per-order from the
+// Orders page. Distinct copy from the pickup reminder — it's coming to them.
+export function deliveryReminderBody({
+  customerName,
+}: DeliveryReminderInput): string {
+  return `Hi ${customerName} — reminder that your Bay Branch Farm order is out for delivery this week. Text back if anything needs to change.`;
+}

--- a/supabase/migrations/20260604220000_delivery_reminder_mode.sql
+++ b/supabase/migrations/20260604220000_delivery_reminder_mode.sql
@@ -1,0 +1,13 @@
+-- Delivery reminder send mode (#193 — amends DEC-014).
+--
+-- DEC-014 originally said "no delivery reminders (B2B locations are staffed)".
+-- Annabel wants parity with pickup reminders, sent per-order from the Orders
+-- page. Widen the customer_sends.mode CHECK to accept 'delivery_reminder'.
+-- Kept distinct from pickup_reminder so per-mode sent-state stays unambiguous.
+
+alter table public.customer_sends
+  drop constraint customer_sends_mode_check;
+
+alter table public.customer_sends
+  add constraint customer_sends_mode_check
+  check (mode in ('weekly_update', 'order_confirmation', 'pickup_reminder', 'delivery_reminder'));

--- a/supabase/tests/customer_sends_modes.sql
+++ b/supabase/tests/customer_sends_modes.sql
@@ -1,0 +1,31 @@
+begin;
+select plan(3);
+
+-- Seed prerequisites (bypass-RLS postgres role).
+insert into public.customers (name, token) values ('Mode Test Farm', 'modetest-token-0001');
+
+-- #193: delivery_reminder is now an accepted mode.
+select lives_ok(
+  $$ insert into public.customer_sends (customer_id, week_of, mode)
+       select id, '2026-06-01', 'delivery_reminder' from public.customers where token = 'modetest-token-0001' $$,
+  'customer_sends accepts mode = delivery_reminder'
+);
+
+-- The original pickup_reminder still works.
+select lives_ok(
+  $$ insert into public.customer_sends (customer_id, week_of, mode)
+       select id, '2026-06-01', 'pickup_reminder' from public.customers where token = 'modetest-token-0001' $$,
+  'customer_sends still accepts mode = pickup_reminder'
+);
+
+-- A bogus mode is still rejected by the CHECK.
+select throws_ok(
+  $$ insert into public.customer_sends (customer_id, week_of, mode)
+       select id, '2026-06-01', 'carrier_pigeon' from public.customers where token = 'modetest-token-0001' $$,
+  '23514',
+  null,
+  'customer_sends rejects an unknown mode'
+);
+
+select * from finish();
+rollback;

--- a/tests/admin-orders.spec.ts
+++ b/tests/admin-orders.spec.ts
@@ -218,7 +218,7 @@ test.describe("admin orders list", () => {
       .toBe("picked-up");
   });
 
-  test("action stack: collapsed shows only the chip; expanded Confirm+Send advances new → confirmed; reminder is pickup-only (#192)", async ({ page }, testInfo) => {
+  test("action stack: collapsed shows only the chip; expanded Confirm+Send advances new → confirmed; reminder wording follows fulfillment (#192/#193)", async ({ page }, testInfo) => {
     const ids = await customerIds();
     const pickupId = await seedOrder({
       customerId: ids.farmStand,
@@ -251,12 +251,13 @@ test.describe("admin orders list", () => {
     await expect(pickupActions).toBeVisible();
     await expect(pickupActions.getByText("Pickup reminder")).toBeVisible();
 
-    // Delivery order expanded → Confirm but NO reminder (DEC-014 / #193).
+    // Delivery order expanded → Confirm + a Delivery reminder (#193), not Pickup.
     const deliveryRow = page.locator(`tr.ord-row[data-order-id="${deliveryId}"]`);
     await expandRow(deliveryRow);
     const deliveryActions = deliveryRow.locator(".ord-actions");
     await expect(deliveryActions.getByText("Confirm order")).toBeVisible();
-    await expect(deliveryActions.getByText(/reminder/i)).toHaveCount(0);
+    await expect(deliveryActions.getByText("Delivery reminder")).toBeVisible();
+    await expect(deliveryActions.getByText("Pickup reminder")).toHaveCount(0);
 
     // Confirm + Send records the send and auto-advances new → confirmed.
     // Desktop-only: WebKit navigates to sms:… on click and clears the page.

--- a/tests/notification-templates.spec.ts
+++ b/tests/notification-templates.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import {
+  deliveryReminderBody,
   orderConfirmationBody,
   pickupReminderBody,
   weeklyUpdateBody,
@@ -109,6 +110,14 @@ test.describe("pickupReminderBody", () => {
   test("includes customer name and pickup-day reminder", () => {
     expect(pickupReminderBody({ customerName: "Hannah" })).toBe(
       "Hi Hannah — reminder that your Bay Branch Farm order is ready for pickup this week. Text back if you need a different time.",
+    );
+  });
+});
+
+test.describe("deliveryReminderBody (#193)", () => {
+  test("includes customer name and delivery wording (distinct from pickup)", () => {
+    expect(deliveryReminderBody({ customerName: "Hannah" })).toBe(
+      "Hi Hannah — reminder that your Bay Branch Farm order is out for delivery this week. Text back if anything needs to change.",
     );
   });
 });


### PR DESCRIPTION
## Summary
Delivery orders now get a reminder action on the Orders page, at parity with pickup reminders (closes #193). Amends DEC-014's "no delivery reminders" — operator-initiated, per-order, no automation.

## Files changed
- `supabase/migrations/20260604220000_delivery_reminder_mode.sql` — widen `customer_sends_mode_check` to accept `delivery_reminder`
- `supabase/tests/customer_sends_modes.sql` — pgTAP (accepts delivery/pickup, rejects bogus)
- `src/lib/notifications/templates.ts` — `deliveryReminderBody`
- `src/lib/admin/send-queue-queries.ts` — `SendMode` + `SEND_MODES` += `delivery_reminder`
- `src/lib/admin/orders-queries.ts` — `listOrders` resolves `reminderSentAt` by fulfillment
- `src/components/admin/order-actions.tsx` — reminder shows for delivery too; mode/wording per fulfillment
- `docs/DECISIONS.md` — amend DEC-014
- `tests/admin-orders.spec.ts`, `tests/notification-templates.spec.ts`

## Code review
@code-review — clean bill of health. Verified: `customer_sends_mode_check` is the correct auto-generated constraint name (inline column CHECK → `<table>_<column>_check`), so the drop resolves; `listOrders` tracks pickup/delivery sent-state in separate map fields and resolves per order via `narrowFulfillment` (no bleed); `SEND_MODES` has no runtime consumers and the Send page is weekly-only, so the growth is inert; single ternary-switched `SendAction`, no double-render.

## Test plan
- **Migration:** `supabase db push` to dev/preview, then prod. `supabase test db` → `customer_sends_modes` asserts `delivery_reminder` + `pickup_reminder` accepted, unknown mode rejected (23514).
- **`/admin/orders`:** expand a **delivery** order → "Delivery reminder + Send" appears (mode `delivery_reminder`, delivery-worded body); a **pickup** order shows "Pickup reminder" (unchanged). Sent-state is per-mode (sending the delivery reminder doesn't mark the pickup reminder, and vice versa).
- `deliveryReminderBody` renders the delivery copy (distinct from pickup) — covered by `notification-templates.spec.ts`.
- Verified locally: db reset applies, pgTAP green, build + lint clean, admin-orders desktop 8/8 + mobile 8/8, notification-templates 19/19, send-page 5/5.

⚠️ Migration is local-only until `supabase db push`. Three migrations now pending prod: #195 fulfillment_link, #190 confirmed-status, #193 delivery_reminder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)