### PR TITLE
DEC-S namespace sweep (seeds#101)

### DIFF
--- a/.claude/agents/doc-consistency.md
+++ b/.claude/agents/doc-consistency.md
@@ -9,7 +9,7 @@ You are @doc-consistency — the doc-set consistency reviewer for this project.
 
 Compare what each project doc *says* against what every other project doc *says about the same thing*. If two docs make the same claim differently, surface it. If a doc is full of unfilled template placeholders, surface it. That's the whole job.
 
-You are not an architect. You are not a copy editor. You are not a refactorer. You do not propose structural changes (DEC numbering policy, file ownership boundaries, "this doc should be split"). You do not propose new sections. You do not edit anything. The reviewer's earlier drift into "should we stub DEC-013 locally?" was scope creep — explicitly out of bounds for this agent.
+You are not an architect. You are not a copy editor. You are not a refactorer. You do not propose structural changes (DEC numbering policy, file ownership boundaries, "this doc should be split"). You do not propose new sections. You do not edit anything. The reviewer's earlier drift into "should we stub DEC-S013 locally?" was scope creep — explicitly out of bounds for this agent.
 
 ## Scope
 
@@ -25,7 +25,7 @@ You are not an architect. You are not a copy editor. You are not a refactorer. Y
 
 If the project has a doc you can't classify, default to **skip and mention it in the report** rather than reading it.
 
-## Project-type awareness (DEC-011)
+## Project-type awareness (DEC-S011)
 
 Read `<project>/.claude/project-type` (single-line file: `webapp`, `tool`, or other token). Use it to interpret what BRAND.md (and any other type-conditioned doc) is allowed to contain.
 

--- a/.claude/agents/sync-config.md
+++ b/.claude/agents/sync-config.md
@@ -12,7 +12,7 @@ Keep the seeds templates and active projects in sync. You run in one of two dire
 - **PUSH (upstream, project → seeds):** invoked by `/push-seeds`. Classify project-side changes; backport structural improvements into seeds templates; leave project-specific tweaks alone.
 - **PULL (downstream, seeds → project):** invoked by `/pull-seeds`. Classify template-side changes since the project's last sync; apply structural improvements into the project's live files; leave the project's own customizations alone.
 
-Same classifier, two directions (DEC-003). The hard part — deciding "structural improvement" vs "project-specific substitution" — is direction-symmetric.
+Same classifier, two directions (DEC-S003). The hard part — deciding "structural improvement" vs "project-specific substitution" — is direction-symmetric.
 
 ## Direction parameter
 
@@ -23,7 +23,7 @@ The invoking skill passes `direction: push` or `direction: pull` in your prompt.
 The invoking caller passes `mode: interactive` (default) or `mode: auto`.
 
 - **`mode: interactive`** — the original behavior. Step 3 presents a table and asks "Apply? (y/n)" per backport hunk and "Keep watching, or act now?" per pattern flag. Used by `/push-seeds`, `/pull-seeds`, and any direct human invocation.
-- **`mode: auto`** — non-interactive automation. Used by the nightly sync Routine (DEC-010). Behavior changes:
+- **`mode: auto`** — non-interactive automation. Used by the nightly sync Routine (DEC-S010). Behavior changes:
   - Skip Step 3 prompts entirely. Make your own judgment calls.
   - Apply every hunk classified as **backport** / **forward-port**. Skip every **skip** hunk silently.
   - Pattern **flag** entries are recorded in the Step 6 report only — never applied, never extracted.
@@ -41,8 +41,8 @@ If `mode` is missing, default to `interactive`. If `mode: auto` is requested but
 - `<seeds>/dev/` — template for dev projects (Next.js + Supabase shape)
 - `<seeds>/domain/` — template for non-dev domains (bread, tomatoes, ops, etc.)
 - `<seeds>/seeds-version` — the latest published schema version (the calling skill should have already gated on compatibility before invoking you, but verify)
-- `<seeds>/.claude/type-manifest.yaml` — project-type gating manifest (DEC-011). Lists the small set of `dev/claude/` files that only apply to certain project types (e.g. `agents/ui-reviewer.md` only applies to `webapp`-type projects)
-- `<seeds>/.claude/routine-config.yaml` — file-class registry (DEC-018) under the `file-classes:` key. Maps seeds-side glob patterns to one of `logic` / `context` / `hybrid`. Read at Step 1.4 to fork classification behavior per file.
+- `<seeds>/.claude/type-manifest.yaml` — project-type gating manifest (DEC-S011). Lists the small set of `dev/claude/` files that only apply to certain project types (e.g. `agents/ui-reviewer.md` only applies to `webapp`-type projects)
+- `<seeds>/.claude/routine-config.yaml` — file-class registry (DEC-S018) under the `file-classes:` key. Maps seeds-side glob patterns to one of `logic` / `context` / `hybrid`. Read at Step 1.4 to fork classification behavior per file.
 - The active project's `.claude/project-type` — single-line file naming the project's type (`webapp` or `tool`). Optional; if absent, no type-gating is applied
 - The active project's `.claude/agents/`, `.claude/skills/`, `CLAUDE.md`, and `docs/` — the live versions
 - `<seeds>/dev/claude/skills/push-seeds/SKILL.md` and `<seeds>/dev/claude/skills/pull-seeds/SKILL.md` — the invocation wrappers that call you
@@ -58,7 +58,7 @@ If `mode` is missing, default to `interactive`. If `mode: auto` is requested but
 
 ### Step 1 — Diff
 
-**Project-type gating (DEC-011).** Before scoping the diff, read `<project>/.claude/project-type` (single-line file: `webapp`, `tool`, or other supported tokens). Then read `<seeds>/.claude/type-manifest.yaml` for the gating rules. For every file pair below, check whether the template-side path appears in the manifest. If it does and the project's type is not in the manifest's allowed list for that path, **drop the pair from the diff scope** and record one entry for the Step 6 report:
+**Project-type gating (DEC-S011).** Before scoping the diff, read `<project>/.claude/project-type` (single-line file: `webapp`, `tool`, or other supported tokens). Then read `<seeds>/.claude/type-manifest.yaml` for the gating rules. For every file pair below, check whether the template-side path appears in the manifest. If it does and the project's type is not in the manifest's allowed list for that path, **drop the pair from the diff scope** and record one entry for the Step 6 report:
 
 > `<file>` skipped — project type `<type>`, file applies to `[<allowed types>]` (manifest-gated)
 
@@ -78,13 +78,13 @@ For each pair that survived the gate, diff project-live against seeds-template:
 
 The diff itself is direction-symmetric — same hunks, same classification rubric. Direction only matters at apply time (Step 4).
 
-**Ignore formatting-only differences (DEC-022 — anti-churn).** A hunk whose only delta is whitespace or non-semantic formatting is **not drift** and must be dropped from the diff scope before classification. This includes: tabs vs spaces, trailing whitespace, indentation width, blank-line count, line-wrapping, and markdown-table separator padding (`|---|` vs `|------|`). Concretely, treat a hunk as formatting-only if it disappears under `git diff --ignore-all-space --ignore-blank-lines` (or the equivalent normalized comparison). Never "forward-port" or "backport" a formatting-only hunk, and never overwrite a file solely to reformat it. The 2026-06-01 sailbook loop (PR #75) was exactly this: the apply step regenerated files with cosmetic drift (tabs, literal `\n`, indent, table padding), which the next run re-detected as "drift" and re-proposed — a self-perpetuating noise generator. Real semantic changes (added/removed/reordered *content*, not whitespace) classify normally.
+**Ignore formatting-only differences (DEC-S022 — anti-churn).** A hunk whose only delta is whitespace or non-semantic formatting is **not drift** and must be dropped from the diff scope before classification. This includes: tabs vs spaces, trailing whitespace, indentation width, blank-line count, line-wrapping, and markdown-table separator padding (`|---|` vs `|------|`). Concretely, treat a hunk as formatting-only if it disappears under `git diff --ignore-all-space --ignore-blank-lines` (or the equivalent normalized comparison). Never "forward-port" or "backport" a formatting-only hunk, and never overwrite a file solely to reformat it. The 2026-06-01 sailbook loop (PR #75) was exactly this: the apply step regenerated files with cosmetic drift (tabs, literal `\n`, indent, table padding), which the next run re-detected as "drift" and re-proposed — a self-perpetuating noise generator. Real semantic changes (added/removed/reordered *content*, not whitespace) classify normally.
 
-**Apply deterministically; never paraphrase (DEC-022).** When a hunk IS a real change to apply, transcribe the source side **verbatim** — copy the bytes, don't regenerate prose from memory. For a full-file/"logic-drift" overwrite, write the source file's exact content (then re-apply the project's preserved substitutions per Step 4). Regenerating text is what introduced the cosmetic drift that fed the loop.
+**Apply deterministically; never paraphrase (DEC-S022).** When a hunk IS a real change to apply, transcribe the source side **verbatim** — copy the bytes, don't regenerate prose from memory. For a full-file/"logic-drift" overwrite, write the source file's exact content (then re-apply the project's preserved substitutions per Step 4). Regenerating text is what introduced the cosmetic drift that fed the loop.
 
 **Never blanket-skip a file** that has a corresponding template, even if the project's copy is heavily customized. Hunk-classify the diff. Files like `docs/BRAND.md`, `docs/PROJECT_PLAN.md`, `docs/RETROSPECTIVES.md`, and `CLAUDE.md` carry both project substitutions AND structural template content; treating them as 100%-project-specific blanks out the structural channel and was the failure mode of the 2026-05-08 first run. The only gates that drop a whole file from scope are the project-type manifest above, the file-class `context` lookup in Step 1.4 below, and the duplicate-PR check in Step 1.5 — all three explicit.
 
-### Step 1.4 — File-class lookup (DEC-018)
+### Step 1.4 — File-class lookup (DEC-S018)
 
 After Step 1's type-gate and before Step 1.5's duplicate-PR check, read `<seeds>/.claude/routine-config.yaml` and parse the `file-classes:` block. This is an ordered list of single-key maps from glob pattern to class name (one of `logic` / `context` / `hybrid`). First match wins — earlier entries take precedence over later ones.
 
@@ -92,10 +92,10 @@ For each file pair that survived Step 1, look up its seeds-side path against the
 
 - **`logic`** — file is byte-identical-by-design across projects. Skip hunk classification entirely. Step 2 hash-compares; if hashes diverge, emit a single Step 3 row (see Step 2 + Step 3 below). If hashes match, emit nothing.
 - **`context`** — file is project-specific. Drop the pair from diff scope entirely. Record in Step 6 aggregated summary (see Step 6 below). **Do not emit a Step 3 table row.**
-- **`hybrid`** — file is a generic shell paired with a project-side `.claude/<basename>-context.{md,json}` context file (DEC-019). Only the shell participates in classification. The project-side context file is implicitly context-class and not in scope. Proceed to Step 2 hunk classification on the shell file as today.
+- **`hybrid`** — file is a generic shell paired with a project-side `.claude/<basename>-context.{md,json}` context file (DEC-S019). Only the shell participates in classification. The project-side context file is implicitly context-class and not in scope. Proceed to Step 2 hunk classification on the shell file as today.
 - **Unmatched** — no glob in the registry matches the file's seeds-side path. Default to `hybrid` behavior with the seeds file as the de facto shell. Legacy behavior is preserved for any file not yet listed in the registry; the noise reduction kicks in only as files get registered.
 
-If `<seeds>/.claude/routine-config.yaml` is missing or unreadable, or the `file-classes:` block is absent, log one line in Step 6 (`File-class lookup skipped — routine-config.yaml or file-classes block unavailable.`) and treat all pairs as unmatched. Same fallback discipline as DEC-011's type-gating: never fail-closed, always fall through to legacy behavior with a visible note.
+If `<seeds>/.claude/routine-config.yaml` is missing or unreadable, or the `file-classes:` block is absent, log one line in Step 6 (`File-class lookup skipped — routine-config.yaml or file-classes block unavailable.`) and treat all pairs as unmatched. Same fallback discipline as DEC-S011's type-gating: never fail-closed, always fall through to legacy behavior with a visible note.
 
 This step is a **scoping + behavior-fork** step, not a hunk-level one. It either drops the pair from scope (`context`) or changes how Step 2 classifies it (`logic` → hash-only, `hybrid`/unmatched → hunk classification). The fork happens once per file pair.
 
@@ -256,7 +256,7 @@ If a logic file picks up project-specific content over time, the right fix is to
 
 The classifier is symmetric; the substitution-preservation logic flips. In push, you generify; in pull, you respect existing concretions. Logic-drift bypasses both — it's a wholesale sync (or, in PUSH+auto, no sync at all).
 
-**Post-apply no-op guard (DEC-022 — anti-churn).** After writing all approved changes, re-diff the target against its pre-apply state with whitespace ignored (`git diff --ignore-all-space --ignore-blank-lines`). If nothing remains, **revert the writes and stage no commit** — the "changes" were formatting-only and must not open a PR. Never stage an empty or whitespace-only commit. This is the backstop that breaks the sailbook-style nightly loop even if a formatting-only hunk slips past the Step 1 filter.
+**Post-apply no-op guard (DEC-S022 — anti-churn).** After writing all approved changes, re-diff the target against its pre-apply state with whitespace ignored (`git diff --ignore-all-space --ignore-blank-lines`). If nothing remains, **revert the writes and stage no commit** — the "changes" were formatting-only and must not open a PR. Never stage an empty or whitespace-only commit. This is the backstop that breaks the sailbook-style nightly loop even if a formatting-only hunk slips past the Step 1 filter.
 
 ### Step 5 — Bug check
 
@@ -271,7 +271,7 @@ Apply if approved.
 
 Output the following sections in order. Sections with no entries are omitted entirely — do not emit empty section headers.
 
-**Derive this report from the actual staged diff, not from intentions (DEC-022 — anti-churn).** The "Files updated" list and any action/classification table MUST be generated from what was really written and staged (`git diff --staged --name-only` / `--stat`), never from the set of changes you *planned* to make. The sailbook PR #75 body advertised 15 full-file overwrites and 4 new files while the staged diff touched 5 files with cosmetic changes only — because the table was written from intent. A file that produced no staged change (e.g. dropped by the no-op guard, or whose only delta was formatting) must NOT appear as an applied row. Report what happened, byte-for-byte.
+**Derive this report from the actual staged diff, not from intentions (DEC-S022 — anti-churn).** The "Files updated" list and any action/classification table MUST be generated from what was really written and staged (`git diff --staged --name-only` / `--stat`), never from the set of changes you *planned* to make. The sailbook PR #75 body advertised 15 full-file overwrites and 4 new files while the staged diff touched 5 files with cosmetic changes only — because the table was written from intent. A file that produced no staged change (e.g. dropped by the no-op guard, or whose only delta was formatting) must NOT appear as an applied row. Report what happened, byte-for-byte.
 
 **Files updated.** List with one line per file noting hunks touched (PUSH: seeds-side; PULL: project-side). For logic-drift, write `<file> — full-file overwrite from <source-side>`.
 

--- a/.claude/skills/bump-major/SKILL.md
+++ b/.claude/skills/bump-major/SKILL.md
@@ -8,14 +8,14 @@ You are bumping the project's major version. Major bumps are manual because they
 
 ## Step 0 — Sanity gate
 
-Run `[ -f package.json ] || echo "missing"`. If `package.json` is missing at the repo root, STOP. Tell the user: "/bump-major requires `package.json` (DEC-007 — dev projects only). This repo has none." Do not proceed.
+Run `[ -f package.json ] || echo "missing"`. If `package.json` is missing at the repo root, STOP. Tell the user: "/bump-major requires `package.json` (DEC-S007 — dev projects only). This repo has none." Do not proceed.
 
 ## Step 1 — Resolve working branch
 
 ```
 WORKING_BRANCH=main
 ```
-The active trunk is always `main` (DEC-022). `production` (if any) only moves at `/promote-production`.
+The active trunk is always `main` (DEC-S022). `production` (if any) only moves at `/promote-production`.
 
 `BRANCH=$(git branch --show-current)`.
 

--- a/.claude/skills/its-alive/SKILL.md
+++ b/.claude/skills/its-alive/SKILL.md
@@ -16,7 +16,7 @@ Run `git fetch origin` to refresh remote state. Capture `BRANCH=$(git branch --s
 
 **Branch handling:**
 - `task/*` or other intentional feature branch: continue (PR-flow project).
-- `claude/*` (CC Desktop / web / mobile auto-branch): accept and continue. The platform pre-cuts this branch when launching a session. Per DEC-013, this branch is the **session-anchor**; per-task code branches get cut as work proceeds, each PR'd separately. Session-file commits go to the orphan `sessions` branch via the worktree (DEC-014), NOT to this branch.
+- `claude/*` (CC Desktop / web / mobile auto-branch): accept and continue. The platform pre-cuts this branch when launching a session. Per DEC-S013, this branch is the **session-anchor**; per-task code branches get cut as work proceeds, each PR'd separately. Session-file commits go to the orphan `sessions` branch via the worktree (DEC-S014), NOT to this branch.
 - `main`: `git pull --ff-only origin main`. On divergence, show `git log --oneline origin/main..HEAD` and `git log --oneline HEAD..origin/main`, then ask: **"(a) rebase, (b) reset to origin/main, (c) abort?"** Wait for the choice.
 - Anything else (manual non-standard branch): if `git status --porcelain` is dirty, stop and ask the user to commit/stash. If clean, ask the user **"Stay on `$BRANCH` or switch to `main`?"** Wait for the choice.
 
@@ -28,7 +28,7 @@ Before stamping time, check for leftover work from prior sessions. The CC platfo
 ```
 WORKING_BRANCH=main
 ```
-The active trunk is always `main` (DEC-022); a `production` branch, if present, is a downstream deploy pointer and never the orphan-scan base.
+The active trunk is always `main` (DEC-S022); a `production` branch, if present, is a downstream deploy pointer and never the orphan-scan base.
 
 **Scan A — remote `claude/*` branches with commits not on `$WORKING_BRANCH`:**
 ```
@@ -55,7 +55,7 @@ For each Scan-A candidate, find the most recent PR whose `headRefName` matches t
 
 **Tool-outage fallback.** If `gh` and `mcp__github__list_pull_requests` are both unavailable, skip Scan B entirely and surface every Scan-A candidate as "branch has commits — PR state check unavailable, do not assume orphan." Don't false-alarm during a tool outage. Note the skipped check in the session Context section.
 
-### Step 0.6 — Ensure `.sessions-worktree/` (DEC-014)
+### Step 0.6 — Ensure `.sessions-worktree/` (DEC-S014)
 
 The session file lives on an orphan `sessions` branch checked out at `.sessions-worktree/`. Skills commit there; the user's main checkout never moves.
 
@@ -74,19 +74,19 @@ git rm -rf . 2>/dev/null || true
 # If a sessions/ dir existed on main, bring its contents over:
 git checkout main -- sessions/ 2>/dev/null || mkdir -p sessions
 [ -d sessions ] || mkdir sessions
-[ -f sessions/README.md ] || echo "# Sessions branch (DEC-014). Each project session writes one file here." > sessions/README.md
+[ -f sessions/README.md ] || echo "# Sessions branch (DEC-S014). Each project session writes one file here." > sessions/README.md
 git add sessions/
 git commit -m "Initialize sessions branch"
 git push -u origin sessions
 git checkout main
 # Remove sessions/ from main if it existed:
-[ -d sessions ] && git rm -r sessions && git commit -m "Move sessions to orphan sessions branch (DEC-014)" && git push origin main
+[ -d sessions ] && git rm -r sessions && git commit -m "Move sessions to orphan sessions branch (DEC-S014)" && git push origin main
 # Add .gitignore entry on main:
-grep -q "^\.sessions-worktree/" .gitignore 2>/dev/null || (echo ".sessions-worktree/" >> .gitignore && git add .gitignore && git commit -m "Ignore .sessions-worktree (DEC-014)" && git push origin main)
+grep -q "^\.sessions-worktree/" .gitignore 2>/dev/null || (echo ".sessions-worktree/" >> .gitignore && git add .gitignore && git commit -m "Ignore .sessions-worktree (DEC-S014)" && git push origin main)
 # Attach worktree:
 git worktree add .sessions-worktree sessions
 ```
-Note: on protected main, the two follow-up commits (remove `sessions/`, add `.gitignore`) may need a PR instead of direct push. Detect with `gh api repos/{owner}/{repo}/branches/main/protection --silent 2>/dev/null`; if protected, open a "Migrate to DEC-014" PR with those commits on a `claude/dec-014-migrate` branch and surface the URL.
+Note: on protected main, the two follow-up commits (remove `sessions/`, add `.gitignore`) may need a PR instead of direct push. Detect with `gh api repos/{owner}/{repo}/branches/main/protection --silent 2>/dev/null`; if protected, open a "Migrate to DEC-S014" PR with those commits on a `claude/dec-014-migrate` branch and surface the URL.
 
 c. **`origin/sessions` exists but local sessions/ also has uncommitted files** (mid-migration): stop and ask the user to resolve manually.
 
@@ -150,7 +150,7 @@ Capture as `JSONL_DIR`. Use the **Glob** tool with `path: <JSONL_DIR>` and `patt
 SESSION_FILE=".sessions-worktree/sessions/${DATE_PART}-${TIME_PART}-${DEV}-${SLUG}.md"
 ```
 
-Write the file with this content (DEC-013 schema — atomic, no time math fields):
+Write the file with this content (DEC-S013 schema — atomic, no time math fields):
 
 ```
 ---
@@ -201,7 +201,7 @@ Extract:
 - **Next Steps** — verbatim
 - **Context** — gotchas
 
-**Pre-DEC-013 schema tolerance:** legacy session files use a single `Task:` block instead of `## Task <N>` headers. Read either shape.
+**Pre-DEC-S013 schema tolerance:** legacy session files use a single `Task:` block instead of `## Task <N>` headers. Read either shape.
 
 ## Step 8 — Read project state
 
@@ -239,7 +239,7 @@ Then ask: **"Ready to go? Confirm the task or redirect me."** — or, if the use
 
 Stop. Do not begin work until the user confirms.
 
-## DEC-013 + DEC-014 reminders
+## DEC-S013 + DEC-S014 reminders
 
 - One Claude window opens **one** session. `/its-dead` runs **once** at the end.
 - `/kill-this` may run multiple times — one per task — each opens its own PR and appends a `## Task <N>` block to this session file (on the sessions branch).

--- a/.claude/skills/its-dead/SKILL.md
+++ b/.claude/skills/its-dead/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: its-dead
-description: Session end. Stamps `ended:` on the open session file, tallies total points from per-task blocks, displays wall_clock to screen for gut-check, commits + pushes the sessions branch. No time math, no version bump, no merge handshake — those moved to `/retro` per DEC-013. Run once at the end of a Claude window after every task's `/kill-this` has shipped its PR.
+description: Session end. Stamps `ended:` on the open session file, tallies total points from per-task blocks, displays wall_clock to screen for gut-check, commits + pushes the sessions branch. No time math, no version bump, no merge handshake — those moved to `/retro` per DEC-S013. Run once at the end of a Claude window after every task's `/kill-this` has shipped its PR.
 tools: Read, Edit, Write, Bash, Glob, Grep
 ---
 
-You are closing the session. Under DEC-013, this is a one-action skill: stamp `ended:`, write `status: closed`, commit + push to the orphan `sessions` branch. All time math (wall_clock and active = wall_clock − breaks, via transcript break inference) and version bumps moved to `/retro`. The session file becomes atomic — never modified after this runs.
+You are closing the session. Under DEC-S013, this is a one-action skill: stamp `ended:`, write `status: closed`, commit + push to the orphan `sessions` branch. All time math (wall_clock and active = wall_clock − breaks, via transcript break inference) and version bumps moved to `/retro`. The session file becomes atomic — never modified after this runs.
 
 ## Step 0 — Locate the open session (on the sessions worktree)
 
@@ -26,7 +26,7 @@ Edit `$SESSION_FILE` frontmatter:
 - `ended: <END_UTC>`
 - `status: closed`
 
-Do **not** write `wall_clock`, `active`, `breaks`, `duration`, or any time-derived field. Time math is `/retro`'s job (DEC-013).
+Do **not** write `wall_clock`, `active`, `breaks`, `duration`, or any time-derived field. Time math is `/retro`'s job (DEC-S013).
 
 ## Step 2 — Tally total points
 
@@ -108,5 +108,5 @@ Phase progress: gh issue list --label phase:current --state open
 ## Notes
 
 - Sanity check at close: the displayed wall_clock is `ended − started`. If it includes overnight or away-from-desk time, that's correct — `/retro` will subtract break gaps later. The screen number isn't the final number.
-- No interactive merge handshake (DEC-012 had one). Under DEC-013, the user merges PRs whenever convenient — before `/its-dead`, after, doesn't matter. Retro reads GitHub for merge timestamps at retro time.
-- Atomicity guarantee: once `status: closed` is set and the file is pushed, this skill is done. No subsequent skill modifies this file. `/its-alive`'s old Step 7.5 backfill is gone (DEC-013).
+- No interactive merge handshake (DEC-S012 had one). Under DEC-S013, the user merges PRs whenever convenient — before `/its-dead`, after, doesn't matter. Retro reads GitHub for merge timestamps at retro time.
+- Atomicity guarantee: once `status: closed` is set and the file is pushed, this skill is done. No subsequent skill modifies this file. `/its-alive`'s old Step 7.5 backfill is gone (DEC-S013).

--- a/.claude/skills/kill-this/SKILL.md
+++ b/.claude/skills/kill-this/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: kill-this
-description: Per-task PR + session-log update. Build check, commit code, push the task branch, run code review, open a PR, and append a `## Task <N>` block to the running session file on the orphan `sessions` branch. May run multiple times in one Claude window — one per task. Pair with `/its-dead` once at the end of the window. Time math + version bump moved to `/retro` (DEC-013).
+description: Per-task PR + session-log update. Build check, commit code, push the task branch, run code review, open a PR, and append a `## Task <N>` block to the running session file on the orphan `sessions` branch. May run multiple times in one Claude window — one per task. Pair with `/its-dead` once at the end of the window. Time math + version bump moved to `/retro` (DEC-S013).
 tools: Read, Edit, Write, Bash, Glob, Grep, Agent
 ---
 
-You are shipping one task. Under DEC-013, `/kill-this` runs **per task**, not per session — there may be N invocations between `/its-alive` and `/its-dead`. Each one opens its own PR and appends one `## Task <N>` block to the session file (which lives on the orphan `sessions` branch via `.sessions-worktree/`, per DEC-014).
+You are shipping one task. Under DEC-S013, `/kill-this` runs **per task**, not per session — there may be N invocations between `/its-alive` and `/its-dead`. Each one opens its own PR and appends one `## Task <N>` block to the session file (which lives on the orphan `sessions` branch via `.sessions-worktree/`, per DEC-S014).
 
 ## Step 0 — Capture branch + locate session file
 
@@ -45,7 +45,7 @@ If there is nothing to commit, surface that and stop here — no PR for no code.
 
 **Push the branch — do not open a PR yet:**
 
-- **On `main` (DEC-005 solo flow, unprotected main):** `git push origin main`. Skip Steps 3+4 — no PR. Go to Step 5.
+- **On `main` (DEC-S005 solo flow, unprotected main):** `git push origin main`. Skip Steps 3+4 — no PR. Go to Step 5.
 - **On a `task/*`, `claude/<slug>`, or feature branch:** `git push -u origin $BRANCH`. Continue.
 
 Capture `SUBJECT=$(git log -1 --format=%s)` for the PR title.
@@ -58,7 +58,7 @@ When addressing review findings before opening the PR: Read every file before ed
 
 ## Step 4 — Open the PR
 
-Resolve base branch — always the project's active trunk (DEC-022):
+Resolve base branch — always the project's active trunk (DEC-S022):
 ```
 BASE=main
 ```
@@ -147,7 +147,7 @@ If `EXISTING_PR_STATE` was `OPEN` and Step 4.2 was skipped, surface the existing
 
 ## Notes
 
-- **No time math, no version bump, no CHANGELOG.** All deferred to `/retro` per DEC-013. This skill ships a task and logs it; that's it.
+- **No time math, no version bump, no CHANGELOG.** All deferred to `/retro` per DEC-S013. This skill ships a task and logs it; that's it.
 - **Branch ownership.** Code commits go to the current task branch. Session-file commits go to the sessions branch via the worktree. Two completely separate timelines.
 - **Multiple PRs per session is normal.** Each `/kill-this` appends a `## Task <N>` block; the `pr_numbers:` list grows. `/retro` reads this list to enumerate the PRs to query for merge timestamps.
 - **Merge ordering is free.** The user can merge each PR whenever — before the next `/kill-this`, after `/its-dead`, days later. Retro reads GitHub at retro time and gets the merge timestamps regardless.

--- a/.claude/skills/promote-production/SKILL.md
+++ b/.claude/skills/promote-production/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: promote-production
-description: Promote the active trunk (`main`) to the `production` deploy branch via fast-forward merge, then push. The release was already version-bumped and tagged on `main` by `/retro` or `/bump-major`, so promotion is deploy-only — it advances `production` to the tagged commit. Use when work on `main` is ready to ship. Requires `origin/production` to exist (DEC-022).
+description: Promote the active trunk (`main`) to the `production` deploy branch via fast-forward merge, then push. The release was already version-bumped and tagged on `main` by `/retro` or `/bump-major`, so promotion is deploy-only — it advances `production` to the tagged commit. Use when work on `main` is ready to ship. Requires `origin/production` to exist (DEC-S022).
 tools: Read, Edit, Write, Bash, Grep
 ---
 
-You are promoting `main` → `production`. Under DEC-022, `main` is the always-active trunk and `production` is a downstream deploy pointer that Vercel (or whatever host) watches. Version bumps and tags already happened on `main` at `/retro` / `/bump-major`; this skill does **not** tag — it ff-merges the trunk into `production` and pushes, which is the deploy moment.
+You are promoting `main` → `production`. Under DEC-S022, `main` is the always-active trunk and `production` is a downstream deploy pointer that Vercel (or whatever host) watches. Version bumps and tags already happened on `main` at `/retro` / `/bump-major`; this skill does **not** tag — it ff-merges the trunk into `production` and pushes, which is the deploy moment.
 
 ## Step 0 — Sanity gates
 
@@ -12,7 +12,7 @@ You are promoting `main` → `production`. Under DEC-022, `main` is the always-a
 ```
 git show-ref --verify --quiet refs/remotes/origin/production || echo "missing"
 ```
-If `origin/production` doesn't exist (locally cached), STOP. Tell the user: "/promote-production requires an `origin/production` branch (DEC-022). This repo deploys straight off `main` — there's nothing to promote. To adopt a production branch: `git checkout -b production main && git push -u origin production`, then point the host's production branch at it." Do not proceed. Step 1 refreshes the cache from the remote regardless, so a stale local view that misses a freshly-created `production` is recovered after the user re-runs.
+If `origin/production` doesn't exist (locally cached), STOP. Tell the user: "/promote-production requires an `origin/production` branch (DEC-S022). This repo deploys straight off `main` — there's nothing to promote. To adopt a production branch: `git checkout -b production main && git push -u origin production`, then point the host's production branch at it." Do not proceed. Step 1 refreshes the cache from the remote regardless, so a stale local view that misses a freshly-created `production` is recovered after the user re-runs.
 
 **Clean working tree:**
 ```
@@ -48,7 +48,7 @@ git fetch --tags
 SHIP_SHA=$(git rev-parse origin/main)
 SHIP_TAG=$(git tag --points-at "$SHIP_SHA" | grep '^v' | sort -V | tail -1)
 ```
-`SHIP_TAG` is the version tag already on the trunk HEAD (created by `/retro` or `/bump-major`). If `SHIP_TAG` is empty, surface a warning — promotion still works, but the promoted commit carries no version tag: **"⚠ No `v*` tag on `main` HEAD. Promote anyway (deploys an untagged commit), or bump first via `/retro` / `/bump-major`? (promote/abort)"** Wait. Do **not** invent or apply a tag here — tagging is the trunk skills' job (DEC-022).
+`SHIP_TAG` is the version tag already on the trunk HEAD (created by `/retro` or `/bump-major`). If `SHIP_TAG` is empty, surface a warning — promotion still works, but the promoted commit carries no version tag: **"⚠ No `v*` tag on `main` HEAD. Promote anyway (deploys an untagged commit), or bump first via `/retro` / `/bump-major`? (promote/abort)"** Wait. Do **not** invent or apply a tag here — tagging is the trunk skills' job (DEC-S022).
 
 ## Step 4 — ff-merge production → main HEAD
 

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: retro
-description: Phase-end retrospective. Closes the current phase. Under DEC-013, retro is also where per-session time math runs — for every session in the phase window, it computes wall_clock and active time (active = wall_clock - breaks, breaks inferred from the transcript JSONL) from `started`, `ended`. Aggregates to one phase velocity: active h/pt. Marks PROJECT_PLAN.md `[x]`, reconciles drift, writes RETROSPECTIVES.md, runs version bumps (patch per merged PR + minor at phase close on dev projects), prompts retro notes. Optionally chains into `/start-phase`.
+description: Phase-end retrospective. Closes the current phase. Under DEC-S013, retro is also where per-session time math runs — for every session in the phase window, it computes wall_clock and active time (active = wall_clock - breaks, breaks inferred from the transcript JSONL) from `started`, `ended`. Aggregates to one phase velocity: active h/pt. Marks PROJECT_PLAN.md `[x]`, reconciles drift, writes RETROSPECTIVES.md, runs version bumps (patch per merged PR + minor at phase close on dev projects), prompts retro notes. Optionally chains into `/start-phase`.
 tools: Read, Edit, Write, Bash, Glob, Grep, Agent
 ---
 
 You are running the phase-end retrospective. Work for this phase is complete (or you've decided to call it done and move scope).
 
-Under DEC-013, this skill **owns all per-session time math** that used to live in `/its-dead` and **all version bumps** that used to live in `/its-dead` (patch per merge) and `/retro` (minor at close). Session files are atomic event logs; retro is where they get turned into numbers.
+Under DEC-S013, this skill **owns all per-session time math** that used to live in `/its-dead` and **all version bumps** that used to live in `/its-dead` (patch per merge) and `/retro` (minor at close). Session files are atomic event logs; retro is where they get turned into numbers.
 
 ## Step 0 — Identify the current phase
 
@@ -32,7 +32,7 @@ For each open issue, ask the user: "Move to next phase, leave open, or close as 
 - **Leave open:** record in retro.
 - **Close as won't-do:** `gh issue close <N> --reason "not planned" --comment "Closed at Phase N retro — descoped."`
 
-## Step 2 — Per-session time math (DEC-013 — moved from `/its-dead`)
+## Step 2 — Per-session time math (DEC-S013 — moved from `/its-dead`)
 
 Find every session file in the phase window. Phase window = first issue's `createdAt` → last issue's `closedAt` (use `gh issue list --label "phase:<N>" --state all --json createdAt,closedAt`).
 
@@ -64,7 +64,7 @@ active_time = max(0, wall_clock - total_breaks_hours)
 
 Active time is wall-clock minus inferred idle — the time actually spent at the keyboard on this session's work. Round to nearest 0.083 h (5 min). This is the **single** velocity input. No PR timestamps are fetched; no time is split into "dev" vs "review."
 
-**Why there is no dev/review split anymore (retiring the DEC-015 per-PR window model).** Through Phase 7 the retro also computed `dev_time` and `review_time` via per-PR windows. That math is retired. It assumed each PR was merged before the next opened, but the actual workflow opens PRs in a burst and merges them whenever ("merge PRs whenever — order doesn't matter" — CLAUDE.md). Under that real pattern the per-PR anchors collapse: `dev_time` falls to a fictional ~0.03–0.09 h/pt and the overlapping review windows sum past wall-clock (a real case: Session 25 reported 26.8h of "review" inside a 9.2h session — physically impossible). Every retro since Phase 3 footnoted the split as untrustworthy and forecast on active anyway. So we keep the number that was always the headline and drop the two that were always disclaimed. There is no cheap fix for the split — correctly attributing per-task time would require reconstructing keystroke spans from the transcript, which is exactly what `active = wall - breaks` already approximates.
+**Why there is no dev/review split anymore (retiring the DEC-S015 per-PR window model).** Through Phase 7 the retro also computed `dev_time` and `review_time` via per-PR windows. That math is retired. It assumed each PR was merged before the next opened, but the actual workflow opens PRs in a burst and merges them whenever ("merge PRs whenever — order doesn't matter" — CLAUDE.md). Under that real pattern the per-PR anchors collapse: `dev_time` falls to a fictional ~0.03–0.09 h/pt and the overlapping review windows sum past wall-clock (a real case: Session 25 reported 26.8h of "review" inside a 9.2h session — physically impossible). Every retro since Phase 3 footnoted the split as untrustworthy and forecast on active anyway. So we keep the number that was always the headline and drop the two that were always disclaimed. There is no cheap fix for the split — correctly attributing per-task time would require reconstructing keystroke spans from the transcript, which is exactly what `active = wall - breaks` already approximates.
 
 ### Step 2.5 — Per-session line for the retro
 
@@ -168,7 +168,7 @@ Read `docs/RETROSPECTIVES.md` first (Edit requires a prior Read). If it doesn't 
 
 ## Step 7 — Commit (sessions branch updates are read-only here)
 
-Session files were already finalized by `/its-dead` and are not modified by this skill — DEC-013 atomicity.
+Session files were already finalized by `/its-dead` and are not modified by this skill — DEC-S013 atomicity.
 
 ```
 git add docs/PROJECT_PLAN.md docs/RETROSPECTIVES.md
@@ -176,11 +176,11 @@ git commit -m "Phase <N> retro — <points> pts in <active>h active (<active/pt>
 git push origin <BRANCH>
 ```
 
-## Step 8 — Version bumps (dev projects only — DEC-013 moved patch bumps from `/its-dead` here)
+## Step 8 — Version bumps (dev projects only — DEC-S013 moved patch bumps from `/its-dead` here)
 
-Run only if `package.json` exists at the repo root (dev-project signal — DEC-007).
+Run only if `package.json` exists at the repo root (dev-project signal — DEC-S007).
 
-Resolve working branch — always the active trunk (DEC-022):
+Resolve working branch — always the active trunk (DEC-S022):
 ```
 WORKING_BRANCH=main
 ```
@@ -264,7 +264,7 @@ Version: v<NEW_VERSION>  (dev projects only; skipped if no package.json)
 
 ## Notes
 
-- **Session files are read-only here.** Retro reads them; never writes. DEC-013 atomicity.
+- **Session files are read-only here.** Retro reads them; never writes. DEC-S013 atomicity.
 - **GitHub queries can fail.** Time math no longer touches GitHub at all — active time comes from the session file + transcript. `gh` is only used for issue accounting (Steps 1 and 3's points cross-check) and version bumps (Step 8). If it's down, skip those, note it, and let the user rerun. Don't guess.
 - **The headline velocity is `active / point`, and it's the only one.** `active = wall_clock - breaks`. Wall-clock velocity is inflated by overnight gaps and idle — don't quote `wall / point` as a velocity. There is no `dev_time` or `review_time` (retired — see Step 2.4).
 - **Old retros carry dead columns.** Phase retros written under the per-PR model have `Dev` / `Review` columns and a dev/review velocity, all artifacts — the `Active` figure in those same retros was always the real headline. Phases that predate active time have only a legacy `Velocity: X hrs/pt` and no active number; **don't blend those with active h/pt** — they're a different, older metric (the standalone velocity extractor handles this split for you).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Roles:
 | `docs/BRAND.md` | Voice, type, color |
 | `docs/VELOCITY_AND_POKER_GUIDE.md` | Estimation methodology |
 | `docs/CHEATSHEET.md` | One-page printable skill reference |
-| `sessions/*.md` (on orphan `sessions` branch via `.sessions-worktree/`) | Per-session files — `YYYY-MM-DD-HHMM-<dev>-<slug>.md`. Atomic after `/its-dead` closes (DEC-013); orphan branch decouples session log from any code branch (DEC-014). |
+| `sessions/*.md` (on orphan `sessions` branch via `.sessions-worktree/`) | Per-session files — `YYYY-MM-DD-HHMM-<dev>-<slug>.md`. Atomic after `/its-dead` closes (DEC-S013); orphan branch decouples session log from any code branch (DEC-S014). |
 | `.claude/seeds-version` | Schema version this project was last installed at. Used by `/pull-seeds` to gate template syncs. |
 | `.claude/project-type` | Project type — `webapp` or `tool`. Used by `@sync-config` to gate template files that don't apply to this project's type. Optional. |
 
@@ -73,7 +73,7 @@ Schema details land in Phase 1.1 (sketched in plan; finalize at execution).
 6. **Run targeted tests** — `npx playwright test tests/foo.spec.ts --project=desktop` (and mobile/webkit for customer-side). `supabase test db` if RLS-touching. Do NOT run full suite — that's the user's call.
 7. **Mobile screenshot** — confirm 375px viewport passes for customer-side
 8. **Ship the task** — `/kill-this` commits, pushes, opens PR with `closes #<issue>`, appends a `## Task <N>` block to the session file (on the orphan `sessions` branch). Run per task; multiple per session.
-9. **Pick up another task or close out** — start step 1 with a new branch, or run `/its-dead` once at the end of the Claude window. Merge PRs whenever — order doesn't matter (DEC-013).
+9. **Pick up another task or close out** — start step 1 with a new branch, or run `/its-dead` once at the end of the Claude window. Merge PRs whenever — order doesn't matter (DEC-S013).
 
 **No test, no push.**
 
@@ -258,7 +258,7 @@ npx supabase gen types typescript --local > src/lib/supabase/types.ts
 | `/its-alive` | Session start | Ensure `.sessions-worktree/` exists, open per-session file on orphan `sessions` branch, capture transcript, read context, recommend task |
 | `/pause-this` | Mid-session break | Build check, commit WIP on task branch, note pause in session file (sessions branch) |
 | `/restart-this` | Resume from pause | Reload context, continue same session |
-| `/kill-this` | **Per task** (DEC-013) | Build check, commit code on task branch, open PR, append `## Task <N>` block to session file. Run N times per session — one per task. No time math. |
+| `/kill-this` | **Per task** (DEC-S013) | Build check, commit code on task branch, open PR, append `## Task <N>` block to session file. Run N times per session — one per task. No time math. |
 | `/its-dead` | Session end (once per window) | Stamp `ended:`, tally points, display wall_clock to screen, close session file. No time math, no version bump (those moved to `/retro`). Merge PRs whenever. |
 | `/start-phase` | Phase boundary (start) | Materialize phase as Issues with `phase:N`, `points:X` labels |
 | `/retro` | Phase boundary (end) | Compute per-session wall/dev/review from `started`/`ended`/transcript/PR timestamps. Aggregate phase velocity. Mark `[x]`, write retro, patch-bump per merged PR + minor-bump at close. |
@@ -301,7 +301,7 @@ npx supabase gen types typescript --local > src/lib/supabase/types.ts
 - Never two open PRs with migrations on the same table — merge one first.
 - **Stacking PRs is preferred** when tasks depend on each other. Branch the next task off the previous task branch (`git checkout -b task/X.Y-next task/X.Y-prev`), not off main. Only wait for the previous PR to merge when there's a migration conflict on the same table.
 
-### Production branch (DEC-022)
+### Production branch (DEC-S022)
 
 `main` is the always-active trunk. Bushel currently deploys straight off `main`:
 - `/kill-this` opens PRs into `main` per task.
@@ -342,14 +342,14 @@ If the subdomain returns 500 or 404 right after reassignment, the new branch has
 
 ## Versioning
 
-Bushel carries a SemVer version in `package.json`, mirrored to a git tag (`vX.Y.Z`) on `main`. `/retro` is now the sole place version bumps happen (DEC-013 moved patch bumps out of `/its-dead`).
+Bushel carries a SemVer version in `package.json`, mirrored to a git tag (`vX.Y.Z`) on `main`. `/retro` is now the sole place version bumps happen (DEC-S013 moved patch bumps out of `/its-dead`).
 
-**Three triggers (all run at `/retro` per DEC-013):**
+**Three triggers (all run at `/retro` per DEC-S013):**
 - **Patch:** `/retro` Step 8.2 — one bump + CHANGELOG entry per PR merged in the phase window. Title pulled from GitHub.
 - **Minor:** `/retro` Step 8.3 — at phase close after all patches. CHANGELOG entry summarizes the phase.
 - **Major:** `/bump-major` manual. User supplies the breaking-change rationale.
 
-**Tag rule:** tags are applied on the active trunk (`main`) at bump time (DEC-022). A `production` deploy branch, if adopted, receives the already-tagged commit via `/promote-production` ff-merge — promotion does not tag.
+**Tag rule:** tags are applied on the active trunk (`main`) at bump time (DEC-S022). A `production` deploy branch, if adopted, receives the already-tagged commit via `/promote-production` ff-merge — promotion does not tag.
 
 **Detection:** these skills check `package.json` exists at the repo root before bumping. If it doesn't (template/markdown-only project), they no-op silently.
 
@@ -369,7 +369,7 @@ import { VersionTag } from "@/components/VersionTag";
 
 ### CHANGELOG.md
 
-Auto-maintained by `/retro` and `/bump-major` (DEC-013 — `/its-dead` no longer touches it). Don't edit by hand mid-flow — the skills always prepend after the `# Changelog` header. The first bump creates the file if absent.
+Auto-maintained by `/retro` and `/bump-major` (DEC-S013 — `/its-dead` no longer touches it). Don't edit by hand mid-flow — the skills always prepend after the `# Changelog` header. The first bump creates the file if absent.
 
 Format (Keep-a-Changelog inspired but simpler):
 ```

--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -23,7 +23,7 @@ PHASE
 SEMVER  ( dev projects only — needs package.json )
   /bump-major      breaking change. manual. tag on main.
   /promote-production main->prod ff-merge + push.
-                   ( needs origin/production — DEC-022 )
+                   ( needs origin/production — DEC-S022 )
   patch bumps      automatic in /its-dead on PR merge.
 
 REFLECT / SYNC

--- a/scripts/safe-supabase.sh
+++ b/scripts/safe-supabase.sh
@@ -2,7 +2,7 @@
 # safe-supabase.sh — wrapper around the `supabase` CLI that refuses
 # destructive operations when linked to a production project.
 #
-# DEC-009 (seeds): two-layer defense — discipline (never link prod locally)
+# DEC-S009 (seeds): two-layer defense — discipline (never link prod locally)
 # plus this wrapper as belt-and-suspenders.
 #
 # Setup (per project):


### PR DESCRIPTION
Applies seeds **DEC-S025** to bushel: references to *seeds-workflow* decisions take the `DEC-S` prefix everywhere they appear; bushel's own `DEC-NNN` stay plain. This is the standalone per-repo sweep called for in the DEC-S025 rollout runbook (it can't ride the nightly Routine — `@sync-config` only touches mirrored files and can't make the seeds-vs-project-own call).

Bushel's own ceiling is **DEC-035**, so no seeds ref sits above it — every seeds ref had to be judged per line against bushel's colliding own decisions (e.g. bushel `DEC-022` = order-list filters, `DEC-023` = testing, `DEC-009` = no delivery zone).

### Converted → `DEC-S` (seeds-workflow refs)
- All 6 skills carrying refs + `.claude/agents/sync-config.md` + `doc-consistency.md` (verbatim-mirrored from seeds — every ref is seeds-workflow) — 53 refs
- `CLAUDE.md` workflow refs: `DEC-013` ×6, `DEC-014`, `DEC-022` ×2
- `docs/CHEATSHEET.md` `DEC-022`; `scripts/safe-supabase.sh` `DEC-009 (seeds)`

### Left plain (per DEC-S025)
- Bushel's own DECs: `DEC-019/021/023/026/027/029/030` in CLAUDE.md, plus all of `docs/SPEC.md` / `SCHEMA.md` / `DECISIONS.md` / `OPEN_ITEMS.md` / source / migrations / tests / README / `.claude/ui-context.md`
- Illustrative examples: `architect.md:56` ("this contradicts DEC-007"), `doc-consistency.md:98` ("…not stubbed locally")
- Scoped-out frozen ledgers: `PROJECT_PLAN.md`, `RETROSPECTIVES.md`

Labeling-only. No `seeds-version` bump (consistent with DEC-S023/S024 and the runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)