### PR TITLE
auto-sync downstream — 2026-06-10

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,6 +1,7 @@
 ---
 name: architect
 description: Architectural reviewer for [Project]. Reviews design decisions against SPEC.md, DECISIONS.md, and the project deadline. Use before committing to a new pattern, adding a dependency, or when scope creep is knocking.
+model: fable
 ---
 
 You are @architect — the architectural decision reviewer for this project.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -192,7 +192,7 @@ Slash commands manage session lifecycle. Time tracking is automatic.
 
 | Agent/Skill | Model | When | Purpose |
 |-------------|-------|------|---------|
-| @architect | Opus | Before design decisions | Keep architecture coherent |
+| @architect | Fable 5 | Before design decisions | Keep architecture coherent |
 | @code-review | Sonnet | After commits, optional | Catch issues early |
 | @pm | Sonnet | Start/end of sessions | Track progress, flag risks |
 | @ui-reviewer | Sonnet | After UI work, phase boundaries | Design quality |

--- a/docs/VELOCITY_AND_POKER_GUIDE.md
+++ b/docs/VELOCITY_AND_POKER_GUIDE.md
@@ -59,6 +59,8 @@ For one phase, read RETROSPECTIVES.md. For your lifetime number — or a combine
 **No 1s** — if it's that small, just do it. Don't plan it.
 **No 13s if avoidable** — break them down. A 13 means you don't understand the task well enough yet.
 
+**Points size estimation, not execution units.** A point is a relative planning number calibrated to your own velocity — *not* a ceiling on how much Claude builds in one run. Current models hold coherence across far more than an 8, and splitting a *coherent* task to honor a points ceiling fragments context and can lower quality (two stitched 5s < one well-specified 8). Split execution units by **reviewability, blast radius, reversibility, and migration conflicts** — not by "the model can't hold it." A coherent 8 is a fine single unit; a genuine 13 still gets broken up (you don't understand it well enough yet, and the diff is hard to review). See CLAUDE.md § Scope Discipline.
+
 ### How to poker (solo dev + Claude)
 
 **Setup:** Claude proposes effort for each task in a phase. You review.


### PR DESCRIPTION
Base: `main`

Nightly downstream sync — `@sync-config` run in `mode: auto`, `direction: pull` against seeds@v4. Project-type `webapp`. Schema versions match (project: 4, seeds: 4).

## Sources

- `mobiustripper42/bushel`: 3 forward-ports applied, ~50+ hunks skipped

## Classification table

| File | Hunk | Provenance | Classification | Action |
|------|------|------------|----------------|--------|
| `.claude/agents/architect.md` | `model: fable` added to frontmatter | Template-only | Forward-port | Forward-ported |
| `docs/AGENTS.md` | `@architect` row: `Opus` → `Fable 5` | Template-only | Forward-port | Forward-ported |
| `docs/VELOCITY_AND_POKER_GUIDE.md` | new "Points size estimation, not execution units" paragraph | Template-only | Forward-port | Forward-ported |
| `agents/ui-reviewer.md` | 4 hunks (description/intro Bay Branch Farm wording) | Project-only | Skip | Skipped — project substitutions preserved |
| `CLAUDE.md` | ~50+ hunks | Both-modified | Skip | Skipped — heavy webapp customization (design folder, Supabase split, Next.js 16 routing); interactive `/pull-seeds` recommended for the §Model Selection / §Narration / §Scope-Discipline candidates |
| 6 context files | (file) | n/a | Skip | Skipped — class:context (SPEC, BRAND, DECISIONS, PROJECT_PLAN, RETROSPECTIVES, USER_STORIES) |
| 15 logic files | (file) | n/a | Skip | Skipped — logic class, hash-equal (13 skills + sync-config + tape-reader) |

## Files changed

- `.claude/agents/architect.md`
- `docs/AGENTS.md`
- `docs/VELOCITY_AND_POKER_GUIDE.md`

## Pattern flags

None.

## Notes

Worth a follow-up interactive `/pull-seeds` pass on `CLAUDE.md` — auto skipped the §Model Selection / §Narration / "Splitting is a reviewability call" template additions because of heavy Both-modified context, but they may apply cleanly with human judgment per hunk.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxH8B5GNCXtXn28bNhSHBK)_