### PR TITLE
#132 reject orders against sold-out (qty=0) products (DEC-036)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -432,6 +432,21 @@ PWA push notification remains the stretch upgrade per DEC-027's framing.
 
 ---
 
+## DEC-036 — Optimistic oversell (DEC-012) does not extend to qty=0 (#132)
+
+**Decision:** `place_order` rejects any line item whose product has `qty_available = 0` at submit time. DEC-012's optimistic placement — let the "last few" oversell and flag `needs_reconciliation` — applies **only while `qty_available > 0`**. Zero means truly unavailable (DEC-031), so an order against it is refused, not driven negative.
+
+**Why:**
+- UAT (#132) surfaced an order for qty=4 against `qty_available = 0`. The customer form already greys sold-out rows and pins the stepper to 0 (DEC-031), so this was only reachable via the stale-tab race: page loaded with stock → inventory hit 0 (admin edit or another order) → customer submitted the stale cart. DEC-012's unconditional decrement then drove the product to −4 and flagged reconciliation — a "successful" oversell of something with nothing left.
+- DEC-031 says qty=0 is uneditable "period." Honoring that only in the client (load-time) but not the server (submit-time) left the race open. DEC-036 closes it server-side.
+
+**Implementation:**
+- The decrement becomes `UPDATE products SET qty_available = qty_available - n WHERE id = ? AND qty_available > 0` plus `IF NOT FOUND THEN RAISE … sold out` (migration `20260611213000_place_order_reject_soldout.sql`). The `qty_available > 0` guard is part of the write, so the check is race-free; a raise mid-loop rolls back the whole order (atomic — no partial order, no orphaned decrement).
+- `place-order.ts` maps the raise to a friendly "Some items sold out — reload" message; reloading re-fetches inventory and greys the rows.
+- Unchanged: `qty_available > 0` but insufficient still oversells into the negative and flags `needs_reconciliation` — the intended DEC-012 "last few" behavior.
+
+---
+
 ## Open / Pending Product Owner Discussion
 
 - **Minimum delivery amount (in dollars).** Threshold below which delivery is unavailable, or above which delivery is free. Phase 7+ candidate.

--- a/src/actions/place-order.ts
+++ b/src/actions/place-order.ts
@@ -67,7 +67,19 @@ export async function placeOrder(
     p_items: payload.items as unknown as Json,
   });
 
-  if (error) return { error: error.message };
+  if (error) {
+    // #132 / DEC-036: place_order rejects items whose product is sold out
+    // (qty_available = 0) at submit time — the stale-tab race. Surface a
+    // friendly, actionable message instead of the raw RPC text; reloading
+    // re-fetches inventory and greys the sold-out rows.
+    if (error.message.includes("is sold out")) {
+      return {
+        error:
+          "Some items sold out while you were ordering. Reload to see what's still available.",
+      };
+    }
+    return { error: error.message };
+  }
 
   // Best-effort admin alert (DEC-033). Failure is swallowed inside the
   // wrapper — order placement never blocks on a notification miss. We

--- a/supabase/migrations/20260611213000_place_order_reject_soldout.sql
+++ b/supabase/migrations/20260611213000_place_order_reject_soldout.sql
@@ -1,0 +1,153 @@
+-- #132 / DEC-036 — reject line items for products that are already sold out.
+--
+-- DEC-012 optimistic placement intentionally lets a customer oversell the
+-- "last few" of a product (qty_available > 0, ordered qty pushes it negative)
+-- and flags the order needs_reconciliation. DEC-031 says qty_available = 0 is
+-- *truly* unavailable — the customer form greys those rows and disables the
+-- stepper. But the place_order RPC applied the optimistic decrement
+-- unconditionally, so a stale tab (page loaded with stock → inventory hit 0 →
+-- customer submitted) could place an order against qty_available = 0, driving
+-- it negative. DEC-036: optimism does NOT extend to zero.
+--
+-- The fix is the WHERE guard + IF NOT FOUND on the decrement UPDATE below.
+-- Making it part of the UPDATE (rather than a separate SELECT … check) keeps
+-- it race-free: the row is only decremented when qty_available > 0 at the
+-- instant of the write, and FOUND tells us whether it applied. A raise inside
+-- the loop rolls back the whole order (single transaction) — atomic, no
+-- partial order, no orphaned decrement.
+--
+-- Everything else is byte-identical to 20260524141544_place_order_unit_aware.
+
+create or replace function public.place_order(
+  p_customer_id          uuid,
+  p_week_of              date,
+  p_fulfillment_type     text,
+  p_delivery_address     text,
+  p_delivery_preference  text,
+  p_pickup_note          text,
+  p_notes                text,
+  p_items                jsonb
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  v_order_id     uuid;
+  v_item         jsonb;
+  v_product_id   uuid;
+  v_unit_id      uuid;
+  v_qty          int;
+  v_unit_price   int;
+  v_conv         numeric(10,4);
+  v_negative     boolean;
+begin
+  if jsonb_typeof(p_items) is distinct from 'array' or jsonb_array_length(p_items) = 0 then
+    raise exception 'place_order: p_items must be a non-empty json array';
+  end if;
+
+  -- Atomic double-submit handling. See prior migration's comment block for
+  -- the TOCTOU rationale (20260514173354_place_order_function.sql).
+  insert into public.orders (
+    customer_id, week_of, fulfillment_type,
+    delivery_address, delivery_preference, pickup_note,
+    notes, status, needs_reconciliation
+  )
+  values (
+    p_customer_id, p_week_of, p_fulfillment_type,
+    p_delivery_address, p_delivery_preference, p_pickup_note,
+    p_notes, 'new', false
+  )
+  on conflict (customer_id, week_of) do nothing
+  returning id into v_order_id;
+
+  if v_order_id is null then
+    select id into v_order_id
+    from public.orders
+    where customer_id = p_customer_id and week_of = p_week_of;
+    return v_order_id;
+  end if;
+
+  for v_item in select * from jsonb_array_elements(p_items)
+  loop
+    v_product_id := (v_item->>'product_id')::uuid;
+    v_qty        := (v_item->>'qty')::int;
+    -- product_unit_id is optional in the payload. When absent, the
+    -- order_items_default_unit BEFORE-INSERT trigger (from 6.5a) fills
+    -- in the first active unit for this product. We resolve the unit
+    -- here too so the price snapshot + decrement math match what the
+    -- row will end up with.
+    v_unit_id := nullif(v_item->>'product_unit_id', '')::uuid;
+    if v_unit_id is null then
+      select id into v_unit_id
+        from public.product_units
+       where product_id = v_product_id and is_active = true
+       order by sort_order nulls last, created_at
+       limit 1;
+      -- Distinct error path from the cross-product-id case below so the
+      -- message points at the right remedy: re-activate (or seed) a unit
+      -- on this product, not "fix the unit_id in your payload."
+      if v_unit_id is null then
+        raise exception 'place_order: product % has no active units', v_product_id;
+      end if;
+    end if;
+
+    -- Snapshot from product_units, not from the client payload. If a unit
+    -- id was supplied but doesn't belong to this product (mismatched),
+    -- the lookup returns null and we raise — refusing to record a
+    -- cross-product unit reference rather than silently falling through.
+    select unit_price_cents, conversion_to_base
+      into v_unit_price, v_conv
+      from public.product_units
+     where id = v_unit_id and product_id = v_product_id;
+
+    if v_unit_price is null then
+      raise exception
+        'place_order: product_unit_id % does not belong to product %', v_unit_id, v_product_id;
+    end if;
+
+    insert into public.order_items (order_id, product_id, product_unit_id, qty, unit_price_cents)
+    values (v_order_id, v_product_id, v_unit_id, v_qty, v_unit_price);
+
+    -- DEC-036: optimistic oversell (DEC-012) applies only while there is
+    -- stock to draw down. The `qty_available > 0` guard makes this a no-op
+    -- on a sold-out product; FOUND is then false and we reject the whole
+    -- order. qty_available > 0 but insufficient still decrements into the
+    -- negative + flags reconciliation below — unchanged "last few" behavior.
+    update public.products
+       set qty_available = qty_available - (v_qty::numeric * v_conv),
+           updated_at = now()
+     where id = v_product_id and qty_available > 0;
+
+    if not found then
+      raise exception 'place_order: product % is sold out', v_product_id
+        using errcode = 'P0001';
+    end if;
+  end loop;
+
+  -- Flip needs_reconciliation if any product touched by this order is now
+  -- negative. Same one-shot check as the prior version.
+  select exists (
+    select 1
+    from public.products p
+    join public.order_items oi on oi.product_id = p.id
+    where oi.order_id = v_order_id
+      and p.qty_available < 0
+  ) into v_negative;
+
+  if v_negative then
+    update public.orders
+       set needs_reconciliation = true
+     where id = v_order_id;
+  end if;
+
+  return v_order_id;
+end;
+$$;
+
+-- Re-apply grants. CREATE OR REPLACE preserves the prior REVOKE/GRANT state
+-- when the signature is unchanged, but it's cheap to be explicit so a future
+-- hand-edit doesn't accidentally widen access.
+revoke all on function public.place_order(uuid, date, text, text, text, text, text, jsonb) from public;
+grant execute on function public.place_order(uuid, date, text, text, text, text, text, jsonb) to service_role;

--- a/supabase/tests/place_order_units.sql
+++ b/supabase/tests/place_order_units.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(16);
+select plan(19);
 
 -- ============================================================
 -- 6.5d — place_order RPC under multi-unit (DEC-032)
@@ -307,6 +307,47 @@ select is(
      and week_of = '2026-06-01'),
   0,
   'no order row created — the whole transaction rolled back'
+);
+
+-- ============================================================
+-- 10. Multi-item atomicity (DEC-036). An order containing an in-stock item
+--     AND a sold-out item is rejected as a whole: the in-stock item is
+--     listed FIRST so it gets inserted + decremented before the loop reaches
+--     the sold-out item and raises — proving the prior item's write rolls
+--     back too. No partial order.
+-- ============================================================
+insert into public.customers (id, name, token)
+values ('dddd0000-0000-0000-0000-000000000007'::uuid, 'Multi Item Customer', 'token-multi-036');
+
+insert into public.products (id, name, unit, price_cents, qty_available, sort_order, category)
+values ('dddd0000-0000-0000-0000-aaaa00000006'::uuid, 'In Stock Item', 'bunch', 400, 9.00, 6, 'Herbs');
+
+select throws_like(
+  $$ select public.place_order(
+       'dddd0000-0000-0000-0000-000000000007'::uuid,
+       '2026-06-01'::date,
+       'delivery', '333 Multi St', '', '', '',
+       jsonb_build_array(
+         jsonb_build_object('product_id', 'dddd0000-0000-0000-0000-aaaa00000006'::text, 'qty', 1, 'unit_price_cents', 400),
+         jsonb_build_object('product_id', 'dddd0000-0000-0000-0000-aaaa00000005'::text, 'qty', 1, 'unit_price_cents', 300)
+       )
+     ) $$,
+  '%is sold out%',
+  'multi-item order with one sold-out line is rejected as a whole'
+);
+
+select is(
+  (select qty_available from public.products
+   where id = 'dddd0000-0000-0000-0000-aaaa00000006'::uuid),
+  9.00::numeric(10,2),
+  'in-stock item in a rejected multi-item order is NOT decremented (its write rolled back)'
+);
+
+select is(
+  (select count(*)::int from public.orders
+   where customer_id = 'dddd0000-0000-0000-0000-000000000007'::uuid),
+  0,
+  'no order row from the rejected multi-item order'
 );
 
 select * from finish();

--- a/supabase/tests/place_order_units.sql
+++ b/supabase/tests/place_order_units.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(13);
+select plan(16);
 
 -- ============================================================
 -- 6.5d — place_order RPC under multi-unit (DEC-032)
@@ -262,6 +262,51 @@ select throws_like(
      ) $$,
   '%has no active units%',
   'product with zero active units raises a targeted error (not the unit-mismatch message)'
+);
+
+-- ============================================================
+-- 9. DEC-036 / #132 — a product already at qty_available = 0 rejects the
+--    order. Optimistic oversell (DEC-012) applies only while qty > 0; at
+--    zero the whole order rolls back: inventory stays 0, no order row.
+--    The product's trigger-spawned base unit means the RPC resolves a unit
+--    fine, so the rejection is purely the qty=0 guard — not "no units".
+-- ============================================================
+insert into public.customers (id, name, token)
+values ('dddd0000-0000-0000-0000-000000000006'::uuid, 'Sold Out Customer', 'token-soldout-036');
+
+insert into public.products (id, name, unit, price_cents, qty_available, sort_order, category)
+values ('dddd0000-0000-0000-0000-aaaa00000005'::uuid, 'Zero Stock', 'bunch', 300, 0.00, 5, 'Herbs');
+
+select throws_like(
+  $$ select public.place_order(
+       'dddd0000-0000-0000-0000-000000000006'::uuid,
+       '2026-06-01'::date,
+       'delivery', '222 Soldout St', '', '', '',
+       jsonb_build_array(
+         jsonb_build_object(
+           'product_id', 'dddd0000-0000-0000-0000-aaaa00000005'::text,
+           'qty',        1,
+           'unit_price_cents', 300
+         )
+       )
+     ) $$,
+  '%is sold out%',
+  'place_order against a qty=0 product raises sold-out (DEC-036)'
+);
+
+select is(
+  (select qty_available from public.products
+   where id = 'dddd0000-0000-0000-0000-aaaa00000005'::uuid),
+  0.00::numeric(10,2),
+  'sold-out product stays at 0 — not driven negative (rejection rolled back the decrement)'
+);
+
+select is(
+  (select count(*)::int from public.orders
+   where customer_id = 'dddd0000-0000-0000-0000-000000000006'::uuid
+     and week_of = '2026-06-01'),
+  0,
+  'no order row created — the whole transaction rolled back'
 );
 
 select * from finish();

--- a/tests/customer-closed-and-soldout.spec.ts
+++ b/tests/customer-closed-and-soldout.spec.ts
@@ -113,4 +113,23 @@ test.describe("/c/[token] state — closed + all sold out (DEC-031)", () => {
       page.getByRole("heading", { name: /Order received/i }),
     ).toBeVisible();
   });
+
+  // #132 / DEC-036 — the inverse of the closed-race above. DEC-012 optimism
+  // lets a customer oversell the "last few" (qty>0), but it does NOT extend to
+  // a product that is already at qty=0. A stale tab (loaded with stock →
+  // inventory hit 0 → submit) must be rejected, not driven negative.
+  test("sold-out mid-order race: product hits qty=0 after load, submit is rejected (DEC-036)", async ({ page }) => {
+    // Customer loads with stock and adds eggs.
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    const eggsRow = page.locator(".item-row", { hasText: TEST_PRODUCTS.eggs.name });
+    await eggsRow.getByRole("button", { name: "increase" }).click();
+
+    // Eggs sell out under them (admin edit or another customer's order).
+    await setProductQty(TEST_PRODUCTS.eggs.id, 0);
+
+    // Submit is rejected — no redirect, friendly error, order not created.
+    await page.locator(".submit-btn").click();
+    await expect(page.locator(".submit-error")).toContainText(/sold out/i);
+    await expect(page).toHaveURL(/\/c\/[^/]+$/);
+  });
 });


### PR DESCRIPTION
## Summary
Reject orders placed against sold-out (qty_available=0) products (#132, DEC-036). DEC-012's optimistic decrement applied even at qty=0, so a stale tab could oversell something with nothing left. Now `qty=0` is truly unavailable per DEC-031; `qty>0` last-few oversell is unchanged.

## Files changed
- `supabase/migrations/20260611213000_place_order_reject_soldout.sql` — replaces `place_order`: decrement becomes `UPDATE products SET qty_available = qty_available - n WHERE id = ? AND qty_available > 0` + `IF NOT FOUND THEN RAISE … sold out`. Atomic/race-free; a raise rolls back the whole order. Body otherwise byte-identical to the prior migration.
- `src/actions/place-order.ts` — maps the sold-out raise to a friendly "reload" message; other errors unchanged.
- `supabase/tests/place_order_units.sql` — sold-out rejection (stays at 0, no order row) + multi-item atomicity (in-stock line rolls back when a later line is sold out).
- `tests/customer-closed-and-soldout.spec.ts` — sold-out mid-order race (load with stock → product hits 0 → submit rejected, no redirect).
- `docs/DECISIONS.md` — DEC-036.

## Code review
Race-free guard, atomic rollback, no body drift, grants intact — confirmed. Flagged: the error-mapping matches on the RPC message substring (kept — it's more specific than the shared `P0001` SQLSTATE and is covered end-to-end by the Playwright assertion, which would fail on a reword). Added the multi-item rollback test the reviewer noted was missing. Known/intended per DEC-036: a `qty>0`-but-insufficient order (e.g. 2 in stock, conv-4 unit) still oversells + flags reconciliation — reject is only at exactly 0.

## Test plan
- **DB:** `supabase db push` applies the `place_order` replacement (function only; no data change). Push dev/preview → prod in timestamp order (this is the newest migration).
- **pgTAP:** `supabase test db` → `place_order_units.sql` covers: qty=0 → raises "sold out", product stays at 0, no order row; multi-item [in-stock, sold-out] → in-stock line not decremented, no order row; DEC-012 oversell at qty>0 still flips `needs_reconciliation` (existing cases).
- **Customer /c/[token]:** add an item with stock → drop that product to 0 (admin) → submit → friendly "Some items sold out — reload" error, stays on form, no order created. Normal order with stock still redirects to /confirmed.

closes #132