### PR TITLE
#208 changeable base unit — atomic invariant-preserving rebase (DEC-038)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -453,6 +453,19 @@ PWA push notification remains the stretch upgrade per DEC-027's framing.
 
 ---
 
+## DEC-038 — Base-unit change is an atomic, invariant-preserving rebase (#208)
+
+**Decision:** changing which `product_units` row is a product's base unit is a single server-side operation (`set_base_unit` RPC, migration `20260612153000`) that divides EVERY unit's `conversion_to_base` AND `products.qty_available` by the new base's old conversion, then renumbers `sort_order` so the new base sorts first. Making a unit the base also makes it the customer's default-selected unit — one deliberate action, both effects. Unit prices are untouched.
+
+**Why:**
+- `qty_available` is stored in base units and `order_items` read conversion live from `product_units` (no per-line conversion snapshot), so a line's footprint is `qty * live_conv`. Rescaling all conversions and the stock figure by the same factor leaves every historical comparison physically unchanged — oversold state and `needs_reconciliation` can't flip. Doing it as anything other than one transaction (e.g. folding it into the drawer's staged Save) would open a window where conversions and stock disagree.
+- Prices are per-unit truths ("$6 per lb" holds regardless of what stock is counted in), so they don't participate in the rescale.
+- The customer form defaults to `units[0]` (sorted by `sort_order nulls last, created_at`); renumbering with the new base at 0 is how "make base" doubles as "make default" without a new column.
+
+**Guard rails:** the drawer's "Make base" affordance only appears on saved, active, non-base rows; it's disabled while the drawer has unsaved edits (the post-rebase reload would clobber them); and it confirms via modal before calling the RPC. The RPC raises on cross-product, missing, or inactive units and no-ops when the unit is already base.
+
+---
+
 ## Open / Pending Product Owner Discussion
 
 - **Minimum delivery amount (in dollars).** Threshold below which delivery is unavailable, or above which delivery is free. Phase 7+ candidate.

--- a/src/actions/set-base-unit.ts
+++ b/src/actions/set-base-unit.ts
@@ -38,6 +38,12 @@ export async function setBaseUnit(
         error: "That unit doesn't belong to this product. Reload and try again.",
       };
     }
+    if (error.message.includes("too far apart in scale")) {
+      return {
+        error:
+          "These units are too far apart in size to switch the base unit. Adjust the conversions closer first.",
+      };
+    }
     return { error: error.message };
   }
 

--- a/src/actions/set-base-unit.ts
+++ b/src/actions/set-base-unit.ts
@@ -1,0 +1,46 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+
+export type SetBaseUnitResult = {
+  error: string | null;
+};
+
+// #208 (DEC-038) — promote a product_units row to base. Thin wrapper over the
+// set_base_unit RPC, which atomically rescales every unit's conversion + the
+// product's qty_available and renumbers sort_order so the new base sorts
+// first (becoming the customer default). Deliberately NOT folded into
+// saveProductUnits' staged save — re-basing touches live stock and must run
+// as one server-side transaction, not as a diff of row updates.
+export async function setBaseUnit(
+  productId: string,
+  unitId: string,
+): Promise<SetBaseUnitResult> {
+  const supabase = await createClient();
+
+  const { error } = await supabase.rpc("set_base_unit", {
+    p_product_id: productId,
+    p_new_base_unit_id: unitId,
+  });
+
+  if (error) {
+    // Map the RPC's raise texts to remedies Annabel can act on; anything
+    // else surfaces raw (same contract as saveProductUnits).
+    if (error.message.includes("is inactive")) {
+      return {
+        error:
+          "An inactive unit can't be the base. Turn its Active switch on and save first.",
+      };
+    }
+    if (error.message.includes("does not belong")) {
+      return {
+        error: "That unit doesn't belong to this product. Reload and try again.",
+      };
+    }
+    return { error: error.message };
+  }
+
+  revalidatePath("/admin/inventory");
+  return { error: null };
+}

--- a/src/components/admin/units-drawer.tsx
+++ b/src/components/admin/units-drawer.tsx
@@ -2,8 +2,10 @@
 
 import { useEffect, useMemo, useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { Switch } from "@/components/ui/switch";
 import { saveProductUnits, type UnitInput } from "@/actions/save-product-units";
+import { setBaseUnit } from "@/actions/set-base-unit";
 import { useUnsavedChangesGuard } from "@/lib/hooks/use-unsaved-changes-guard";
 
 export type ProductUnitState = {
@@ -65,6 +67,10 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
   const [deletedIds, setDeletedIds] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [saving, startSaving] = useTransition();
+  // #208 — "Make base" promotion. Target unit pending confirmation, plus its
+  // own transition so the Save button's label/disabled logic stays untouched.
+  const [makeBaseTarget, setMakeBaseTarget] = useState<ProductUnitState | null>(null);
+  const [rebasing, startRebasing] = useTransition();
 
   const baseId = useMemo(() => pickBaseId(initialUnits), [initialUnits]);
 
@@ -95,6 +101,8 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
   const guardActive = dirty && !saving;
   useUnsavedChangesGuard(guardActive);
 
+  const busy = saving || rebasing;
+
   function tryClose() {
     if (guardActive && !window.confirm("You have unsaved changes — leave anyway?")) {
       return;
@@ -104,13 +112,15 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape" && !saving) tryClose();
+      // While the Make-base confirm is up, Escape belongs to the modal
+      // (ConfirmModal handles its own keydown) — don't also close the drawer.
+      if (e.key === "Escape" && !busy && !makeBaseTarget) tryClose();
     }
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-    // tryClose closes over guardActive/onClose; saving is also a dep.
+    // tryClose closes over guardActive/onClose; busy + the modal flag are deps too.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onClose, saving, guardActive]);
+  }, [onClose, busy, guardActive, makeBaseTarget]);
 
   function update(id: string, patch: Partial<ProductUnitState>) {
     setUnits((us) => us.map((u) => (u.id === id ? { ...u, ...patch } : u)));
@@ -203,9 +213,34 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
     });
   }
 
+  // #208 — promote the confirmed unit to base. Calls the atomic set_base_unit
+  // RPC immediately (NOT staged into the drawer's Save — it rescales live
+  // stock server-side). Only reachable from a clean drawer, so closing via
+  // onSaved() can't clobber staged edits; reopening shows the rebased units.
+  function handleMakeBase() {
+    if (!makeBaseTarget) return;
+    const target = makeBaseTarget;
+    startRebasing(async () => {
+      let result;
+      try {
+        result = await setBaseUnit(productId, target.id);
+      } catch (e) {
+        setMakeBaseTarget(null);
+        setError(e instanceof Error ? e.message : "Couldn't change the base unit. Try again.");
+        return;
+      }
+      if (result.error) {
+        setMakeBaseTarget(null);
+        setError(result.error);
+        return;
+      }
+      onSaved();
+    });
+  }
+
   return (
     <>
-      <div className="drawer-scrim" onClick={() => !saving && tryClose()} aria-hidden="true" />
+      <div className="drawer-scrim" onClick={() => !busy && tryClose()} aria-hidden="true" />
       <aside
         className="drawer units-drawer"
         role="dialog"
@@ -225,7 +260,7 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
             className="drawer-close"
             onClick={tryClose}
             aria-label="Close drawer"
-            disabled={saving}
+            disabled={busy}
           >
             <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
               <path d="M6 6l12 12 M18 6 6 18" />
@@ -249,6 +284,9 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
 
             {units.map((u) => {
               const isBase = u.id === baseId;
+              // "Make base" only on saved, active, non-base rows — a new row
+              // has no DB id to promote, and an inactive unit can't be base.
+              const canMakeBase = !isBase && !u.isNew && u.is_active;
               return (
                 <UnitRow
                   key={u.id}
@@ -256,6 +294,13 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
                   isBase={isBase}
                   onUpdate={(patch) => update(u.id, patch)}
                   onRemove={() => remove(u.id)}
+                  onMakeBase={canMakeBase ? () => setMakeBaseTarget(u) : null}
+                  // Re-basing closes + reloads the drawer, which would clobber
+                  // staged edits — require a clean drawer first.
+                  makeBaseDisabled={dirty || busy}
+                  makeBaseTitle={
+                    dirty ? "Save your unit changes first" : `Make ${u.label || "this unit"} the base unit`
+                  }
                 />
               );
             })}
@@ -278,12 +323,30 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
           <div style={{ flex: 1 }} />
           {/* Cancel is the explicit "discard" button — skips the guard
               intentionally. Scrim/X/Escape still prompt. */}
-          <Button variant="ghost" onClick={onClose} disabled={saving}>Cancel</Button>
-          <Button variant="primary" onClick={handleSave} disabled={!dirty || saving} dirty={dirty}>
+          <Button variant="ghost" onClick={onClose} disabled={busy}>Cancel</Button>
+          <Button variant="primary" onClick={handleSave} disabled={!dirty || busy} dirty={dirty}>
             {saving ? "Saving…" : dirty ? "Save units" : "Saved"}
           </Button>
         </footer>
       </aside>
+
+      {makeBaseTarget && (
+        <ConfirmModal
+          title={`Make "${makeBaseTarget.label}" the base unit?`}
+          body={
+            <>
+              <strong>{productName || "This product"}</strong> will be counted and sold in{" "}
+              <strong>{makeBaseTarget.label}</strong> — conversions and stock are recalculated
+              to match, and customers will see {makeBaseTarget.label} by default. Prices
+              don&apos;t change.
+            </>
+          }
+          confirmLabel="Make base"
+          busy={rebasing}
+          onConfirm={handleMakeBase}
+          onCancel={() => !rebasing && setMakeBaseTarget(null)}
+        />
+      )}
     </>
   );
 }
@@ -293,11 +356,18 @@ function UnitRow({
   isBase,
   onUpdate,
   onRemove,
+  onMakeBase,
+  makeBaseDisabled,
+  makeBaseTitle,
 }: {
   unit: ProductUnitState;
   isBase: boolean;
   onUpdate: (patch: Partial<ProductUnitState>) => void;
   onRemove: () => void;
+  // null hides the affordance (base row, new row, inactive unit)
+  onMakeBase: (() => void) | null;
+  makeBaseDisabled: boolean;
+  makeBaseTitle: string;
 }) {
   // Decimal-bug: type="number" + a re-formatted controlled value fights
   // mid-typing ("1.5" reformats to "1.50" before the 5 lands, cursor
@@ -324,6 +394,18 @@ function UnitRow({
           aria-label={isBase ? "Base unit label" : "Unit label"}
         />
         {isBase && <span className="units-base-badge">BASE</span>}
+        {onMakeBase && (
+          <button
+            type="button"
+            className="units-make-base"
+            onClick={onMakeBase}
+            disabled={makeBaseDisabled}
+            title={makeBaseTitle}
+            aria-label={`Make ${unit.label || "unit"} the base unit`}
+          >
+            Make base
+          </button>
+        )}
       </div>
       <div className="units-col-conv">
         <input

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -432,6 +432,10 @@ export type Database = {
           product_id: string
         }[]
       }
+      set_base_unit: {
+        Args: { p_new_base_unit_id: string; p_product_id: string }
+        Returns: undefined
+      }
     }
     Enums: {
       [_ in never]: never

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -664,6 +664,35 @@
   flex-shrink: 0;
 }
 
+/* #208 — promote-to-base affordance on non-base rows. Echoes the BASE badge
+   (same size/radius) but as an outlined button: deliberate, not decorative. */
+.units-make-base {
+  flex-shrink: 0;
+  font-family: var(--sans);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 2px 5px;
+  background: transparent;
+  border: 1px solid var(--ink-300);
+  border-radius: 3px;
+  color: var(--ink-500);
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+.units-make-base:hover:not(:disabled) {
+  background: var(--leaf-50);
+  border-color: var(--leaf-600);
+  color: var(--leaf-700);
+}
+.units-make-base:disabled { opacity: 0.45; cursor: not-allowed; }
+/* At phone widths the label track is narrow — let the badge/button wrap
+   under the input instead of crushing it. */
+@media (max-width: 480px) {
+  .units-col-label { flex-wrap: wrap; }
+}
+
 .units-col-conv .field-input:disabled,
 .units-col-conv .field-input[disabled] {
   background: var(--ink-100);

--- a/supabase/migrations/20260612153000_set_base_unit.sql
+++ b/supabase/migrations/20260612153000_set_base_unit.sql
@@ -1,0 +1,95 @@
+-- #208 (DEC-038) — change which product_units row is a product's base unit.
+--
+-- The base unit is the row with conversion_to_base = 1.0 (DEC-037). Re-basing
+-- is an invariant-preserving rescale: divide EVERY unit's conversion_to_base
+-- AND products.qty_available (stored in base units) by the new base's current
+-- conversion, atomically. The new base lands at exactly 1.0; every other unit
+-- rescales by the same factor.
+--
+-- Why this preserves order math: order_items store qty in the ordered unit and
+-- read conversion live from product_units, so a line's base-unit footprint is
+-- qty * conversion_to_base. Dividing all conversions and qty_available by the
+-- same factor rescales both sides of every comparison identically — physical
+-- stock, oversold state, and reconciliation flags are all unchanged.
+--
+-- Unit PRICES are per-unit ("$6 per lb" is true regardless of what we count
+-- stock in) and are intentionally untouched.
+--
+-- The function also renumbers sort_order so the new base sorts first — the
+-- customer order form defaults to units[0] (sorted by sort_order nulls last,
+-- created_at), so "make base" doubles as "make this the customer default."
+
+create function public.set_base_unit(
+  p_product_id        uuid,
+  p_new_base_unit_id  uuid
+)
+returns void
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  v_old_conv   numeric(10,4);
+  v_is_active  boolean;
+begin
+  select conversion_to_base, is_active
+    into v_old_conv, v_is_active
+    from public.product_units
+   where id = p_new_base_unit_id
+     and product_id = p_product_id;
+
+  if v_old_conv is null then
+    raise exception 'set_base_unit: unit % does not belong to product %',
+      p_new_base_unit_id, p_product_id;
+  end if;
+
+  if not v_is_active then
+    raise exception 'set_base_unit: unit % is inactive — it cannot be the base unit',
+      p_new_base_unit_id;
+  end if;
+
+  -- Already the base — nothing to rescale, nothing to reorder.
+  if v_old_conv = 1.0 then
+    return;
+  end if;
+
+  -- Rescale every unit's conversion by the same factor. The new base becomes
+  -- round(v_old_conv / v_old_conv, 4) = exactly 1.0000.
+  update public.product_units
+     set conversion_to_base = round(conversion_to_base / v_old_conv, 4),
+         updated_at = now()
+   where product_id = p_product_id;
+
+  -- qty_available is stored in base units, so it rescales by the same factor.
+  update public.products
+     set qty_available = round(qty_available / v_old_conv, 2),
+         updated_at = now()
+   where id = p_product_id;
+
+  -- Renumber sort_order deterministically: new base first (0), then the rest
+  -- in their current display order (sort_order nulls last, created_at) — the
+  -- same order the customer form and admin drawer sort by.
+  with ordered as (
+    select id,
+           row_number() over (
+             order by (id = p_new_base_unit_id) desc,
+                      sort_order nulls last,
+                      created_at
+           ) - 1 as new_order
+      from public.product_units
+     where product_id = p_product_id
+  )
+  update public.product_units pu
+     set sort_order = o.new_order
+    from ordered o
+   where pu.id = o.id;
+end;
+$$;
+
+-- security invoker: callers go through product_units/products RLS (admin "all"
+-- policies for authenticated). Same grant pattern as the other admin-facing
+-- function (prepopulate_inventory_from_last_week), plus service_role for
+-- test/ops tooling — revoking from public drops its default execute too.
+revoke all on function public.set_base_unit(uuid, uuid) from public;
+grant execute on function public.set_base_unit(uuid, uuid) to authenticated;
+grant execute on function public.set_base_unit(uuid, uuid) to service_role;

--- a/supabase/migrations/20260612153000_set_base_unit.sql
+++ b/supabase/migrations/20260612153000_set_base_unit.sql
@@ -53,6 +53,20 @@ begin
     return;
   end if;
 
+  -- Guard the conversion_to_base > 0 CHECK: a large rescale factor (a tiny
+  -- unit promoted onto a much bigger base) can round a small conversion down
+  -- to 0.0000 and abort the whole rebase with a raw constraint error. Catch
+  -- it up front with a remedy-shaped message instead.
+  if exists (
+    select 1 from public.product_units
+     where product_id = p_product_id
+       and round(conversion_to_base / v_old_conv, 4) <= 0
+  ) then
+    raise exception
+      'set_base_unit: units on product % are too far apart in scale to switch the base unit (a conversion would round to zero)',
+      p_product_id;
+  end if;
+
   -- Rescale every unit's conversion by the same factor. The new base becomes
   -- round(v_old_conv / v_old_conv, 4) = exactly 1.0000.
   update public.product_units

--- a/supabase/tests/set_base_unit.sql
+++ b/supabase/tests/set_base_unit.sql
@@ -1,0 +1,210 @@
+begin;
+select plan(16);
+
+-- ============================================================
+-- #208 (DEC-038) — set_base_unit RPC
+--
+-- Re-basing divides every unit's conversion_to_base AND the product's
+-- qty_available (stored in base units) by the new base's old conversion,
+-- atomically, then renumbers sort_order so the new base sorts first.
+-- Verifies:
+--   - the rescale lands the new base at exactly 1.0 and rescales the rest
+--     (including inactive units) by the same factor
+--   - qty_available rescales identically → historical order math
+--     (qty * live conversion vs qty_available) is physically unchanged
+--   - prices are untouched (per-unit truths don't depend on the base)
+--   - the new base gets the smallest sort_order (customer default = units[0])
+--   - raises on cross-product / inactive / missing units; no-op on the
+--     current base
+-- ============================================================
+
+-- Fixture: Basil with base "bunch" (conv 1.0) + "lb" (conv 0.5 — one lb is
+-- half a bunch's worth) + an INACTIVE "case" (conv 4). 10 bunches in stock.
+-- DEC-037: unit rows are inserted explicitly (nothing spawns them).
+insert into public.products (id, name, qty_available, sort_order, category)
+values ('ee080000-0000-0000-0000-aaaa00000001'::uuid, 'Basil', 10.00, 1, 'Herbs');
+
+insert into public.product_units (id, product_id, label, conversion_to_base, unit_price_cents, is_active, slug, sort_order)
+values
+  ('ee080000-0000-0000-0000-bbbb00000001'::uuid,
+   'ee080000-0000-0000-0000-aaaa00000001'::uuid,
+   'bunch', 1, 350, true, 'basil-bunch-ee080000', 0),
+  ('ee080000-0000-0000-0000-bbbb00000002'::uuid,
+   'ee080000-0000-0000-0000-aaaa00000001'::uuid,
+   'lb', 0.5, 600, true, 'basil-lb-ee080000', 1),
+  ('ee080000-0000-0000-0000-bbbb00000003'::uuid,
+   'ee080000-0000-0000-0000-aaaa00000001'::uuid,
+   'case', 4, 2000, false, 'basil-case-ee080000', 2);
+
+-- Second product whose unit must not be promotable onto Basil.
+insert into public.products (id, name, qty_available, sort_order, category)
+values ('ee080000-0000-0000-0000-aaaa00000002'::uuid, 'Mint', 5.00, 2, 'Herbs');
+
+insert into public.product_units (id, product_id, label, conversion_to_base, unit_price_cents, is_active, slug, sort_order)
+values ('ee080000-0000-0000-0000-cccc00000001'::uuid,
+        'ee080000-0000-0000-0000-aaaa00000002'::uuid,
+        'bunch', 1, 250, true, 'mint-bunch-ee080000', 0);
+
+-- Existing order line on the lb unit: 3 lb = 1.5 base (bunch) against stock
+-- of 10. The physical footprint ratio (qty * conv) / qty_available = 0.15
+-- must survive the rebase.
+insert into public.customers (id, name, token)
+values ('ee080000-0000-0000-0000-000000000001'::uuid, 'Rebase Customer', 'token-rebase-208');
+
+insert into public.orders (id, customer_id, week_of, fulfillment_type, status)
+values ('ee080000-0000-0000-0000-dddd00000001'::uuid,
+        'ee080000-0000-0000-0000-000000000001'::uuid,
+        '2026-06-01', 'pickup', 'new');
+
+insert into public.order_items (order_id, product_id, product_unit_id, qty, unit_price_cents)
+values ('ee080000-0000-0000-0000-dddd00000001'::uuid,
+        'ee080000-0000-0000-0000-aaaa00000001'::uuid,
+        'ee080000-0000-0000-0000-bbbb00000002'::uuid,
+        3, 600);
+
+-- ============================================================
+-- 1. Guard rails: cross-product, missing, and inactive units raise.
+-- ============================================================
+select throws_like(
+  $$ select public.set_base_unit(
+       'ee080000-0000-0000-0000-aaaa00000001'::uuid,
+       'ee080000-0000-0000-0000-cccc00000001'::uuid) $$,
+  '%does not belong to product%',
+  'unit belonging to another product is rejected'
+);
+
+select throws_like(
+  $$ select public.set_base_unit(
+       'ee080000-0000-0000-0000-aaaa00000001'::uuid,
+       'ee080000-0000-0000-0000-feed00000099'::uuid) $$,
+  '%does not belong to product%',
+  'nonexistent unit id is rejected'
+);
+
+select throws_like(
+  $$ select public.set_base_unit(
+       'ee080000-0000-0000-0000-aaaa00000001'::uuid,
+       'ee080000-0000-0000-0000-bbbb00000003'::uuid) $$,
+  '%is inactive%',
+  'inactive unit cannot become the base'
+);
+
+-- ============================================================
+-- 2. No-op when the unit is already the base: nothing rescales.
+-- ============================================================
+select lives_ok(
+  $$ select public.set_base_unit(
+       'ee080000-0000-0000-0000-aaaa00000001'::uuid,
+       'ee080000-0000-0000-0000-bbbb00000001'::uuid) $$,
+  'promoting the current base is a no-op, not an error'
+);
+
+select is(
+  (select conversion_to_base from public.product_units
+   where id = 'ee080000-0000-0000-0000-bbbb00000002'::uuid),
+  0.5000::numeric(10,4),
+  'no-op left the lb conversion untouched'
+);
+
+select is(
+  (select qty_available from public.products
+   where id = 'ee080000-0000-0000-0000-aaaa00000001'::uuid),
+  10.00::numeric(10,2),
+  'no-op left qty_available untouched'
+);
+
+-- ============================================================
+-- 3. The rebase: lb (conv 0.5) becomes the base. Every conversion and
+--    qty_available divides by 0.5.
+-- ============================================================
+select lives_ok(
+  $$ select public.set_base_unit(
+       'ee080000-0000-0000-0000-aaaa00000001'::uuid,
+       'ee080000-0000-0000-0000-bbbb00000002'::uuid) $$,
+  'set_base_unit succeeds on an active non-base unit'
+);
+
+select is(
+  (select conversion_to_base from public.product_units
+   where id = 'ee080000-0000-0000-0000-bbbb00000002'::uuid),
+  1.0000::numeric(10,4),
+  'new base lands at exactly 1.0'
+);
+
+select is(
+  (select conversion_to_base from public.product_units
+   where id = 'ee080000-0000-0000-0000-bbbb00000001'::uuid),
+  2.0000::numeric(10,4),
+  'old base rescales: one bunch is now 2 lb-units (1 / 0.5)'
+);
+
+select is(
+  (select conversion_to_base from public.product_units
+   where id = 'ee080000-0000-0000-0000-bbbb00000003'::uuid),
+  8.0000::numeric(10,4),
+  'inactive unit rescales too (4 / 0.5 = 8)'
+);
+
+select is(
+  (select count(*)::int from public.product_units
+   where product_id = 'ee080000-0000-0000-0000-aaaa00000001'::uuid
+     and conversion_to_base = 1),
+  1,
+  'exactly one base unit after the rebase (saveInventory invariant holds)'
+);
+
+select is(
+  (select qty_available from public.products
+   where id = 'ee080000-0000-0000-0000-aaaa00000001'::uuid),
+  20.00::numeric(10,2),
+  'qty_available rescales by the same factor (10 / 0.5 = 20)'
+);
+
+-- ============================================================
+-- 4. New base sorts first; the rest keep their display order.
+--    Customer default = units[0] sorted by (sort_order nulls last, created_at).
+-- ============================================================
+select is(
+  (select array_agg(label order by sort_order, created_at)
+   from public.product_units
+   where product_id = 'ee080000-0000-0000-0000-aaaa00000001'::uuid),
+  array['lb', 'bunch', 'case'],
+  'sort_order renumbered: new base first, others in prior display order'
+);
+
+-- ============================================================
+-- 5. Prices are per-unit and must NOT change.
+-- ============================================================
+select is(
+  (select array_agg(unit_price_cents order by label)
+   from public.product_units
+   where product_id = 'ee080000-0000-0000-0000-aaaa00000001'::uuid),
+  array[350, 2000, 600],  -- bunch, case, lb
+  'unit prices untouched by the rebase'
+);
+
+-- ============================================================
+-- 6. Order-math invariance: the historical line's physical footprint
+--    relative to stock is unchanged. Before: 3 * 0.5 / 10 = 0.15.
+--    After: 3 * 1.0 / 20 = 0.15.
+-- ============================================================
+select is(
+  (select (oi.qty * pu.conversion_to_base) / p.qty_available
+   from public.order_items oi
+   join public.product_units pu on pu.id = oi.product_unit_id
+   join public.products p on p.id = oi.product_id
+   where oi.order_id = 'ee080000-0000-0000-0000-dddd00000001'::uuid),
+  0.15::numeric,
+  'order line footprint ratio (qty * live conv / qty_available) is unchanged'
+);
+
+select is(
+  (select row(oi.qty, oi.unit_price_cents)::text
+   from public.order_items oi
+   where oi.order_id = 'ee080000-0000-0000-0000-dddd00000001'::uuid),
+  '(3,600)',
+  'order line qty + snapshotted price untouched by the rebase'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/set_base_unit.sql
+++ b/supabase/tests/set_base_unit.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(16);
+select plan(17);
 
 -- ============================================================
 -- #208 (DEC-038) — set_base_unit RPC
@@ -62,6 +62,25 @@ values ('ee080000-0000-0000-0000-dddd00000001'::uuid,
         'ee080000-0000-0000-0000-bbbb00000002'::uuid,
         3, 600);
 
+-- Third product to exercise the scale guard: a tiny "mg" unit (conv 0.0001,
+-- the numeric(10,4) floor) alongside a big "crate" (conv 3). Promoting crate
+-- would rescale mg to round(0.0001/3, 4) = 0.0000, tripping the
+-- conversion_to_base > 0 CHECK — set_base_unit must reject it up front.
+insert into public.products (id, name, qty_available, sort_order, category)
+values ('ee080000-0000-0000-0000-aaaa00000003'::uuid, 'Bulk', 9.00, 3, 'Other');
+
+insert into public.product_units (id, product_id, label, conversion_to_base, unit_price_cents, is_active, slug, sort_order)
+values
+  ('ee080000-0000-0000-0000-eeee00000001'::uuid,
+   'ee080000-0000-0000-0000-aaaa00000003'::uuid,
+   'kg', 1, 500, true, 'bulk-kg-ee080000', 0),
+  ('ee080000-0000-0000-0000-eeee00000002'::uuid,
+   'ee080000-0000-0000-0000-aaaa00000003'::uuid,
+   'mg', 0.0001, 1, true, 'bulk-mg-ee080000', 1),
+  ('ee080000-0000-0000-0000-eeee00000003'::uuid,
+   'ee080000-0000-0000-0000-aaaa00000003'::uuid,
+   'crate', 3, 9000, true, 'bulk-crate-ee080000', 2);
+
 -- ============================================================
 -- 1. Guard rails: cross-product, missing, and inactive units raise.
 -- ============================================================
@@ -87,6 +106,17 @@ select throws_like(
        'ee080000-0000-0000-0000-bbbb00000003'::uuid) $$,
   '%is inactive%',
   'inactive unit cannot become the base'
+);
+
+-- Promoting "crate" (conv 3) would round "mg" (conv 0.0001) to 0.0000 and
+-- violate the conversion_to_base > 0 CHECK — rejected with a remedy message,
+-- not a raw constraint error.
+select throws_like(
+  $$ select public.set_base_unit(
+       'ee080000-0000-0000-0000-aaaa00000003'::uuid,
+       'ee080000-0000-0000-0000-eeee00000003'::uuid) $$,
+  '%too far apart in scale%',
+  'rebase that would round a conversion to zero is rejected'
 );
 
 -- ============================================================

--- a/tests/admin-base-unit.spec.ts
+++ b/tests/admin-base-unit.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  ADMIN_STORAGE_STATE,
+  TEST_PRODUCTS,
+  admin,
+  resetProductUnits,
+  setProductQty,
+  setProductUnits,
+} from "./helpers";
+
+// #208 (DEC-038) — changeable base unit. "Make base" on a non-base unit row
+// opens a confirm modal; confirming calls the atomic set_base_unit RPC, which
+// rescales every conversion + qty_available and makes the new base the
+// customer default (smallest sort_order). Gated while the drawer has unsaved
+// edits so the post-rebase reload can't clobber staged changes.
+
+const KALE = TEST_PRODUCTS.kale;
+
+function row(page: Page, name: string) {
+  return page.locator(`tr[data-row-name="${name}"]`);
+}
+function chip(page: Page, name: string) {
+  return row(page, name).locator(".units-chip");
+}
+function drawer(page: Page) {
+  return page.locator("aside.units-drawer");
+}
+function confirmModal(page: Page) {
+  return page.locator(".modal");
+}
+
+test.describe("admin inventory · make base unit", () => {
+  test.use({ storageState: ADMIN_STORAGE_STATE });
+
+  test.beforeEach(async () => {
+    // Two units: bunch is base (conv 1), "per lb" is half a bunch's worth
+    // (conv 0.5). Stock pinned to 10 base units so the rescale is assertable.
+    await setProductUnits(KALE.id, [
+      { label: KALE.unit, conversion_to_base: 1, unit_price_cents: KALE.price_cents },
+      { label: "per lb", conversion_to_base: 0.5, unit_price_cents: 800 },
+    ]);
+    await setProductQty(KALE.id, 10);
+  });
+
+  test.afterEach(async () => {
+    await resetProductUnits(KALE.id, KALE.price_cents, KALE.unit);
+    await setProductQty(KALE.id, KALE.qty_available);
+  });
+
+  test("make base: confirm rebases conversions, stock, and default order", async ({ page }) => {
+    await page.goto("/admin/inventory");
+    await chip(page, KALE.name).click();
+    await expect(drawer(page)).toBeVisible();
+
+    // Base row carries the badge and no Make-base affordance.
+    await expect(drawer(page).locator(".units-row.is-base")).toHaveAttribute(
+      "data-unit-label",
+      KALE.unit,
+    );
+    await expect(
+      drawer(page).locator(".units-row.is-base .units-make-base"),
+    ).toHaveCount(0);
+
+    await drawer(page)
+      .getByRole("button", { name: "Make per lb the base unit" })
+      .click();
+
+    // Deliberate step: a confirm modal, not an inline flip.
+    await expect(confirmModal(page)).toBeVisible();
+    await expect(confirmModal(page)).toContainText(/counted and sold in/i);
+    await confirmModal(page).getByRole("button", { name: /^Make base$/ }).click();
+
+    // Success closes the drawer (state reloads via router.refresh).
+    await expect(drawer(page)).toBeHidden();
+
+    // DB: per lb is now 1.0, bunch rescaled to 2.0, stock 10 / 0.5 = 20,
+    // prices untouched, new base sorts first.
+    const sb = admin();
+    const { data: units } = await sb
+      .from("product_units")
+      .select("label, conversion_to_base, unit_price_cents, sort_order")
+      .eq("product_id", KALE.id)
+      .order("sort_order");
+    expect(units).toHaveLength(2);
+    expect(units![0].label).toBe("per lb");
+    expect(Number(units![0].conversion_to_base)).toBe(1);
+    expect(units![0].unit_price_cents).toBe(800);
+    expect(units![1].label).toBe(KALE.unit);
+    expect(Number(units![1].conversion_to_base)).toBe(2);
+    expect(units![1].unit_price_cents).toBe(KALE.price_cents);
+
+    const { data: product } = await sb
+      .from("products")
+      .select("qty_available")
+      .eq("id", KALE.id)
+      .single();
+    expect(Number(product!.qty_available)).toBe(20);
+
+    // Reload + reopen: the drawer now badges "per lb" as base, and the inline
+    // row's unit cell follows (it mirrors the base unit per DEC-037).
+    await page.reload();
+    await expect(row(page, KALE.name).getByLabel("Unit", { exact: true })).toHaveValue("per lb");
+    await chip(page, KALE.name).click();
+    await expect(drawer(page).locator(".units-row.is-base")).toHaveAttribute(
+      "data-unit-label",
+      "per lb",
+    );
+  });
+
+  test("cancel leaves everything untouched", async ({ page }) => {
+    await page.goto("/admin/inventory");
+    await chip(page, KALE.name).click();
+    await drawer(page)
+      .getByRole("button", { name: "Make per lb the base unit" })
+      .click();
+    await expect(confirmModal(page)).toBeVisible();
+    await confirmModal(page).getByRole("button", { name: "Cancel" }).click();
+    await expect(confirmModal(page)).toBeHidden();
+    await expect(drawer(page)).toBeVisible();
+
+    const sb = admin();
+    const { data } = await sb
+      .from("product_units")
+      .select("conversion_to_base")
+      .eq("product_id", KALE.id)
+      .eq("label", "per lb")
+      .single();
+    expect(Number(data!.conversion_to_base)).toBe(0.5);
+  });
+
+  test("make base is gated while the drawer has unsaved edits", async ({ page }) => {
+    await page.goto("/admin/inventory");
+    await chip(page, KALE.name).click();
+    await expect(drawer(page)).toBeVisible();
+
+    const makeBase = drawer(page).getByRole("button", {
+      name: "Make per lb the base unit",
+    });
+    await expect(makeBase).toBeEnabled();
+
+    // Dirty the drawer: edit the non-base unit's price.
+    const lbRow = drawer(page).locator('.units-row[data-unit-label="per lb"]');
+    await lbRow.getByRole("textbox", { name: "Unit price" }).fill("9.00");
+
+    await expect(makeBase).toBeDisabled();
+    await expect(makeBase).toHaveAttribute("title", "Save your unit changes first");
+
+    // A brand-new (unsaved) row never offers Make base — it has no DB id.
+    await drawer(page).getByRole("button", { name: /add another unit/i }).click();
+    const newRow = drawer(page).locator(".units-row").nth(2);
+    await expect(newRow.locator(".units-make-base")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
Let an admin change which `product_units` row is a product's base unit (DEC-038, closes #208). "Make base" is one deliberate, confirmed action that **atomically re-bases** the product (every unit's `conversion_to_base` and `qty_available` divide by the new base's current conversion → new base lands at exactly 1.0) **and** makes it the customer's default-selected unit (renumbers `sort_order` so the new base sorts first). Unit prices are per-unit truths and stay untouched; all historical order math (`qty × conversion_to_base` vs `qty_available`) is invariant under the rebase.

closes #208

## Files changed
**Migration**
- `supabase/migrations/20260612153000_set_base_unit.sql` — `set_base_unit(p_product_id, p_new_base_unit_id)`, `security invoker`. Atomic rescale + `sort_order` renumber. Raises on cross-product / inactive / missing unit, no-ops when already base, and (review fix) rejects a rebase that would round a conversion to `0.0000` with a remedy message instead of a raw CHECK violation.

**App**
- `src/actions/set-base-unit.ts` — thin RPC wrapper, friendly error mapping, `revalidatePath`.
- `src/components/admin/units-drawer.tsx` — "Make base" pill on saved + active + non-base rows only; opens the existing `ConfirmModal`; calls `setBaseUnit` immediately (not staged into Save); disabled while the drawer is dirty; Escape/close paths respect the busy + modal state.
- `src/styles/app.css` — pill styling (+ a `flex-wrap` so it drops below the label at 375px).
- `src/lib/supabase/types.ts` — RPC type.

**Docs**
- `docs/DECISIONS.md` — DEC-038.

## Code review
@code-review confirmed atomicity, the "exactly one base = 1.0" invariant, the no-op guard, and the drawer's single-fire / clean-only gating. One real (low-likelihood) bug — a large rescale factor rounding a conversion to `0.0000` against the `> 0` CHECK — fixed in `cbe122c` with a pre-check + mapped message + pgTAP case. Grant posture verified safe (no non-admin `authenticated` user exists).

## Test plan
- [x] `npm run build` green.
- [x] `supabase db reset && supabase test db` → 154 pgTAP pass (9 files). `set_base_unit.sql` (17 assertions) proves rescale incl. inactive units, `qty_available` 10→20, prices untouched, new base sorts first, **order-footprint ratio invariance**, all rejection paths, no-op, and the scale guard.
- [x] Playwright `tests/admin-base-unit.spec.ts` desktop 3/3 + mobile @375px: confirm-rebases flow with DB verification, cancel path, dirty-gating.

## Checklist
- [x] Migration: yes — adds one function, no table change.
- [x] RLS change: no (relies on existing `product_units`/`products` admin policies; `security invoker`).
- [x] UI change at 375px: "Make base" pill verified at mobile width (wraps under the label).

## Known follow-up (pre-existing, not this PR)
The units grid's label inputs are already crushed at 375px (no mobile override for that grid predates this work). This PR only keeps the new pill from overflowing; a proper mobile layout for the units grid is worth its own item.
