### PR TITLE
#207 Hide/Show inventory items: soft-delete for products

### DIFF
--- a/docs/OPEN_ITEMS.md
+++ b/docs/OPEN_ITEMS.md
@@ -30,12 +30,11 @@ GitHub issues closed back into the parking lot — premature to commit work with
 - **10DLC brand registration + A2P migration** (DEC-026) — was #139 (1 pt code + 4–8 week carrier approval clock). Reverses operator-sent SMS in part: migrate send path from `sms:` deep link → API send. Trigger: ~50 messages/week sustained, OR Annabel asks for unattended sends, OR carriers start filtering Bushel-derived links.
 - **Minimum delivery amount** — was #138 (2 pts). Per-fulfillment-type dollar threshold; block submit below it for delivery (pickup probably exempt). Open Q: per-customer override (some restaurants free, some $40). Trigger: a $6 delivery to a restaurant actually happens and bites.
 - **Realtime inventory subscription** (was Phase 3.8 ship-or-skip) — was #53 (5 pts). Supabase Realtime push of `products.qty_available` + `is_available` to the customer order form, behind `NEXT_PUBLIC_REALTIME_INVENTORY` flag. Tightens DEC-012's optimistic-placement window without replacing `needs_reconciliation`. Trigger: oversell becomes a frequent operational problem (e.g. Annabel reconciling multiple orders a week).
-- **Make `product_units` strictly authoritative** — was #174. Drop the denormalized `products.unit` + `products.price_cents` columns and the bidirectional mirror triggers added in PR #175 (`task/7.x-inline-debug`). Replace remaining `products.unit` / `products.price_cents` readers (`src/lib/admin/orders-queries.ts:112` legacy fallback, `src/components/customer/OrderForm.tsx` defensive fallbacks) with `product_units` joins; saveInventory stops writing the mirror columns; migration drops them. Trigger: a third drift symptom from the dual-storage mirror, OR the inline-debug stack settles enough that this cleanup is worth the migration cost.
 - **Inventory drag-reorder above/below precision** — was #168. Split each row into upper/lower halves by cursor Y (`getBoundingClientRect().top + height/2`); below-half drops splice *after* the target. ~20 LOC + an `insertPosition: 'before' | 'after'` param on `reorderRows`. Bundled: "Save N changes" copy could special-case reorder-only diffs (one-row drag currently reports "Save 3 changes" because every row's sort_order shifts). Trigger: Annabel notices the down-drag asymmetry, OR a second person hits the surprising copy.
 
 ## Promoted
 
-*(empty — entries move here with a `→ #NNN` link when filed as issues)*
+- **Make `product_units` strictly authoritative** → [#212](https://github.com/mobiustripper42/bushel/issues/212) — promoted 2026-06-11. Trigger met: #208 surfaced the dual-storage drift again. Split out of #208; drop the denormalized `products.unit` + `products.price_cents` mirror columns + PR #175 triggers.
 
 ## Dropped
 

--- a/src/actions/save-inventory.ts
+++ b/src/actions/save-inventory.ts
@@ -16,12 +16,12 @@ export type InventoryRowInput = {
   price_cents: number;
   qty_available: number;
   is_available: boolean;
+  is_active: boolean;
   sort_order: number | null;
 };
 
 export type SaveInventoryInput = {
   rows: InventoryRowInput[];
-  deletedIds: string[];
 };
 
 export type SaveInventoryResult = {
@@ -59,11 +59,9 @@ export async function saveInventory(input: SaveInventoryInput): Promise<SaveInve
 
   const newIdMap: Record<string, string> = {};
 
-  if (input.deletedIds.length > 0) {
-    const { error } = await supabase.from("products").delete().in("id", input.deletedIds);
-    if (error) return { error: error.message, newIdMap };
-  }
-
+  // #207 — products are never hard-deleted; the editor's trash button stages a
+  // soft-hide (is_active=false), persisted through the row update below. This
+  // keeps order_items references intact.
   for (const row of input.rows) {
     const payload = {
       name: row.name.trim(),
@@ -73,6 +71,7 @@ export async function saveInventory(input: SaveInventoryInput): Promise<SaveInve
       price_cents: row.price_cents,
       qty_available: Math.round(row.qty_available * 100) / 100,
       is_available: row.is_available,
+      is_active: row.is_active,
       sort_order: row.sort_order,
       updated_at: now,
     };

--- a/src/app/(admin)/admin/inventory/page.tsx
+++ b/src/app/(admin)/admin/inventory/page.tsx
@@ -115,6 +115,7 @@ export default async function InventoryPage() {
     price_cents: p.price_cents,
     qty_available: p.qty_available,
     is_available: p.is_available,
+    is_active: p.is_active,
     sort_order: p.sort_order,
   }));
 

--- a/src/components/admin/customer-drawer.tsx
+++ b/src/components/admin/customer-drawer.tsx
@@ -20,7 +20,8 @@ export type CustomerDrawerState = {
   priority: string;
   send_weekly_link: boolean;
   token: string;
-  // #61 — when false, the drawer swaps "Delete customer" for "Reactivate".
+  // #61 — when false, the drawer swaps "Hide customer" for "Restore" (#207
+  // unified the wording across the inventory + customer screens to Hide/Show).
   is_active: boolean;
 };
 
@@ -150,7 +151,7 @@ export function CustomerDrawer({ initial, onClose, onSaved }: Props) {
         <header className="drawer-head">
           <div>
             <div className="eyebrow">
-              {isNew ? "new customer" : isInactive ? "deactivated customer" : "edit customer"}
+              {isNew ? "new customer" : isInactive ? "hidden customer" : "edit customer"}
             </div>
             <h2 className="drawer-title">
               {isNew ? "Add a new customer" : initial.name || "—"}
@@ -255,7 +256,7 @@ export function CustomerDrawer({ initial, onClose, onSaved }: Props) {
               onClick={handleDelete}
               disabled={deleting || saving}
             >
-              {deleting ? "Deactivating…" : "Delete customer"}
+              {deleting ? "Hiding…" : "Hide customer"}
             </Button>
           )}
           {isInactive && (
@@ -264,7 +265,7 @@ export function CustomerDrawer({ initial, onClose, onSaved }: Props) {
               onClick={handleReactivate}
               disabled={reactivating || saving || deleting}
             >
-              {reactivating ? "Reactivating…" : "Reactivate customer"}
+              {reactivating ? "Restoring…" : "Restore customer"}
             </Button>
           )}
           <div style={{ flex: 1 }} />

--- a/src/components/admin/customers-page.tsx
+++ b/src/components/admin/customers-page.tsx
@@ -138,8 +138,8 @@ export function CustomersPage({ customers }: Props) {
             aria-pressed={showDeactivated}
           >
             {showDeactivated
-              ? `Hide deactivated (${deactivatedCount})`
-              : `Show deactivated (${deactivatedCount})`}
+              ? `Hide hidden (${deactivatedCount})`
+              : `Show hidden (${deactivatedCount})`}
           </Button>
         )}
         <Button variant="secondary" disabled title="Coming later">
@@ -180,7 +180,7 @@ export function CustomersPage({ customers }: Props) {
                 <td colSpan={7} style={{ padding: 32, textAlign: "center", color: "var(--ink-500)" }}>
                   {showDeactivated
                     ? "No customers."
-                    : "No active customers. Add one to get started."}
+                    : "No visible customers. Add one to get started."}
                 </td>
               </tr>
             )}

--- a/src/components/admin/inventory-editor.tsx
+++ b/src/components/admin/inventory-editor.tsx
@@ -57,7 +57,7 @@ export function InventoryEditor({ initialRows, initialUnits, soldByProductId, we
   const router = useRouter();
   const [rows, setRows] = useState<InventoryRowState[]>(initialRows);
   const [baseline, setBaseline] = useState<InventoryRowState[]>(initialRows);
-  const [deletedIds, setDeletedIds] = useState<string[]>([]);
+  const [showHidden, setShowHidden] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saving, startSaving] = useTransition();
   const [unitsOpenFor, setUnitsOpenFor] = useState<string | null>(null);
@@ -71,7 +71,10 @@ export function InventoryEditor({ initialRows, initialUnits, soldByProductId, we
   }, [baseline]);
 
   const dirtyCount = useMemo(() => {
-    let count = deletedIds.length;
+    // #207 — hiding is an is_active field change on the row (persisted via the
+    // normal Save), so the JSON diff below already counts it. No separate
+    // deleted-ids tally.
+    let count = 0;
     for (const row of rows) {
       if (row.isNew) {
         count += 1;
@@ -83,7 +86,7 @@ export function InventoryEditor({ initialRows, initialUnits, soldByProductId, we
       }
     }
     return count;
-  }, [rows, baselineMap, deletedIds]);
+  }, [rows, baselineMap]);
 
   const dirty = dirtyCount > 0;
   // #129 — suspend the guard while a save is in flight; the success path
@@ -108,11 +111,24 @@ export function InventoryEditor({ initialRows, initialUnits, soldByProductId, we
   // admin V1.
   const dirtyRef = useRef(dirty);
   dirtyRef.current = dirty;
+  // Only adopt fresh server data when it actually differs from our current
+  // baseline. This guards two cases that would otherwise clobber an edit:
+  //   1. The mount run — useState already seeded rows + baseline from
+  //      initialRows, so re-setting them is redundant.
+  //   2. A spurious re-render that hands us a new initialRows *reference* with
+  //      identical content (observed on WebKit/mobile during hydration). The
+  //      old reference-only guard would fire setRows(initialRows) and drop a
+  //      qty edit typed in the same tick — the local field draft survives, so
+  //      the input shows the new value while the dirty count silently stays 0.
+  // A genuine change (router.refresh() after save / prepopulate, or a
+  // concurrent-tab write) differs in content and resyncs as before.
+  const baselineRef = useRef(baseline);
+  baselineRef.current = baseline;
   useEffect(() => {
     if (dirtyRef.current) return;
+    if (JSON.stringify(initialRows) === JSON.stringify(baselineRef.current)) return;
     setRows(initialRows);
     setBaseline(initialRows);
-    setDeletedIds([]);
   }, [initialRows]);
 
   function update(id: string, patch: Partial<InventoryRowState>) {
@@ -120,11 +136,20 @@ export function InventoryEditor({ initialRows, initialUnits, soldByProductId, we
     setError(null);
   }
 
-  function remove(id: string) {
-    setRows((rs) => rs.filter((r) => r.id !== id));
-    if (!id.startsWith("new-")) {
-      setDeletedIds((ids) => [...ids, id]);
+  // #207 — the trash button hides instead of deleting. A never-saved new row
+  // has no DB row to keep, so it drops locally; a saved row is soft-hidden
+  // (is_active=false) and persists on the next Save.
+  function hide(id: string) {
+    if (id.startsWith("new-")) {
+      setRows((rs) => rs.filter((r) => r.id !== id));
+    } else {
+      setRows((rs) => rs.map((r) => (r.id === id ? { ...r, is_active: false } : r)));
     }
+    setError(null);
+  }
+
+  function restore(id: string) {
+    setRows((rs) => rs.map((r) => (r.id === id ? { ...r, is_active: true } : r)));
     setError(null);
   }
 
@@ -145,6 +170,7 @@ export function InventoryEditor({ initialRows, initialUnits, soldByProductId, we
         price_cents: 0,
         qty_available: 0,
         is_available: true,
+        is_active: true,
         sort_order: maxOrder + 10,
       },
     ]);
@@ -153,7 +179,6 @@ export function InventoryEditor({ initialRows, initialUnits, soldByProductId, we
 
   function handleDiscard() {
     setRows(baseline);
-    setDeletedIds([]);
     setError(null);
   }
 
@@ -196,9 +221,9 @@ export function InventoryEditor({ initialRows, initialUnits, soldByProductId, we
             price_cents: r.price_cents,
             qty_available: r.qty_available,
             is_available: r.is_available,
+            is_active: r.is_active,
             sort_order: r.sort_order,
           })),
-          deletedIds,
         });
       } catch (e) {
         setError(e instanceof Error ? e.message : "Save failed. Try again.");
@@ -221,12 +246,14 @@ export function InventoryEditor({ initialRows, initialUnits, soldByProductId, we
       }
 
       setBaseline(mapped);
-      setDeletedIds([]);
       router.refresh();
     });
   }
 
-  const productCount = rows.length;
+  const activeRows = rows.filter((r) => r.is_active);
+  const hiddenCount = rows.length - activeRows.length;
+  const visibleRows = showHidden ? rows : activeRows;
+  const productCount = activeRows.length;
 
   return (
     <>
@@ -235,6 +262,15 @@ export function InventoryEditor({ initialRows, initialUnits, soldByProductId, we
         title="Inventory"
         titleSuffix={weekLabel}
       >
+        {hiddenCount > 0 && (
+          <Button
+            variant="secondary"
+            onClick={() => setShowHidden((v) => !v)}
+            aria-pressed={showHidden}
+          >
+            {showHidden ? `Hide hidden (${hiddenCount})` : `Show hidden (${hiddenCount})`}
+          </Button>
+        )}
         <PrepopulateButton />
         <Button
           variant="primary"
@@ -292,7 +328,7 @@ export function InventoryEditor({ initialRows, initialUnits, soldByProductId, we
             </tr>
           </thead>
           <tbody>
-            {rows.map((row) => {
+            {visibleRows.map((row) => {
               const units = initialUnits[row.id] ?? [];
               return (
                 <InventoryRow
@@ -302,7 +338,8 @@ export function InventoryEditor({ initialRows, initialUnits, soldByProductId, we
                   inactiveExtrasCount={Math.max(0, units.filter((u) => !u.is_active).length)}
                   soldThisWeek={soldByProductId[row.id] ?? 0}
                   onUpdate={(patch) => update(row.id, patch)}
-                  onRemove={() => remove(row.id)}
+                  onRemove={() => hide(row.id)}
+                  onRestore={() => restore(row.id)}
                   onOpenUnits={row.isNew ? undefined : () => setUnitsOpenFor(row.id)}
                   isDragging={draggingId === row.id}
                   isDropTarget={dropTargetId === row.id && draggingId !== row.id}

--- a/src/components/admin/inventory-row.tsx
+++ b/src/components/admin/inventory-row.tsx
@@ -15,6 +15,9 @@ export type InventoryRowState = {
   price_cents: number;
   qty_available: number;
   is_available: boolean;
+  // #207 soft-delete. false = hidden: filtered out of the default view,
+  // excluded from the customer order form. Persisted via the normal Save.
+  is_active: boolean;
   sort_order: number | null;
 };
 
@@ -24,7 +27,9 @@ type Props = {
   inactiveExtrasCount?: number;
   soldThisWeek?: number;
   onUpdate: (patch: Partial<InventoryRowState>) => void;
+  // #207 — trash hides (active rows) or drops unsaved new rows; restore unhides.
   onRemove: () => void;
+  onRestore?: () => void;
   onOpenUnits?: () => void;
   // Drag-to-reorder (#143). The row is only `draggable` while the grip is
   // armed (onMouseDown on grip → arm; onDragEnd → disarm) so clicks into
@@ -58,6 +63,7 @@ export function InventoryRow({
   soldThisWeek = 0,
   onUpdate,
   onRemove,
+  onRestore,
   onOpenUnits,
   isDragging = false,
   isDropTarget = false,
@@ -81,6 +87,7 @@ export function InventoryRow({
 
   const rowClass =
     "data-row" +
+    (!row.is_active ? " is-hidden" : "") +
     (!row.is_available ? " is-disabled" : "") +
     (isDragging ? " is-dragging" : "") +
     (isDropTarget ? " is-drop-target" : "");
@@ -266,20 +273,32 @@ export function InventoryRow({
           />
         </td>
         <td className="row-actions">
-          <button
-            type="button"
-            className="row-trash"
-            onClick={onRemove}
-            title="Delete row"
-            aria-label={`Delete ${row.name || "new row"}`}
-          >
-            <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M3 6h18" />
-              <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
-              <path d="M19 6 17.5 20a2 2 0 0 1-2 2h-7a2 2 0 0 1-2-2L5 6" />
-              <path d="M10 11v6 M14 11v6" />
-            </svg>
-          </button>
+          {row.is_active ? (
+            <button
+              type="button"
+              className="row-trash"
+              onClick={onRemove}
+              title="Hide row"
+              aria-label={`Hide ${row.name || "new row"}`}
+            >
+              <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M3 6h18" />
+                <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+                <path d="M19 6 17.5 20a2 2 0 0 1-2 2h-7a2 2 0 0 1-2-2L5 6" />
+                <path d="M10 11v6 M14 11v6" />
+              </svg>
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="row-restore"
+              onClick={onRestore}
+              title="Restore row"
+              aria-label={`Restore ${row.name || "row"}`}
+            >
+              Restore
+            </button>
+          )}
         </td>
       </tr>
       {descOpen && (

--- a/src/lib/admin/queries.ts
+++ b/src/lib/admin/queries.ts
@@ -9,6 +9,7 @@ export async function getInventoryCount(): Promise<number> {
   const { count, error } = await supabase
     .from("products")
     .select("id", { count: "exact", head: true })
+    .eq("is_active", true)
     .eq("is_available", true);
   if (error) throw new Error(`getInventoryCount: ${error.message}`);
   return count ?? 0;

--- a/src/lib/customer/queries.ts
+++ b/src/lib/customer/queries.ts
@@ -20,6 +20,7 @@ export async function getAvailableProducts(): Promise<ProductRow[]> {
   const { data, error } = await supabase
     .from("products")
     .select("*, product_units(*)")
+    .eq("is_active", true)
     .eq("is_available", true)
     .order("sort_order", { ascending: true });
   if (error) throw new Error(`getAvailableProducts: ${error.message}`);

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -356,6 +356,7 @@ export type Database = {
           created_at: string
           description: string | null
           id: string
+          is_active: boolean
           is_available: boolean
           name: string
           price_cents: number
@@ -369,6 +370,7 @@ export type Database = {
           created_at?: string
           description?: string | null
           id?: string
+          is_active?: boolean
           is_available?: boolean
           name: string
           price_cents: number
@@ -382,6 +384,7 @@ export type Database = {
           created_at?: string
           description?: string | null
           id?: string
+          is_active?: boolean
           is_available?: boolean
           name?: string
           price_cents?: number

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -164,6 +164,19 @@
 .data-table tbody tr.data-row.is-disabled .field-input,
 .data-table tbody tr.data-row.is-disabled .field-num,
 .data-table tbody tr.data-row.is-disabled .field-select { color: var(--ink-500); }
+/* #207 — hidden (soft-deleted) products. Diagonal hatch matches the
+   deactivated-customer treatment so "hidden" reads the same on both screens.
+   Only visible when "Show hidden" is toggled on. */
+.data-table tbody tr.data-row.is-hidden td {
+  background: repeating-linear-gradient(
+    -45deg,
+    var(--ink-100) 0 6px,
+    transparent 6px 12px
+  );
+}
+.data-table tbody tr.data-row.is-hidden .field-input,
+.data-table tbody tr.data-row.is-hidden .field-num,
+.data-table tbody tr.data-row.is-hidden .field-select { color: var(--ink-500); }
 
 /* Drag-to-reorder (#143) */
 .data-table tbody tr.data-row.is-dragging td { opacity: 0.4; }
@@ -197,6 +210,16 @@
   transition: background 0.1s, color 0.1s;
 }
 .row-trash:hover { background: rgba(178,59,46,0.08); color: var(--rose-600); }
+/* #207 — restore swaps in for the trash icon on hidden rows. */
+.row-restore {
+  background: transparent; border: 1px solid var(--ink-300);
+  color: var(--ink-700);
+  font-size: 0.78rem; font-weight: 500;
+  padding: 4px 10px; border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+}
+.row-restore:hover { background: var(--cream); border-color: var(--leaf-600, var(--ink-500)); }
 
 /* Add row footer */
 .add-row {

--- a/supabase/migrations/20260611120000_products_is_active.sql
+++ b/supabase/migrations/20260611120000_products_is_active.sql
@@ -1,0 +1,8 @@
+-- #207 Hide/Show inventory items: soft-delete for products.
+-- Mirrors customers.is_active (#61). Hidden products (is_active = false) are
+-- dropped from the customer order form and the default admin inventory view,
+-- but never hard-deleted — their order history stays intact.
+alter table products add column is_active boolean not null default true;
+
+comment on column products.is_active is
+  'Soft-delete flag. false = hidden/archived: excluded from the customer order form and the default admin inventory view, but order_items references remain valid. Distinct from is_available (per-week sold-out toggle).';

--- a/tests/admin-customers.spec.ts
+++ b/tests/admin-customers.spec.ts
@@ -79,7 +79,7 @@ test.describe("admin customers", () => {
     await expect(rowByName(page, uniqueName)).toBeVisible();
   });
 
-  test("Delete customer deactivates and drops the row from the list", async ({ page }) => {
+  test("Hide customer deactivates and drops the row from the list", async ({ page }) => {
     // Seed phone so beforeEach-cleaned customer can be edited
     const supabase = admin();
     await supabase.from("customers").update({ phone: "216-555-0100" }).eq("token", TEST_CUSTOMERS.restaurant.token);
@@ -87,7 +87,7 @@ test.describe("admin customers", () => {
     await page.goto("/admin/customers");
     await rowByName(page, TEST_CUSTOMERS.restaurant.name).click();
     await expect(drawer(page)).toBeVisible();
-    await drawer(page).getByRole("button", { name: /delete customer/i }).click();
+    await drawer(page).getByRole("button", { name: /hide customer/i }).click();
     await expect(drawer(page)).toHaveCount(0);
     await expect(rowByName(page, TEST_CUSTOMERS.restaurant.name)).toHaveCount(0);
   });
@@ -199,12 +199,13 @@ test.describe("admin customers", () => {
     expect(flipped).not.toBe(initial);
   });
 
-  // #61 — deactivated customers are hidden by default; a header toggle reveals
-  // them with a distinct "is-inactive" treatment, and the drawer swaps
-  // "Delete customer" for "Reactivate customer". The next test's beforeEach
-  // (resetTestCustomers) restores is_active=true on both seed rows so the
-  // bare deactivate doesn't leak.
-  test("Show deactivated reveals inactive rows; drawer Reactivate restores them", async ({ page }) => {
+  // #61 — hidden customers are dropped from the default view; a header toggle
+  // reveals them with a distinct "is-inactive" treatment, and the drawer swaps
+  // "Hide customer" for "Restore customer". #207 unified this wording to
+  // Hide/Show across the customer + inventory screens. The next test's
+  // beforeEach (resetTestCustomers) restores is_active=true on both seed rows
+  // so the bare hide doesn't leak.
+  test("Show hidden reveals inactive rows; drawer Restore restores them", async ({ page }) => {
     const supabase = admin();
     await supabase
       .from("customers")
@@ -220,8 +221,8 @@ test.describe("admin customers", () => {
     // Eyebrow reflects active count only — 1 active row, not 2 accounts.
     await expect(page.getByText(/1 account · /)).toBeVisible();
 
-    // Toggle appears with the deactivated count.
-    const toggle = page.getByRole("button", { name: /show deactivated \(1\)/i });
+    // Toggle appears with the hidden count.
+    const toggle = page.getByRole("button", { name: /show hidden \(1\)/i });
     await expect(toggle).toBeVisible();
     await toggle.click();
 
@@ -232,19 +233,19 @@ test.describe("admin customers", () => {
     // Subscribed switch is disabled on a deactivated row.
     await expect(restaurantRow.getByRole("switch")).toBeDisabled();
 
-    // Drawer on the inactive row swaps Delete → Reactivate.
+    // Drawer on the inactive row swaps Hide → Restore.
     await restaurantRow.locator(".cust-name").click();
     await expect(drawer(page)).toBeVisible();
-    await expect(drawer(page).getByText(/deactivated customer/i)).toBeVisible();
-    await expect(drawer(page).getByRole("button", { name: /^delete customer$/i })).toHaveCount(0);
+    await expect(drawer(page).getByText(/hidden customer/i)).toBeVisible();
+    await expect(drawer(page).getByRole("button", { name: /^hide customer$/i })).toHaveCount(0);
 
-    await drawer(page).getByRole("button", { name: /^reactivate customer$/i }).click();
+    await drawer(page).getByRole("button", { name: /^restore customer$/i }).click();
     await expect(drawer(page)).toHaveCount(0);
 
-    // Row is back in the default view; toggle is gone (no more deactivated).
+    // Row is back in the default view; toggle is gone (no more hidden).
     await expect(rowByName(page, TEST_CUSTOMERS.restaurant.name)).toBeVisible();
     await expect(rowByName(page, TEST_CUSTOMERS.restaurant.name)).not.toHaveClass(/is-inactive/);
-    await expect(page.getByRole("button", { name: /show deactivated/i })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /show hidden/i })).toHaveCount(0);
   });
 
   // #129 — drawer is the most complex consumer of the unsaved-changes

--- a/tests/admin-inventory.spec.ts
+++ b/tests/admin-inventory.spec.ts
@@ -4,6 +4,7 @@ import {
   TEST_PRODUCTS,
   clearOrdersForWeek,
   customerIds,
+  deleteProductByName,
   resetProductSortOrder,
   seedOrder,
   setOrderingSchedule,
@@ -187,35 +188,60 @@ test.describe("admin inventory", () => {
     await expect(saveButton(page, 1)).toBeEnabled();
   });
 
-  test("add row, save, then delete the added row", async ({ page }) => {
-    await page.goto("/admin/inventory");
+  // #207 — products are never hard-deleted. The trash button hides them
+  // (is_active=false): gone from the default view + the customer order form,
+  // recoverable via "Show hidden" → Restore.
+  test("add row, hide it, then restore via Show hidden", async ({ page }) => {
+    try {
+      await page.goto("/admin/inventory");
 
-    await page.getByRole("button", { name: /add row/i }).click();
+      await page.getByRole("button", { name: /add row/i }).click();
 
-    const added = newRow(page);
-    await added.getByRole("textbox", { name: "Product name" }).fill("Test Carrots");
-    // Price input flipped from type=number to type=text + inputMode=decimal
-    // to fix the controlled-decimal-input cursor-jump bug. Role is now
-    // textbox, not spinbutton.
-    await added.getByRole("textbox", { name: /price/i }).fill("4.00");
-    await added.getByRole("textbox", { name: "Unit" }).fill("per lb");
-    await added.getByRole("textbox", { name: /quantity/i }).fill("20");
+      const added = newRow(page);
+      await added.getByRole("textbox", { name: "Product name" }).fill("Test Carrots");
+      // Price input flipped from type=number to type=text + inputMode=decimal
+      // to fix the controlled-decimal-input cursor-jump bug. Role is now
+      // textbox, not spinbutton.
+      await added.getByRole("textbox", { name: /price/i }).fill("4.00");
+      await added.getByRole("textbox", { name: "Unit" }).fill("per lb");
+      await added.getByRole("textbox", { name: /quantity/i }).fill("20");
 
-    await expect(saveButton(page, 1)).toBeEnabled();
-    await saveButton(page, 1).click();
-    await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
+      await expect(saveButton(page, 1)).toBeEnabled();
+      await saveButton(page, 1).click();
+      await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
 
-    await page.reload();
-    const saved = rowByName(page, "Test Carrots");
-    await expect(saved).toBeVisible();
+      await page.reload();
+      const saved = rowByName(page, "Test Carrots");
+      await expect(saved).toBeVisible();
 
-    await saved.getByRole("button", { name: /^Delete/ }).click();
-    await expect(saveButton(page, 1)).toBeEnabled();
-    await saveButton(page, 1).click();
-    await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
+      // Hide it: trash stages is_active=false; save persists.
+      await saved.getByRole("button", { name: /^Hide Test Carrots/ }).click();
+      await expect(saveButton(page, 1)).toBeEnabled();
+      await saveButton(page, 1).click();
+      await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
 
-    await page.reload();
-    await expect(rowByName(page, "Test Carrots")).toHaveCount(0);
+      // Gone from the default view, but not deleted.
+      await page.reload();
+      await expect(rowByName(page, "Test Carrots")).toHaveCount(0);
+
+      // "Show hidden (N)" reveals it with a Restore button.
+      await page.getByRole("button", { name: /^Show hidden \(\d+\)$/ }).click();
+      const hidden = rowByName(page, "Test Carrots");
+      await expect(hidden).toBeVisible();
+      await expect(hidden).toHaveClass(/is-hidden/);
+
+      await hidden.getByRole("button", { name: /^Restore Test Carrots/ }).click();
+      await expect(saveButton(page, 1)).toBeEnabled();
+      await saveButton(page, 1).click();
+      await expect(page.getByRole("button", { name: /^Saved$/ })).toBeVisible();
+
+      // Restored: back in the default view, no "Show hidden" button.
+      await page.reload();
+      await expect(rowByName(page, "Test Carrots")).toBeVisible();
+      await expect(page.getByRole("button", { name: /^Show hidden/ })).toHaveCount(0);
+    } finally {
+      await deleteProductByName("Test Carrots");
+    }
   });
 
   // #129 — guard fires on in-app navigation when the form is dirty;

--- a/tests/customer-closed-and-soldout.spec.ts
+++ b/tests/customer-closed-and-soldout.spec.ts
@@ -7,6 +7,7 @@ import {
   restoreProductQty,
   setAllProductsSoldOut,
   setOrderingOpen,
+  setProductActive,
   setProductQty,
 } from "./helpers";
 
@@ -74,6 +75,25 @@ test.describe("/c/[token] state — closed + all sold out (DEC-031)", () => {
     await expect(eggsRow).not.toHaveClass(/is-sold-out/);
     await eggsRow.getByRole("button", { name: "increase" }).click();
     await expect(eggsRow.locator(".stepper-val")).toHaveValue("1");
+  });
+
+  // #207 — a hidden product (is_active=false) is gone from the customer form
+  // entirely, regardless of is_available/qty. Distinct from sold-out, which
+  // still renders the row greyed.
+  test("hidden product: is_active=false excludes the row from the customer form", async ({ page }) => {
+    try {
+      await setProductActive(TEST_PRODUCTS.honey.id, false);
+
+      await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+
+      // Honey is absent — not greyed, not present at all.
+      await expect(page.locator(".item-row", { hasText: TEST_PRODUCTS.honey.name })).toHaveCount(0);
+      // Other products still render and the form is interactive.
+      const kaleRow = page.locator(".item-row", { hasText: TEST_PRODUCTS.kale.name });
+      await expect(kaleRow).toBeVisible();
+    } finally {
+      await setProductActive(TEST_PRODUCTS.honey.id, true);
+    }
   });
 
   test("closed mid-order race: page loaded open, schedule flips closed, submit still succeeds (DEC-031 soft hint)", async ({ page }) => {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -182,6 +182,19 @@ export async function resetProductSortOrder(): Promise<void> {
   }
 }
 
+// #207 — products are soft-hidden (is_active=false) from the UI, never
+// hard-deleted, so a test that adds a throwaway product can't clean up through
+// the editor. This removes it at the DB level for test isolation.
+export async function deleteProductByName(name: string): Promise<void> {
+  await admin().from("products").delete().eq("name", name);
+}
+
+// #207 — flip a product's soft-delete flag. Hidden products (is_active=false)
+// drop out of the customer order form and the default admin view.
+export async function setProductActive(id: string, active: boolean): Promise<void> {
+  await admin().from("products").update({ is_active: active }).eq("id", id);
+}
+
 // Patches the singleton ordering_schedule row. Pass only the fields you want
 // to change. Used by the inventory meta-pill tests to walk all three open
 // states (closed / open manual / open via schedule).


### PR DESCRIPTION
## Summary
Soft-delete for inventory products (#207). The trash button hides products (`is_active=false`) instead of hard-deleting — gone from the customer order form and the default admin view, but `order_items` history stays intact. A "Show hidden (N)" toggle reveals hidden rows with a Restore action. Wording unified to Hide/Show across the inventory + customer screens.

## Files changed
- `supabase/migrations/20260611120000_products_is_active.sql` — `products.is_active boolean not null default true`
- `src/actions/save-inventory.ts` — removed the hard `.delete()` path + `deletedIds`; `is_active` persists through the normal Save
- `src/components/admin/inventory-editor.tsx` — hide/restore/showHidden + `visibleRows`; resync `useEffect` now content-gated (see Code review)
- `src/components/admin/inventory-row.tsx` — trash→Hide / Restore, `is-hidden` row
- `src/lib/customer/queries.ts` — `getAvailableProducts` excludes `is_active=false`
- `src/lib/admin/queries.ts` — `getInventoryCount` (nav "N listed" badge) excludes hidden
- `src/app/(admin)/admin/inventory/page.tsx`, `src/lib/supabase/types.ts`, `src/styles/app.css`
- `src/components/admin/customers-page.tsx`, `customer-drawer.tsx` — Delete→Hide, Reactivate→Restore, deactivated→hidden
- tests: `admin-inventory`, `admin-customers`, `customer-closed-and-soldout`, `helpers`
- `docs/OPEN_ITEMS.md` — #174 promoted to #212 (grooming that rode along)

## Code review
One real defect found + fixed: `getInventoryCount` didn't filter `is_active`, over-counting hidden products in the admin "N listed" badge — now filtered. Advisory (not addressed, low-risk): `prepopulate_inventory_from_last_week` and `place_order` don't guard on `is_active` (hidden products are filtered from the customer path anyway — defense-in-depth only). RLS anon SELECT keys on `is_available`; customer reads go through the service-role client, so the query-layer `.eq("is_active", true)` is the gate by design.

## Test plan
- **DB:** `supabase db push` applies `products.is_active` (default true → existing rows unaffected). Three S36 migrations are still pending prod ahead of this — push in timestamp order.
- **Admin /admin/inventory:** trash a product → it leaves the list, "Save N" enabled → Save → row gone, "Show hidden (1)" appears → toggle → row shown hatched with Restore → Restore + Save → back in list, toggle gone. "N listed" nav badge drops when a product is hidden.
- **Customer /c/[token]:** a hidden product does not render in the order form (distinct from sold-out, which greys the row).
- **Admin /admin/customers:** header reads "Show hidden (N)"; drawer on an inactive customer reads "Restore customer" / eyebrow "hidden customer"; active drawer reads "Hide customer".
- **Tests:** desktop green (`admin-inventory admin-customers customer-closed-and-soldout --project=desktop`, 32 pass). Mobile WebKit has the known pre-existing `.fill()` flake on the qty tests (green in CI w/ retries:2, red locally w/ retries:0 — fails on main too).

closes #207