### PR TITLE
#149 persist cart draft to sessionStorage (survive reload / phone rotation)

### DIFF
--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -346,15 +346,27 @@ export function OrderForm({
     // canonical unit_price_cents + conversion_to_base from product_units
     // at RPC time (6.5d). unit_price_cents is sent for display continuity
     // but the RPC ignores it — strict "price at moment of order" semantics.
-    const payloadItems = itemsWithQty.map((p) => {
+    // #149 — a hydrated draft can carry qty for a product whose units were all
+    // deactivated since it was saved; unitFor then returns null. Drop those
+    // rather than dereference u!.id (a crash persistence newly made reachable).
+    // The row still renders as sold-out; it just isn't submittable.
+    const payloadItems = itemsWithQty.flatMap((p) => {
       const u = unitFor(p);
-      return {
-        product_id: p.id,
-        product_unit_id: u!.id,
-        qty: qty[p.id] ?? 0,
-        unit_price_cents: u?.unit_price_cents ?? p.price_cents,
-      };
+      if (!u) return [];
+      return [
+        {
+          product_id: p.id,
+          product_unit_id: u.id,
+          qty: qty[p.id] ?? 0,
+          unit_price_cents: u.unit_price_cents,
+        },
+      ];
     });
+    if (payloadItems.length === 0) {
+      setSubmitError("Those items are no longer available. Reload to see what's in stock.");
+      submittingRef.current = false;
+      return;
+    }
     // #149 — latch off persistence and clear the draft up front. On success the
     // action redirects and unmounts before any post-await code reliably runs,
     // so we can't clear there; on failure the error branches below unlatch and

--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -23,6 +23,20 @@ function formatPrice(cents: number): string {
   return (cents / 100).toFixed(2);
 }
 
+// A server action's redirect() throws NEXT_REDIRECT on the client, which lands
+// in our submit catch. It carries a `digest` string like "NEXT_REDIRECT;…".
+// Distinguish it from a real failure so the success path doesn't get treated
+// as an error (and doesn't restore the cart draft we just cleared).
+function isRedirectError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "digest" in err &&
+    typeof (err as { digest?: unknown }).digest === "string" &&
+    (err as { digest: string }).digest.startsWith("NEXT_REDIRECT")
+  );
+}
+
 // Press-and-hold tuning: pause before repeating, then a steady cadence that
 // accelerates after a few ticks so wholesale qty (24, 50…) is reachable
 // without 50 taps. Manual feel — not exercised by tests.
@@ -218,7 +232,73 @@ export function OrderForm({
   // latch; the server action is idempotent on the second call but the second
   // request still hits the network unnecessarily.
   const submittingRef = useRef(false);
+  // #149 — once a submit is in flight we stop persisting: the redirect on
+  // success unmounts before any post-await code runs, and a re-render during
+  // the submit transition would otherwise re-fire the persist effect and
+  // resurrect the draft we just cleared. Reset on a failed submit.
+  const submittedRef = useRef(false);
   const fulfillRef = useRef<HTMLElement>(null);
+
+  // #149 — persist the in-progress cart to sessionStorage so a reload or an
+  // Android orientation change (which can evict the bfcache and remount this
+  // component) doesn't wipe it. Keyed by customer so drafts can't bleed across
+  // tokens in one tab. sessionStorage, not localStorage: it survives a same-tab
+  // reload but not a tab close — a tokened weekly order shouldn't resurrect days
+  // later (matches the AC: reopen via SMS link = fresh order).
+  const draftKey = `bushel:cart:${customer.id}`;
+  const [hydrated, setHydrated] = useState(false);
+
+  const writeDraft = () => {
+    try {
+      sessionStorage.setItem(
+        draftKey,
+        JSON.stringify({ qty, selectedUnit, mode, pickupNote, deliveryPreference, notes }),
+      );
+    } catch {
+      // Private-mode / quota / storage disabled — persistence is best-effort.
+    }
+  };
+  const clearDraft = () => {
+    try {
+      sessionStorage.removeItem(draftKey);
+    } catch {
+      // ignore — see writeDraft
+    }
+  };
+
+  // Hydrate once on mount (client-only — sessionStorage is undefined during
+  // SSR). A stored qty/unit for a product that's since gone sold-out or hidden
+  // is harmless: itemsWithQty filters against the live product list and unitFor
+  // falls back to the first active unit.
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem(draftKey);
+      if (raw) {
+        const d = JSON.parse(raw);
+        if (d.qty && typeof d.qty === "object") setQty(d.qty);
+        if (d.selectedUnit && typeof d.selectedUnit === "object") setSelectedUnit(d.selectedUnit);
+        if (d.mode === "delivery" || d.mode === "pickup") setMode(d.mode);
+        if (typeof d.pickupNote === "string") setPickupNote(d.pickupNote);
+        if (typeof d.deliveryPreference === "string") setDeliveryPreference(d.deliveryPreference);
+        if (typeof d.notes === "string") setNotes(d.notes);
+      }
+    } catch {
+      // Corrupt/unreadable draft — start fresh.
+    }
+    setHydrated(true);
+    // Mount-only; draftKey is stable for the component's life (customer.id).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Persist on every cart-state change — but only after hydration, so the
+  // initial empty state on first render can't clobber a stored draft before
+  // the mount effect loads it.
+  useEffect(() => {
+    if (!hydrated || submittedRef.current) return;
+    writeDraft();
+    // writeDraft closes over the current state; deps list the persisted fields.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hydrated, qty, selectedUnit, mode, pickupNote, deliveryPreference, notes]);
 
   const scrollToFulfill = () => {
     fulfillRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
@@ -275,6 +355,12 @@ export function OrderForm({
         unit_price_cents: u?.unit_price_cents ?? p.price_cents,
       };
     });
+    // #149 — latch off persistence and clear the draft up front. On success the
+    // action redirects and unmounts before any post-await code reliably runs,
+    // so we can't clear there; on failure the error branches below unlatch and
+    // re-persist so a rotation after a failed submit still keeps the cart.
+    submittedRef.current = true;
+    clearDraft();
     startTransition(async () => {
       try {
         const result = await placeOrder({
@@ -287,13 +373,22 @@ export function OrderForm({
         if (result?.error) {
           setSubmitError(result.error);
           submittingRef.current = false; // allow retry after a failed submit
+          submittedRef.current = false; // re-enable persistence
+          writeDraft(); // restore the draft we optimistically cleared
         }
         // On success the action redirects; page unmounts, latch stays true.
       } catch (err) {
+        // A server-action redirect() surfaces here as a thrown NEXT_REDIRECT —
+        // that's the SUCCESS path (order placed, Next is navigating to
+        // /confirmed). Leave the draft cleared and the latch set; the page is
+        // unmounting. Only a genuine failure restores the draft + unlatches.
+        if (isRedirectError(err)) return;
         // Thrown errors (network failure, action exception) used to leave the
         // ref stuck true and silently swallow every subsequent click. Reset.
         setSubmitError(err instanceof Error ? err.message : "Submit failed.");
         submittingRef.current = false;
+        submittedRef.current = false; // re-enable persistence
+        writeDraft(); // restore the draft we optimistically cleared
       }
     });
   };

--- a/tests/customer-order-form.spec.ts
+++ b/tests/customer-order-form.spec.ts
@@ -130,4 +130,45 @@ test.describe("/c/[token] order form", () => {
     expect(afterY).toBeGreaterThan(beforeY);
     expect(page.url()).not.toContain("/confirmed");
   });
+
+  // #149 — cart draft persists to sessionStorage so a same-tab reload (the
+  // Android-rotation bfcache-evict remount) doesn't wipe it.
+  test("cart draft survives a same-tab reload (sessionStorage persistence)", async ({ page }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+
+    const kaleRow = page.locator(".item-row", { hasText: TEST_PRODUCTS.kale.name });
+    await kaleRow.getByRole("button", { name: "increase" }).click();
+    await kaleRow.getByRole("button", { name: "increase" }).click();
+    await expect(kaleRow.locator(".stepper-val")).toHaveValue("2");
+
+    // Also flip mode + add a note so we cover the non-qty fields too.
+    await page.getByRole("tab", { name: /pickup/i }).click();
+    await page.locator("section.notes textarea").fill("leave at side door");
+
+    await page.reload();
+
+    // Cart + mode + note all restored from the draft.
+    await expect(
+      page.locator(".item-row", { hasText: TEST_PRODUCTS.kale.name }).locator(".stepper-val"),
+    ).toHaveValue("2");
+    await expect(page.getByRole("tab", { name: /pickup/i })).toHaveAttribute("aria-selected", "true");
+    await expect(page.locator("section.notes textarea")).toHaveValue("leave at side door");
+  });
+
+  // #149 — sessionStorage is per-tab: a fresh context (reopening the SMS link
+  // in a new tab/session) starts empty, not resurrected from an old draft.
+  test("cart draft does NOT cross into a fresh browser context", async ({ page, browser }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    const kaleRow = page.locator(".item-row", { hasText: TEST_PRODUCTS.kale.name });
+    await kaleRow.getByRole("button", { name: "increase" }).click();
+    await expect(kaleRow.locator(".stepper-val")).toHaveValue("1");
+
+    const fresh = await browser.newContext();
+    const freshPage = await fresh.newPage();
+    await freshPage.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    await expect(
+      freshPage.locator(".item-row", { hasText: TEST_PRODUCTS.kale.name }).locator(".stepper-val"),
+    ).toHaveValue("0");
+    await fresh.close();
+  });
 });

--- a/tests/customer-order-form.spec.ts
+++ b/tests/customer-order-form.spec.ts
@@ -171,4 +171,22 @@ test.describe("/c/[token] order form", () => {
     ).toHaveValue("0");
     await fresh.close();
   });
+
+  // #149 — a corrupt/unparseable draft must be ignored, not crash the form.
+  test("corrupt sessionStorage draft is ignored; form renders empty", async ({ page }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    // The form writes an (empty) draft on mount; clobber it with junk, reload.
+    await page.evaluate(() => {
+      const key =
+        Object.keys(sessionStorage).find((k) => k.startsWith("bushel:cart:")) ?? "bushel:cart:x";
+      sessionStorage.setItem(key, "{ not valid json");
+    });
+    await page.reload();
+
+    // Form renders (no crash), products visible, cart empty.
+    await expect(page.getByText(TEST_PRODUCTS.kale.name, { exact: true }).first()).toBeVisible();
+    await expect(
+      page.locator(".item-row", { hasText: TEST_PRODUCTS.kale.name }).locator(".stepper-val"),
+    ).toHaveValue("0");
+  });
 });

--- a/tests/customer-place-order.spec.ts
+++ b/tests/customer-place-order.spec.ts
@@ -79,6 +79,29 @@ test.describe("/c/[token] place order", () => {
     expect(kale?.qty_available).toBe(TEST_PRODUCTS.kale.qty_available - 2);
   });
 
+  // #149 — a successful submit clears the persisted cart draft, so a back-nav
+  // to /c/[token] (or any later visit in the same tab) doesn't resurrect a
+  // stale cart on top of the now-placed order.
+  test("submit clears the persisted cart draft", async ({ page }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    await stepUp(page, TEST_PRODUCTS.kale.name, 1);
+
+    // Draft exists while ordering.
+    const draftBefore = await page.evaluate(() =>
+      Object.keys(sessionStorage).filter((k) => k.startsWith("bushel:cart:")),
+    );
+    expect(draftBefore.length).toBe(1);
+
+    await page.locator(".submit-btn").click();
+    await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
+
+    // sessionStorage survives the same-tab nav to /confirmed; the key is gone.
+    const draftAfter = await page.evaluate(() =>
+      Object.keys(sessionStorage).filter((k) => k.startsWith("bushel:cart:")),
+    );
+    expect(draftAfter.length).toBe(0);
+  });
+
   test("oversold qty sets needs_reconciliation = true (DEC-012)", async ({
     page,
   }) => {

--- a/tests/customer-place-order.spec.ts
+++ b/tests/customer-place-order.spec.ts
@@ -6,6 +6,7 @@ import {
   admin,
   customerOrderUrl,
   resetCustomerOrderState,
+  setProductQty,
 } from "./helpers";
 
 async function getCustomerId(token: string): Promise<string> {
@@ -100,6 +101,34 @@ test.describe("/c/[token] place order", () => {
       Object.keys(sessionStorage).filter((k) => k.startsWith("bushel:cart:")),
     );
     expect(draftAfter.length).toBe(0);
+  });
+
+  // #149 — a FAILED submit must restore the optimistically-cleared draft and
+  // re-enable persistence, so a rotation after a failed submit still keeps the
+  // cart and later edits keep persisting. Uses the DEC-036 sold-out rejection
+  // as the failure trigger.
+  test("failed submit restores the draft and re-enables persistence", async ({ page }) => {
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    await stepUp(page, TEST_PRODUCTS.eggs.name, 1);
+
+    // Eggs sell out under them → submit is rejected (DEC-036), no redirect.
+    await setProductQty(TEST_PRODUCTS.eggs.id, 0);
+    await page.locator(".submit-btn").click();
+    await expect(page.locator(".submit-error")).toContainText(/sold out/i);
+
+    // Draft restored after the failed submit (not left cleared).
+    const restored = await page.evaluate(() =>
+      Object.keys(sessionStorage).filter((k) => k.startsWith("bushel:cart:")),
+    );
+    expect(restored.length).toBe(1);
+
+    // Persistence re-enabled: a subsequent edit re-writes the draft.
+    await stepUp(page, TEST_PRODUCTS.kale.name, 1);
+    const draft = await page.evaluate(() => {
+      const key = Object.keys(sessionStorage).find((k) => k.startsWith("bushel:cart:"));
+      return key ? sessionStorage.getItem(key) : null;
+    });
+    expect(draft).toContain(TEST_PRODUCTS.kale.id);
   });
 
   test("oversold qty sets needs_reconciliation = true (DEC-012)", async ({


### PR DESCRIPTION
## Summary
Persist the customer cart draft to sessionStorage so a reload or an Android phone-rotation remount (bfcache eviction) doesn't wipe it (#149). Cart state previously lived only in `OrderForm` `useState`.

## Files changed
- `src/components/customer/OrderForm.tsx` — hydrate `{qty, selectedUnit, mode, pickupNote, deliveryPreference, notes}` from `sessionStorage` (keyed `bushel:cart:<customer.id>`) on mount; persist on change, gated by a `hydrated` flag so the empty initial render can't clobber a stored draft. Clear on submit + restore on genuine failure (latch + `isRedirectError` so the success NEXT_REDIRECT isn't treated as a failure). Submit payload now drops products whose units were all deactivated since the draft was saved (avoids a `u!.id` crash a stale draft newly makes reachable).
- `tests/customer-order-form.spec.ts` — reload preserves cart/mode/note; fresh context starts empty; corrupt draft is ignored.
- `tests/customer-place-order.spec.ts` — submit clears the draft; failed submit restores it + re-enables persistence.

## Code review
Hydration race + SSR correctly handled (sessionStorage only in effects/handlers; `hydrated` gate). Acted on two findings: the `u!.id` crash on a unit-less hydrated draft (now filtered), and the two untested subtle paths (failed-submit-restore, corrupt-draft) now covered. Left as-is (advisory): hand-rolled `isRedirectError` vs `unstable_rethrow` (explicit + tested; this action only redirect()s or returns {error}); per-customer (not per-week) key — a week-spanning tab could show stale qtys but won't crash (filtered).

## Test plan
- **Customer /c/[token] (esp. mobile 375px):** add items, switch mode, add a note → reload → cart/mode/note restored. Close tab, reopen SMS link → empty (sessionStorage scope). Submit a valid order → /confirmed, draft cleared (no stale cart on back-nav). Force a failure (a product sells out mid-order, DEC-036) → "sold out" error, draft preserved, a further edit re-persists. Seed a corrupt draft → form renders empty, no crash.
- No DB/migration. Desktop 16/16; mobile 16/16 (lone mobile failure is the pre-existing `.fill()` WebKit flake on "notes textarea accepts input", CI-green via retries — not in this diff).

closes #149