### PR TITLE
#211 Additive orders — append to the week's order (DEC-039)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -453,6 +453,18 @@ PWA push notification remains the stretch upgrade per DEC-027's framing.
 
 ---
 
+## DEC-039 — Additive orders: append to the week's single order (#211)
+
+**Decision:** A customer can submit additional items while ordering is open. Additions append `order_items` to the existing `(customer, week)` order — the `unique (customer_id, week_of)` constraint stays. Appends inherit the order's fulfillment unchanged (the add-mode form shows it read-only; change = text Annabel, DEC-015). An append resets a `confirmed`/`ready` order to `new` (re-enters Annabel's pipeline; the existing Re-send affordance covers the now-stale confirmation SMS) and is refused when terminal (`picked-up`/`delivered` — the box is gone).
+
+**Idempotency:** `place_order`'s on-conflict no-op is replaced by a client-generated `order_items.submission_id` — replaying an already-applied submission returns the existing order with no second decrement. It doubles as a per-submission audit trail (which submit attempt created each line). The RPC now returns `table(order_id, appended)` so the action can pick "new order" vs "added N items" alert copy.
+
+**Rejected:** multiple order rows per customer-week — breaks `customer_sends` keying (`(customer_id, week_of, mode)` PK), `getCurrentWeekOrder`'s `maybeSingle()`, the 1:1 admin sends join, and doubles Annabel's per-customer fulfillment steps.
+
+*(DEC-038 is allocated on a not-yet-merged branch; the gap here is intentional and closes when that branch lands.)*
+
+---
+
 ## Open / Pending Product Owner Discussion
 
 - **Minimum delivery amount (in dollars).** Threshold below which delivery is unavailable, or above which delivery is free. Phase 7+ candidate.

--- a/src/actions/place-order.ts
+++ b/src/actions/place-order.ts
@@ -29,6 +29,13 @@ export type PlaceOrderPayload = {
   delivery_preference: string;
   pickup_note: string;
   notes: string;
+  // DEC-039: client-generated per-submit-attempt UUID. The RPC's idempotency
+  // key — a replay (double-tap slipping the latch, transport-level POST
+  // retry) of an already-applied submission returns the existing order
+  // without appending or decrementing again. Generated in the FORM, not
+  // here: a server-generated id would mint a fresh one per retried request
+  // and guard nothing.
+  submission_id: string;
 };
 
 export async function placeOrder(
@@ -54,18 +61,25 @@ export async function placeOrder(
   }
 
   const supabase = createAdminClient();
-  const { error } = await supabase.rpc("place_order", {
-    p_customer_id: customer.id,
-    p_week_of: weekOfMondayNY(),
-    p_fulfillment_type: payload.mode,
-    p_delivery_address:
-      payload.mode === "delivery" ? (customer.delivery_address ?? "") : "",
-    p_delivery_preference:
-      payload.mode === "delivery" ? payload.delivery_preference.trim() : "",
-    p_pickup_note: payload.mode === "pickup" ? payload.pickup_note.trim() : "",
-    p_notes: payload.notes.trim(),
-    p_items: payload.items as unknown as Json,
-  });
+  // DEC-039: place_order returns table(order_id, appended) — `appended`
+  // tells us whether this submission created the week's order or topped up
+  // an existing one, which picks the alert copy below. .single() collapses
+  // the one-row set.
+  const { data, error } = await supabase
+    .rpc("place_order", {
+      p_customer_id: customer.id,
+      p_week_of: weekOfMondayNY(),
+      p_fulfillment_type: payload.mode,
+      p_delivery_address:
+        payload.mode === "delivery" ? (customer.delivery_address ?? "") : "",
+      p_delivery_preference:
+        payload.mode === "delivery" ? payload.delivery_preference.trim() : "",
+      p_pickup_note: payload.mode === "pickup" ? payload.pickup_note.trim() : "",
+      p_notes: payload.notes.trim(),
+      p_items: payload.items as unknown as Json,
+      p_submission_id: payload.submission_id,
+    })
+    .single();
 
   if (error) {
     // #132 / DEC-036: place_order rejects items whose product is sold out
@@ -78,8 +92,18 @@ export async function placeOrder(
           "Some items sold out while you were ordering. Reload to see what's still available.",
       };
     }
+    // #211 / DEC-039: appending to a picked-up/delivered order is refused —
+    // the box is already packed and gone. Stale add-mode tab is the only
+    // route here (the /confirmed hub hides the add button on terminal).
+    if (error.message.includes("already fulfilled")) {
+      return {
+        error:
+          "This order's already been packed — text Annabel to add more.",
+      };
+    }
     return { error: error.message };
   }
+  const appended = data?.appended ?? false;
 
   // Best-effort admin alert (DEC-033). Failure is swallowed inside the
   // wrapper — order placement never blocks on a notification miss. We
@@ -99,6 +123,10 @@ export async function placeOrder(
     itemCount: totalItemCount(payload.items),
     totalCents: total,
     adminOrdersUrl: `${adminBaseUrl()}/admin/orders`,
+    // DEC-039: append → "Order updated — <name> added N items" so Annabel
+    // can tell a top-up from a brand-new order. Count/total describe the
+    // added items only (the payload), not the merged order.
+    appended,
   });
 
   redirect(`/c/${token}/confirmed`);

--- a/src/app/c/[token]/confirmed/page.tsx
+++ b/src/app/c/[token]/confirmed/page.tsx
@@ -1,7 +1,13 @@
 import Link from "next/link";
 import { PausedShell } from "@/components/customer/PausedShell";
 import { StatusShell } from "@/components/customer/StatusShell";
-import { getCurrentWeekOrder } from "@/lib/customer/queries";
+import { isTerminalStatus } from "@/lib/admin/orders-queries";
+import {
+  anyOrderable,
+  getAvailableProducts,
+  getCurrentWeekOrder,
+  getOrderingScheduleStatus,
+} from "@/lib/customer/queries";
 import { lookupCustomerByToken } from "@/lib/customer/session";
 import { weekOfLabel, weekOfMondayNY } from "@/lib/week";
 
@@ -70,6 +76,18 @@ export default async function ConfirmedPage({
     0,
   );
   const greeting = customer.business_name ?? customer.name;
+
+  // #211 / DEC-039 — "Add to your order" entry point. Gated on the same
+  // predicates /c/[token] uses to render the form at all: ordering open
+  // (DEC-031 soft hint), at least one orderable product (anyOrderable —
+  // shared helper), and the order not terminal (picked-up/delivered means
+  // the box is gone; place_order refuses the append server-side too).
+  const [schedule, products] = await Promise.all([
+    getOrderingScheduleStatus(),
+    getAvailableProducts(),
+  ]);
+  const terminal = isTerminalStatus(order.status);
+  const canAdd = !terminal && schedule.is_open && anyOrderable(products);
 
   return (
     <StatusShell>
@@ -173,6 +191,24 @@ export default async function ConfirmedPage({
       </div>
 
       <div className="status-actions">
+        {canAdd ? (
+          <Link
+            href={`/c/${token}?add=1`}
+            className="btn btn-primary status-btn"
+          >
+            Add to your order
+          </Link>
+        ) : terminal ? (
+          <p className="status-fine">
+            This order&rsquo;s been packed — text Annabel to add more.
+          </p>
+        ) : !schedule.is_open ? (
+          <p className="status-fine">
+            Ordering&rsquo;s closed for this week.
+          </p>
+        ) : null}
+        {/* anyOrderable=false (everything sold out) shows no add affordance
+            and no reason line — nothing left to add is self-explanatory. */}
         <a href="sms:2162025718" className="btn btn-secondary status-btn">
           Need a change? Text Annabel · 216-202-5718
         </a>

--- a/src/app/c/[token]/page.tsx
+++ b/src/app/c/[token]/page.tsx
@@ -3,7 +3,9 @@ import { AllSoldOutShell } from "@/components/customer/AllSoldOutShell";
 import { ClosedShell } from "@/components/customer/ClosedShell";
 import { OrderForm } from "@/components/customer/OrderForm";
 import { PausedShell } from "@/components/customer/PausedShell";
+import { isTerminalStatus } from "@/lib/admin/orders-queries";
 import {
+  anyOrderable,
   getAvailableProducts,
   getCurrentWeekOrder,
   getLatestDeliveryPreference,
@@ -14,10 +16,13 @@ import { weekOfLabel, weekOfMondayNY } from "@/lib/week";
 
 export default async function CustomerTokenPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ token: string }>;
+  searchParams: Promise<{ add?: string }>;
 }) {
   const { token } = await params;
+  const { add } = await searchParams;
   const customer = await lookupCustomerByToken(token);
   if (!customer) notFound();
 
@@ -39,8 +44,18 @@ export default async function CustomerTokenPage({
   // than re-showing the empty form. The server-side place_order RPC would
   // catch a re-submit either way, but seeing the empty form again is
   // confusing UX.
+  //
+  // #211 / DEC-039: ?add=1 (the /confirmed hub's "Add to your order" link)
+  // skips that bounce and renders the form in ADD MODE — new items append to
+  // the existing order. A terminal order (picked-up/delivered) can't take
+  // appends, so it bounces back to /confirmed, where the gated-off reason
+  // copy lives.
   const existingOrder = await getCurrentWeekOrder(customer.id, weekOfMondayNY());
-  if (existingOrder) redirect(`/c/${token}/confirmed`);
+  const addMode = add === "1" && existingOrder !== null;
+  if (existingOrder && !addMode) redirect(`/c/${token}/confirmed`);
+  if (addMode && existingOrder && isTerminalStatus(existingOrder.status)) {
+    redirect(`/c/${token}/confirmed`);
+  }
 
   const [products, priorDeliveryPreference, schedule] = await Promise.all([
     getAvailableProducts(),
@@ -58,10 +73,7 @@ export default async function CustomerTokenPage({
   // 6.5d: orderable means at least one active unit fits in current base
   // inventory. A product with only a conv=4 unit and qty_available=2 is
   // effectively sold out even though qty_available > 0.
-  const anyOrderable = products.some((p) =>
-    p.units.some((u) => p.qty_available >= u.conversion_to_base),
-  );
-  if (!anyOrderable) {
+  if (!anyOrderable(products)) {
     return <AllSoldOutShell customerName={greetingName} />;
   }
 
@@ -75,6 +87,16 @@ export default async function CustomerTokenPage({
       products={products}
       priorDeliveryPreference={priorDeliveryPreference}
       weekLabel={weekOfLabel()}
+      existingOrder={
+        addMode && existingOrder
+          ? {
+              fulfillment_type: existingOrder.fulfillment_type,
+              delivery_address: existingOrder.delivery_address,
+              delivery_preference: existingOrder.delivery_preference,
+              pickup_note: existingOrder.pickup_note,
+            }
+          : null
+      }
     />
   );
 }

--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -362,8 +362,13 @@ export function OrderForm({
   );
   const lineCount = itemsWithQty.length;
 
-  const setItemQty = (id: string, n: number) =>
+  const setItemQty = (id: string, n: number) => {
+    // Belt-and-suspenders with the persist effect: editing the cart starts a
+    // new submission attempt, so drop the idempotency key here at the edit
+    // site too — a changed cart must never be swallowed as a replay no-op.
+    submissionIdRef.current = null;
     setQty((q) => ({ ...q, [id]: n }));
+  };
 
   const handleSubmit = () => {
     if (lineCount === 0 || submittingRef.current) return;

--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -10,11 +10,23 @@ type Customer = {
   delivery_address: string | null;
 };
 
+// #211 / DEC-039 — when set, the form is in ADD MODE: new items append to
+// this existing (customer, week) order. Fulfillment is shown read-only
+// (inherited from the order; change = text Annabel, DEC-015) and the submit
+// payload sends only the new line items — never fulfillment fields.
+export type ExistingOrderFulfillment = {
+  fulfillment_type: string;
+  delivery_address: string | null;
+  delivery_preference: string | null;
+  pickup_note: string | null;
+};
+
 type Props = {
   customer: Customer;
   products: ProductRow[];
   priorDeliveryPreference: string | null;
   weekLabel: string;
+  existingOrder: ExistingOrderFulfillment | null;
 };
 
 type Mode = "delivery" | "pickup";
@@ -212,7 +224,9 @@ export function OrderForm({
   products,
   priorDeliveryPreference,
   weekLabel,
+  existingOrder,
 }: Props) {
+  const addMode = existingOrder !== null;
   const [qty, setQty] = useState<Record<string, number>>({});
   // selectedUnit[productId] → product_units.id. Unset entries fall back to the
   // product's first active unit at render time. Switching units zeros qty for
@@ -229,14 +243,22 @@ export function OrderForm({
   // useTransition's isPending flips asynchronously — a fast cross-button tap
   // (sticky-bar → rail-card) within one frame can fire the handler twice
   // before React commits the disabled state. This ref is the synchronous
-  // latch; the server action is idempotent on the second call but the second
-  // request still hits the network unnecessarily.
+  // latch; the server action is idempotent on the second call (same
+  // submission_id → replay no-op, DEC-039) but the second request still hits
+  // the network unnecessarily.
   const submittingRef = useRef(false);
   // #149 — once a submit is in flight we stop persisting: the redirect on
   // success unmounts before any post-await code runs, and a re-render during
   // the submit transition would otherwise re-fire the persist effect and
   // resurrect the draft we just cleared. Reset on a failed submit.
   const submittedRef = useRef(false);
+  // #211 / DEC-039 — per-submit-attempt idempotency key. Minted lazily on the
+  // first submit and REUSED on a retry of the unchanged cart, so a retry of a
+  // submit that actually committed server-side (network error after the write)
+  // replays as a no-op instead of appending the cart twice. Any cart edit
+  // resets it (in the persist effect below): an edited cart is a new
+  // submission, and reusing the old id would make the server short-circuit it.
+  const submissionIdRef = useRef<string | null>(null);
   const fulfillRef = useRef<HTMLElement>(null);
 
   // #149 — persist the in-progress cart to sessionStorage so a reload or an
@@ -295,6 +317,10 @@ export function OrderForm({
   // the mount effect loads it.
   useEffect(() => {
     if (!hydrated || submittedRef.current) return;
+    // Cart state changed → this is no longer the same submission attempt.
+    // Drop the idempotency key so the next submit mints a fresh one (see
+    // submissionIdRef above). No-op on mount (ref starts null).
+    submissionIdRef.current = null;
     writeDraft();
     // writeDraft closes over the current state; deps list the persisted fields.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -368,6 +394,22 @@ export function OrderForm({
       submittingRef.current = false;
       return;
     }
+    // Lazily mint the submission id; a retry of the unchanged cart reuses it
+    // (the persist effect resets it on any cart edit).
+    if (!submissionIdRef.current) {
+      submissionIdRef.current = crypto.randomUUID();
+    }
+    const submissionId = submissionIdRef.current;
+    // #211 / DEC-039 — in add mode the order's fulfillment is inherited, not
+    // edited: send the existing order's mode for the RPC's (ignored-on-append)
+    // fulfillment args and empty preference/note fields so the form never
+    // tries to mutate them.
+    const effectiveMode: Mode =
+      existingOrder !== null
+        ? existingOrder.fulfillment_type === "pickup"
+          ? "pickup"
+          : "delivery"
+        : mode;
     // #149 — latch off persistence and clear the draft up front. On success the
     // action redirects and unmounts before any post-await code reliably runs,
     // so we can't clear there; on failure the error branches below unlatch and
@@ -377,11 +419,12 @@ export function OrderForm({
     startTransition(async () => {
       try {
         const result = await placeOrder({
-          mode,
+          mode: effectiveMode,
           items: payloadItems,
-          delivery_preference: deliveryPreference,
-          pickup_note: pickupNote,
+          delivery_preference: addMode ? "" : deliveryPreference,
+          pickup_note: addMode ? "" : pickupNote,
           notes,
+          submission_id: submissionId,
         });
         if (result?.error) {
           setSubmitError(result.error);
@@ -546,6 +589,36 @@ export function OrderForm({
               </div>
             </section>
 
+            {addMode && existingOrder ? (
+              // #211 / DEC-039 — add mode inherits the order's fulfillment.
+              // Read-only summary, no inputs: customers don't edit fulfillment
+              // (DEC-015) — change = text Annabel.
+              <section className="fulfill" ref={fulfillRef}>
+                <div className="eyebrow">fulfillment</div>
+                <h2 className="section-title">Going with your order</h2>
+                <div className="fulfill-detail">
+                  <div className="addr-stack">
+                    <div className="label-sm">
+                      {existingOrder.fulfillment_type === "pickup"
+                        ? "Pickup at the farm"
+                        : "Delivery Wednesday"}
+                    </div>
+                    <div className="addr-text">
+                      {existingOrder.fulfillment_type === "pickup"
+                        ? existingOrder.pickup_note?.trim() ||
+                          "3612 W 114th St, Cleveland"
+                        : existingOrder.delivery_address ||
+                          existingOrder.delivery_preference?.trim() ||
+                          "Wednesday morning, 8am–noon"}
+                    </div>
+                  </div>
+                  <div className="fulfill-help">
+                    These items go out with the order you already placed. Need
+                    to change this? Text Annabel · 216-202-5718.
+                  </div>
+                </div>
+              </section>
+            ) : (
             <section className="fulfill" ref={fulfillRef}>
               <div className="eyebrow">fulfillment</div>
               <h2 className="section-title">How would you like it?</h2>
@@ -611,6 +684,7 @@ export function OrderForm({
                 </div>
               )}
             </section>
+            )}
 
             <section className="notes">
               <div className="eyebrow">notes</div>
@@ -654,11 +728,15 @@ export function OrderForm({
                   </div>
                 </div>
                 <div className="summary-sub">
-                  {mode === "delivery"
-                    ? customer.delivery_address
-                      ? `Wednesday delivery to ${customer.delivery_address.split(",")[0]}`
-                      : "Wednesday delivery"
-                    : "Pickup at the farm"}
+                  {addMode
+                    ? existingOrder?.fulfillment_type === "pickup"
+                      ? "Adding to your pickup order"
+                      : "Adding to your delivery order"
+                    : mode === "delivery"
+                      ? customer.delivery_address
+                        ? `Wednesday delivery to ${customer.delivery_address.split(",")[0]}`
+                        : "Wednesday delivery"
+                      : "Pickup at the farm"}
                 </div>
               </div>
               <button
@@ -670,6 +748,8 @@ export function OrderForm({
               >
                 {isPending ? (
                   <span className="btn-spinner" aria-hidden="true" />
+                ) : addMode ? (
+                  "Add to order"
                 ) : (
                   "Submit order"
                 )}
@@ -724,6 +804,8 @@ export function OrderForm({
               >
                 {isPending ? (
                   <span className="btn-spinner" aria-hidden="true" />
+                ) : addMode ? (
+                  "Add to order"
                 ) : (
                   "Submit order"
                 )}

--- a/src/lib/admin/orders-queries.ts
+++ b/src/lib/admin/orders-queries.ts
@@ -27,6 +27,14 @@ export function statusAfterConfirmSend(current: OrderStatus): OrderStatus {
   return current === "new" ? "confirmed" : current;
 }
 
+// DEC-039: terminal = the box has been handed over. Appending to the week's
+// order is refused at this point (place_order raises; the /confirmed hub and
+// the ?add=1 entry both gate on it). Takes raw text because orders.status is
+// app-enforced text in the DB (DEC-010) — customer-side reads arrive untyped.
+export function isTerminalStatus(status: string): boolean {
+  return status === "picked-up" || status === "delivered";
+}
+
 // DEC-035 (amends DEC-010): new → [confirmed] → ready → (picked-up | delivered).
 // Confirmed is optional — new → ready stays valid (Annabel may pack before
 // texting). Fulfillment type pins which terminal state is valid. Pure +

--- a/src/lib/customer/queries.ts
+++ b/src/lib/customer/queries.ts
@@ -46,6 +46,17 @@ export async function getAvailableProducts(): Promise<ProductRow[]> {
   });
 }
 
+// 6.5d: orderable means at least one active unit fits in current base
+// inventory. A product with only a conv=4 unit and qty_available=2 is
+// effectively sold out even though qty_available > 0. Shared by /c/[token]
+// (all-sold-out shell, DEC-031) and /c/[token]/confirmed (gates the
+// "Add to your order" affordance, DEC-039) so the two can't drift.
+export function anyOrderable(products: ProductRow[]): boolean {
+  return products.some((p) =>
+    p.units.some((u) => p.qty_available >= u.conversion_to_base),
+  );
+}
+
 // Reads the ordering_schedule singleton. Customer page uses this to decide
 // between the open form, the manual-closed shell, and the all-sold-out shell
 // (DEC-031). DEC-030 guarantees a single row exists — .single() lets a
@@ -80,7 +91,8 @@ export async function getLatestDeliveryPreference(
 // Pulls the customer's order for a specific week (typically the current NY-time
 // week), joined with its line items + product names + per-line unit labels
 // (product_units, DEC-037). Returns null if no order exists for that week.
-// Used by /confirmed.
+// Used by /confirmed (which also gates its "Add to your order" affordance on
+// `status`, DEC-039) and by /c/[token]'s ?add=1 add-mode entry.
 export async function getCurrentWeekOrder(customerId: string, weekOf: string) {
   const supabase = createAdminClient();
   const { data, error } = await supabase
@@ -94,6 +106,7 @@ export async function getCurrentWeekOrder(customerId: string, weekOf: string) {
       delivery_preference,
       pickup_note,
       notes,
+      status,
       created_at,
       order_items (
         id,

--- a/src/lib/notifications/admin-alert-template.ts
+++ b/src/lib/notifications/admin-alert-template.ts
@@ -8,6 +8,11 @@ export type AdminOrderAlertInput = {
   itemCount: number;
   totalCents: number;
   adminOrdersUrl: string;
+  // DEC-039: true when the submission appended items to the week's existing
+  // order rather than creating it. Switches the headline so Annabel can tell
+  // a brand-new order from a top-up. itemCount/totalCents then describe the
+  // ADDED items only, not the merged order.
+  appended?: boolean;
 };
 
 function formatDollars(cents: number): string {
@@ -25,16 +30,20 @@ export function adminOrderAlertText({
   itemCount,
   totalCents,
   adminOrdersUrl,
+  appended = false,
 }: AdminOrderAlertInput): string {
   const total = formatDollars(totalCents);
   const itemsLabel = itemCount === 1 ? "1 item" : `${itemCount} items`;
+  const headline = appended
+    ? `Order updated — ${customerName} added ${itemsLabel}, ${total}`
+    : `New order — ${customerName}, ${total}`;
   return [
-    `New order — ${customerName}, ${total}`,
+    headline,
     "",
     `Customer: ${customerName}`,
     `Week of: ${weekOf}`,
-    `Items: ${itemsLabel}`,
-    `Total: ${total}`,
+    `${appended ? "Added" : "Items"}: ${itemsLabel}`,
+    `${appended ? "Added total" : "Total"}: ${total}`,
     "",
     adminOrdersUrl,
   ].join("\n");

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -164,6 +164,7 @@ export type Database = {
           product_id: string
           product_unit_id: string
           qty: number
+          submission_id: string | null
           unit_price_cents: number
         }
         Insert: {
@@ -173,6 +174,7 @@ export type Database = {
           product_id: string
           product_unit_id: string
           qty: number
+          submission_id?: string | null
           unit_price_cents: number
         }
         Update: {
@@ -182,6 +184,7 @@ export type Database = {
           product_id?: string
           product_unit_id?: string
           qty?: number
+          submission_id?: string | null
           unit_price_cents?: number
         }
         Relationships: [
@@ -421,9 +424,13 @@ export type Database = {
           p_items: Json
           p_notes: string
           p_pickup_note: string
+          p_submission_id?: string
           p_week_of: string
         }
-        Returns: string
+        Returns: {
+          appended: boolean
+          order_id: string
+        }[]
       }
       prepopulate_inventory_from_last_week: {
         Args: never

--- a/supabase/migrations/20260612170000_place_order_additive.sql
+++ b/supabase/migrations/20260612170000_place_order_additive.sql
@@ -1,0 +1,263 @@
+-- #211 / DEC-039 — additive orders: append to the week's single order.
+--
+-- Model B: a customer can submit ADDITIONAL items while ordering is open.
+-- Additions append order_items rows to the existing (customer, week) order —
+-- the `unique (customer_id, week_of)` constraint STAYS (one order row per
+-- customer per week, so customer_sends keying, maybeSingle() reads, and the
+-- 1:1 admin sends join all hold).
+--
+-- What changes here:
+--
+-- 1. order_items.submission_id — a client-generated per-submit-attempt UUID.
+--    It replaces the old ON CONFLICT no-op as the double-submit guard: a
+--    replay of an already-applied submission short-circuits (returns the
+--    existing order, no insert, no decrement). It doubles as a per-submission
+--    audit trail — every line carries which submit attempt created it.
+--    Nullable: historical rows (pre-DEC-039) stay null.
+--
+-- 2. place_order grows a trailing `p_submission_id uuid` parameter and now
+--    RETURNS TABLE(order_id uuid, appended boolean) instead of bare uuid.
+--    `appended` tells the caller whether this submission created the week's
+--    order (false) or appended to an existing one (true) so the action can
+--    pick the right alert copy. RETURNS TABLE chosen over OUT params for a
+--    self-describing shape in the generated TS types; chosen over a second
+--    lookup in the action to keep "did this append?" race-free (only the
+--    function, inside its transaction, knows).
+--
+-- 3. Append semantics:
+--    - terminal guard: appending to a 'picked-up'/'delivered' order raises —
+--      the box is already gone.
+--    - status reset: appending to a 'confirmed'/'ready' order resets it to
+--      'new' so it re-enters Annabel's pipeline (the now-stale confirmation
+--      SMS is covered by the existing Re-send affordance). A 'new' order's
+--      status is untouched; terminal is guarded above.
+--    - notes: a non-empty p_notes on an append is concatenated onto the
+--      existing orders.notes with a " — " separator, never overwritten.
+--    - fulfillment fields are NOT touched on append (DEC-015: customers
+--      don't edit fulfillment; change = text Annabel).
+--    - per-item loop (unit resolution, price snapshot, DEC-036 soldout
+--      reject, optimistic decrement) is byte-equivalent to
+--      20260611213000_place_order_reject_soldout.sql, plus submission_id on
+--      each inserted row.
+--    - needs_reconciliation recomputes across ALL the order's items (the
+--      existing union-over-the-order query already does this).
+
+alter table public.order_items
+  add column submission_id uuid;
+
+comment on column public.order_items.submission_id is
+  'Client-generated per-submit-attempt UUID (DEC-039). Idempotency key for '
+  'place_order — a replayed submission is a no-op returning the existing '
+  'order — and per-submission audit (which submit attempt created this line). '
+  'Null on rows that predate additive orders.';
+
+create index order_items_submission_id_idx
+  on public.order_items (submission_id);
+
+-- Signature change (8 args → 9) requires dropping the old overload explicitly;
+-- CREATE OR REPLACE would otherwise leave both callable and PostgREST RPC
+-- resolution ambiguous.
+drop function if exists public.place_order(uuid, date, text, text, text, text, text, jsonb);
+
+-- p_submission_id defaults to null so legacy callers (and pre-DEC-039 pgTAP
+-- fixtures) remain valid; the app always passes one.
+create function public.place_order(
+  p_customer_id          uuid,
+  p_week_of              date,
+  p_fulfillment_type     text,
+  p_delivery_address     text,
+  p_delivery_preference  text,
+  p_pickup_note          text,
+  p_notes                text,
+  p_items                jsonb,
+  p_submission_id        uuid default null
+)
+returns table(order_id uuid, appended boolean)
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  v_order_id     uuid;
+  v_status       text;
+  v_appended     boolean := false;
+  v_item         jsonb;
+  v_product_id   uuid;
+  v_unit_id      uuid;
+  v_qty          int;
+  v_unit_price   int;
+  v_conv         numeric(10,4);
+  v_negative     boolean;
+begin
+  -- NOTE: `order_id` and `appended` are in scope as OUT variables of the
+  -- RETURNS TABLE clause — every column reference below is table-qualified
+  -- to avoid ambiguity.
+
+  if jsonb_typeof(p_items) is distinct from 'array' or jsonb_array_length(p_items) = 0 then
+    raise exception 'place_order: p_items must be a non-empty json array';
+  end if;
+
+  -- Replay short-circuit (idempotency). If any order_items row already
+  -- carries this submission_id, the submission was applied — return the
+  -- order it landed on without inserting or decrementing anything. This
+  -- replaces the old ON CONFLICT no-op for the double-tap / retried-POST
+  -- case (which under DEC-039 would otherwise APPEND a duplicate).
+  if p_submission_id is not null then
+    select oi.order_id into v_order_id
+      from public.order_items oi
+     where oi.submission_id = p_submission_id
+     limit 1;
+    if v_order_id is not null then
+      -- Report `appended` consistently with the original call: the
+      -- submission was an append iff the order carries items from other
+      -- submissions (or pre-DEC-039 null-submission rows).
+      return query
+        select v_order_id,
+               exists (
+                 select 1 from public.order_items oi
+                  where oi.order_id = v_order_id
+                    and oi.submission_id is distinct from p_submission_id
+               );
+      return;
+    end if;
+  end if;
+
+  -- Resolve the week's order. The unique (customer_id, week_of) insert is
+  -- still the race-free arbiter of "who creates the row"; losing the race
+  -- (or appending later) falls through to a locked read of the existing row.
+  insert into public.orders (
+    customer_id, week_of, fulfillment_type,
+    delivery_address, delivery_preference, pickup_note,
+    notes, status, needs_reconciliation
+  )
+  values (
+    p_customer_id, p_week_of, p_fulfillment_type,
+    p_delivery_address, p_delivery_preference, p_pickup_note,
+    p_notes, 'new', false
+  )
+  on conflict (customer_id, week_of) do nothing
+  returning id into v_order_id;
+
+  if v_order_id is null then
+    v_appended := true;
+    -- Lock the existing order row for this transaction so a concurrent
+    -- append/status change serializes behind us.
+    select o.id, o.status into v_order_id, v_status
+      from public.orders o
+     where o.customer_id = p_customer_id and o.week_of = p_week_of
+       for update;
+
+    -- Terminal guard: the box has already been handed over — appending is
+    -- refused, nothing is written. ('picked_up' variant included defensively;
+    -- the app writes hyphenated statuses per orders-queries.ts.)
+    if v_status in ('picked-up', 'delivered', 'picked_up') then
+      raise exception 'place_order: order already fulfilled'
+        using errcode = 'P0001';
+    end if;
+
+    -- Notes on an append are additive — never clobber what the customer
+    -- already told Annabel.
+    if coalesce(trim(p_notes), '') <> '' then
+      update public.orders o
+         set notes = case
+                       when coalesce(trim(o.notes), '') = '' then p_notes
+                       else o.notes || ' — ' || p_notes
+                     end,
+             updated_at = now()
+       where o.id = v_order_id;
+    end if;
+  end if;
+
+  for v_item in select * from jsonb_array_elements(p_items)
+  loop
+    v_product_id := (v_item->>'product_id')::uuid;
+    v_qty        := (v_item->>'qty')::int;
+    -- product_unit_id is optional in the payload. When absent, the
+    -- order_items_default_unit BEFORE-INSERT trigger (from 6.5a) fills
+    -- in the first active unit for this product. We resolve the unit
+    -- here too so the price snapshot + decrement math match what the
+    -- row will end up with.
+    v_unit_id := nullif(v_item->>'product_unit_id', '')::uuid;
+    if v_unit_id is null then
+      select pu.id into v_unit_id
+        from public.product_units pu
+       where pu.product_id = v_product_id and pu.is_active = true
+       order by pu.sort_order nulls last, pu.created_at
+       limit 1;
+      -- Distinct error path from the cross-product-id case below so the
+      -- message points at the right remedy: re-activate (or seed) a unit
+      -- on this product, not "fix the unit_id in your payload."
+      if v_unit_id is null then
+        raise exception 'place_order: product % has no active units', v_product_id;
+      end if;
+    end if;
+
+    -- Snapshot from product_units, not from the client payload. If a unit
+    -- id was supplied but doesn't belong to this product (mismatched),
+    -- the lookup returns null and we raise — refusing to record a
+    -- cross-product unit reference rather than silently falling through.
+    select pu.unit_price_cents, pu.conversion_to_base
+      into v_unit_price, v_conv
+      from public.product_units pu
+     where pu.id = v_unit_id and pu.product_id = v_product_id;
+
+    if v_unit_price is null then
+      raise exception
+        'place_order: product_unit_id % does not belong to product %', v_unit_id, v_product_id;
+    end if;
+
+    insert into public.order_items (order_id, product_id, product_unit_id, qty, unit_price_cents, submission_id)
+    values (v_order_id, v_product_id, v_unit_id, v_qty, v_unit_price, p_submission_id);
+
+    -- DEC-036: optimistic oversell (DEC-012) applies only while there is
+    -- stock to draw down. The `qty_available > 0` guard makes this a no-op
+    -- on a sold-out product; FOUND is then false and we reject the whole
+    -- order. qty_available > 0 but insufficient still decrements into the
+    -- negative + flags reconciliation below — unchanged "last few" behavior.
+    update public.products p
+       set qty_available = p.qty_available - (v_qty::numeric * v_conv),
+           updated_at = now()
+     where p.id = v_product_id and p.qty_available > 0;
+
+    if not found then
+      raise exception 'place_order: product % is sold out', v_product_id
+        using errcode = 'P0001';
+    end if;
+  end loop;
+
+  -- An append re-enters Annabel's pipeline: a confirmed/ready order goes
+  -- back to 'new' (the stale confirmation SMS is covered by Re-send). A
+  -- 'new' order is untouched; terminal was refused above.
+  if v_appended then
+    update public.orders o
+       set status = 'new',
+           updated_at = now()
+     where o.id = v_order_id
+       and o.status in ('confirmed', 'ready');
+  end if;
+
+  -- Flip needs_reconciliation if any product touched by this order is now
+  -- negative. The join runs over ALL the order's items (original +
+  -- appended), so an append re-evaluates the whole order.
+  select exists (
+    select 1
+    from public.products p
+    join public.order_items oi on oi.product_id = p.id
+    where oi.order_id = v_order_id
+      and p.qty_available < 0
+  ) into v_negative;
+
+  if v_negative then
+    update public.orders o
+       set needs_reconciliation = true
+     where o.id = v_order_id;
+  end if;
+
+  return query select v_order_id, v_appended;
+end;
+$$;
+
+-- Re-apply access control for the new signature (function privileges don't
+-- carry across a drop/create).
+revoke all on function public.place_order(uuid, date, text, text, text, text, text, jsonb, uuid) from public;
+grant execute on function public.place_order(uuid, date, text, text, text, text, text, jsonb, uuid) to service_role;

--- a/supabase/migrations/20260612170000_place_order_additive.sql
+++ b/supabase/migrations/20260612170000_place_order_additive.sql
@@ -103,9 +103,16 @@ begin
   -- replaces the old ON CONFLICT no-op for the double-tap / retried-POST
   -- case (which under DEC-039 would otherwise APPEND a duplicate).
   if p_submission_id is not null then
+    -- Scoped to this customer's week: submission_id is a client-supplied UUID
+    -- with no unique constraint, so a replayed FOREIGN submission_id must not
+    -- resolve to someone else's order. A collision/forge finds nothing here
+    -- and falls through to create/append under the caller's own identity.
     select oi.order_id into v_order_id
       from public.order_items oi
+      join public.orders o on o.id = oi.order_id
      where oi.submission_id = p_submission_id
+       and o.customer_id = p_customer_id
+       and o.week_of = p_week_of
      limit 1;
     if v_order_id is not null then
       -- Report `appended` consistently with the original call: the
@@ -147,10 +154,33 @@ begin
      where o.customer_id = p_customer_id and o.week_of = p_week_of
        for update;
 
+    -- In-lock replay re-check — closes the create-vs-append race on a shared
+    -- submission_id. The outside-the-lock replay check above is not enough: two
+    -- concurrent requests with the same submission_id can both pass it (neither
+    -- has committed items yet), one wins the on-conflict insert and the other
+    -- arrives here. A unique index on submission_id can't arbitrate (one
+    -- submission legitimately inserts many items sharing the id), so we lock the
+    -- order row, then re-check: the winner's items are now committed and visible
+    -- (READ COMMITTED), so we short-circuit instead of decrementing twice.
+    if p_submission_id is not null and exists (
+      select 1 from public.order_items oi
+       where oi.order_id = v_order_id
+         and oi.submission_id = p_submission_id
+    ) then
+      return query
+        select v_order_id,
+               exists (
+                 select 1 from public.order_items oi
+                  where oi.order_id = v_order_id
+                    and oi.submission_id is distinct from p_submission_id
+               );
+      return;
+    end if;
+
     -- Terminal guard: the box has already been handed over — appending is
-    -- refused, nothing is written. ('picked_up' variant included defensively;
-    -- the app writes hyphenated statuses per orders-queries.ts.)
-    if v_status in ('picked-up', 'delivered', 'picked_up') then
+    -- refused, nothing is written. The app writes hyphenated statuses
+    -- (orders-queries.ts isTerminalStatus); keep this list identical to it.
+    if v_status in ('picked-up', 'delivered') then
       raise exception 'place_order: order already fulfilled'
         using errcode = 'P0001';
     end if;

--- a/supabase/tests/place_order_additive.sql
+++ b/supabase/tests/place_order_additive.sql
@@ -1,0 +1,392 @@
+begin;
+select plan(24);
+
+-- ============================================================
+-- #211 / DEC-039 — additive orders: place_order appends to the
+-- week's single (customer, week) order.
+--
+-- Verifies the post-DEC-039 contract:
+--   - first submission creates the order (appended = false); later
+--     submissions APPEND order_items to it (appended = true) — still
+--     exactly one orders row per (customer, week).
+--   - a replay of an already-applied submission_id is a no-op: same
+--     order_id back, no new items, no double decrement.
+--   - appending to a confirmed/ready order resets status to 'new'
+--     (re-enters the pipeline); a picked-up/delivered order refuses
+--     the append entirely and writes nothing.
+--   - the DEC-036 soldout reject + multi-line atomicity hold on the
+--     append path exactly as on the create path.
+-- ============================================================
+
+-- Fresh fixture rows scoped to this test (rolled back at end-of-file).
+insert into public.customers (id, name, token)
+values ('ee390000-0000-0000-0000-000000000001'::uuid, 'Additive Customer', 'token-additive-039');
+
+-- DEC-037: unit rows are inserted explicitly (nothing spawns them).
+insert into public.products (id, name, qty_available, sort_order, category)
+values ('ee390000-0000-0000-0000-aaaa00000001'::uuid, 'Add Basil', 20.00, 1, 'Herbs');
+
+insert into public.product_units (id, product_id, label, conversion_to_base, unit_price_cents, is_active, slug, sort_order)
+values ('ee390000-0000-0000-0000-bbbb00000001'::uuid,
+        'ee390000-0000-0000-0000-aaaa00000001'::uuid,
+        'bunch', 1, 500, true, 'add-basil-ee390000', 0);
+
+-- Zero-stock product for the DEC-036-on-append cases.
+insert into public.products (id, name, qty_available, sort_order, category)
+values ('ee390000-0000-0000-0000-aaaa00000002'::uuid, 'Add Zero Stock', 0.00, 2, 'Herbs');
+
+insert into public.product_units (id, product_id, label, conversion_to_base, unit_price_cents, is_active, slug, sort_order)
+values ('ee390000-0000-0000-0000-bbbb00000002'::uuid,
+        'ee390000-0000-0000-0000-aaaa00000002'::uuid,
+        'bunch', 1, 300, true, 'add-zero-stock-ee390000', 0);
+
+-- ============================================================
+-- 1–3. First submission creates the week's order: appended = false,
+--      one orders row, inventory decremented.
+-- ============================================================
+select is(
+  (select t.appended from public.place_order(
+     'ee390000-0000-0000-0000-000000000001'::uuid,
+     '2026-06-01'::date,
+     'delivery', '123 Additive St', '', '', 'first note',
+     jsonb_build_array(
+       jsonb_build_object(
+         'product_id',      'ee390000-0000-0000-0000-aaaa00000001'::text,
+         'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text,
+         'qty',             2,
+         'unit_price_cents', 500
+       )
+     ),
+     'ee39aaaa-0000-0000-0000-000000000001'::uuid
+   ) t),
+  false,
+  'first submission creates the order — appended = false'
+);
+
+select is(
+  (select count(*)::int from public.orders
+   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+     and week_of = '2026-06-01'),
+  1,
+  'exactly one orders row after the first submission'
+);
+
+select is(
+  (select qty_available from public.products
+   where id = 'ee390000-0000-0000-0000-aaaa00000001'::uuid),
+  18.00::numeric(10,2),
+  'inventory decremented on create (20 - 2 = 18)'
+);
+
+-- ============================================================
+-- 4–7. (a) Second submission APPENDS: appended = true, still one
+--      orders row, item count grows, inventory decremented again.
+-- ============================================================
+select is(
+  (select t.appended from public.place_order(
+     'ee390000-0000-0000-0000-000000000001'::uuid,
+     '2026-06-01'::date,
+     'delivery', '123 Additive St', '', '', '',
+     jsonb_build_array(
+       jsonb_build_object(
+         'product_id',      'ee390000-0000-0000-0000-aaaa00000001'::text,
+         'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text,
+         'qty',             3,
+         'unit_price_cents', 500
+       )
+     ),
+     'ee39aaaa-0000-0000-0000-000000000002'::uuid
+   ) t),
+  true,
+  'second submission appends — appended = true'
+);
+
+select is(
+  (select count(*)::int from public.orders
+   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+     and week_of = '2026-06-01'),
+  1,
+  'still exactly one orders row after the append (unique constraint holds)'
+);
+
+select is(
+  (select count(*)::int from public.order_items oi
+   join public.orders o on o.id = oi.order_id
+   where o.customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+     and o.week_of = '2026-06-01'),
+  2,
+  'append added a line item (2 total)'
+);
+
+select is(
+  (select qty_available from public.products
+   where id = 'ee390000-0000-0000-0000-aaaa00000001'::uuid),
+  15.00::numeric(10,2),
+  'inventory decremented on append (18 - 3 = 15)'
+);
+
+-- ============================================================
+-- 8–10. (b) Replaying the same submission_id is a no-op: same order
+--       back, no new items, no double decrement.
+-- ============================================================
+select is(
+  (select t.order_id from public.place_order(
+     'ee390000-0000-0000-0000-000000000001'::uuid,
+     '2026-06-01'::date,
+     'delivery', '123 Additive St', '', '', '',
+     jsonb_build_array(
+       jsonb_build_object(
+         'product_id',      'ee390000-0000-0000-0000-aaaa00000001'::text,
+         'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text,
+         'qty',             3,
+         'unit_price_cents', 500
+       )
+     ),
+     'ee39aaaa-0000-0000-0000-000000000002'::uuid
+   ) t),
+  (select id from public.orders
+   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+     and week_of = '2026-06-01'),
+  'replayed submission_id returns the existing order id'
+);
+
+select is(
+  (select count(*)::int from public.order_items oi
+   join public.orders o on o.id = oi.order_id
+   where o.customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+     and o.week_of = '2026-06-01'),
+  2,
+  'replay inserted no new items'
+);
+
+select is(
+  (select qty_available from public.products
+   where id = 'ee390000-0000-0000-0000-aaaa00000001'::uuid),
+  15.00::numeric(10,2),
+  'replay did not double-decrement inventory (still 15)'
+);
+
+-- ============================================================
+-- 11–14. (c) Appending to a confirmed/ready order resets status to
+--        'new' (re-enters Annabel's pipeline, DEC-035 Re-send covers
+--        the stale confirmation SMS).
+-- ============================================================
+update public.orders set status = 'confirmed'
+ where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+   and week_of = '2026-06-01';
+
+select lives_ok(
+  $$ select * from public.place_order(
+       'ee390000-0000-0000-0000-000000000001'::uuid,
+       '2026-06-01'::date,
+       'delivery', '123 Additive St', '', '', '',
+       jsonb_build_array(
+         jsonb_build_object(
+           'product_id',      'ee390000-0000-0000-0000-aaaa00000001'::text,
+           'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text,
+           'qty',             1,
+           'unit_price_cents', 500
+         )
+       ),
+       'ee39aaaa-0000-0000-0000-000000000003'::uuid
+     ) $$,
+  'append to a confirmed order is accepted'
+);
+
+select is(
+  (select status from public.orders
+   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+     and week_of = '2026-06-01'),
+  'new',
+  'append resets confirmed → new'
+);
+
+update public.orders set status = 'ready'
+ where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+   and week_of = '2026-06-01';
+
+select lives_ok(
+  $$ select * from public.place_order(
+       'ee390000-0000-0000-0000-000000000001'::uuid,
+       '2026-06-01'::date,
+       'delivery', '123 Additive St', '', '', '',
+       jsonb_build_array(
+         jsonb_build_object(
+           'product_id',      'ee390000-0000-0000-0000-aaaa00000001'::text,
+           'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text,
+           'qty',             1,
+           'unit_price_cents', 500
+         )
+       ),
+       'ee39aaaa-0000-0000-0000-000000000004'::uuid
+     ) $$,
+  'append to a ready order is accepted'
+);
+
+select is(
+  (select status from public.orders
+   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+     and week_of = '2026-06-01'),
+  'new',
+  'append resets ready → new'
+);
+
+-- ============================================================
+-- 15–18. (d) Appending to a terminal order (picked-up / delivered)
+--        raises and writes nothing — the box is gone.
+-- ============================================================
+update public.orders set status = 'picked-up'
+ where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+   and week_of = '2026-06-01';
+
+select throws_like(
+  $$ select * from public.place_order(
+       'ee390000-0000-0000-0000-000000000001'::uuid,
+       '2026-06-01'::date,
+       'delivery', '123 Additive St', '', '', '',
+       jsonb_build_array(
+         jsonb_build_object(
+           'product_id',      'ee390000-0000-0000-0000-aaaa00000001'::text,
+           'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text,
+           'qty',             1,
+           'unit_price_cents', 500
+         )
+       ),
+       'ee39aaaa-0000-0000-0000-000000000005'::uuid
+     ) $$,
+  '%already fulfilled%',
+  'append to a picked-up order is refused'
+);
+
+select is(
+  (select count(*)::int from public.order_items oi
+   join public.orders o on o.id = oi.order_id
+   where o.customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+     and o.week_of = '2026-06-01'),
+  4,
+  'refused append wrote no items (still 4 from s1–s4)'
+);
+
+select is(
+  (select qty_available from public.products
+   where id = 'ee390000-0000-0000-0000-aaaa00000001'::uuid),
+  13.00::numeric(10,2),
+  'refused append did not decrement inventory (still 13)'
+);
+
+update public.orders set status = 'delivered'
+ where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+   and week_of = '2026-06-01';
+
+select throws_like(
+  $$ select * from public.place_order(
+       'ee390000-0000-0000-0000-000000000001'::uuid,
+       '2026-06-01'::date,
+       'delivery', '123 Additive St', '', '', '',
+       jsonb_build_array(
+         jsonb_build_object(
+           'product_id',      'ee390000-0000-0000-0000-aaaa00000001'::text,
+           'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text,
+           'qty',             1,
+           'unit_price_cents', 500
+         )
+       ),
+       'ee39aaaa-0000-0000-0000-000000000006'::uuid
+     ) $$,
+  '%already fulfilled%',
+  'append to a delivered order is refused'
+);
+
+-- ============================================================
+-- 19–22. (e) DEC-036 on the append path: a sold-out line rejects the
+--        append; multi-line appends are atomic (the in-stock line's
+--        write rolls back when a later line is sold out).
+-- ============================================================
+update public.orders set status = 'new'
+ where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+   and week_of = '2026-06-01';
+
+select throws_like(
+  $$ select * from public.place_order(
+       'ee390000-0000-0000-0000-000000000001'::uuid,
+       '2026-06-01'::date,
+       'delivery', '123 Additive St', '', '', '',
+       jsonb_build_array(
+         jsonb_build_object(
+           'product_id',      'ee390000-0000-0000-0000-aaaa00000002'::text,
+           'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000002'::text,
+           'qty',             1,
+           'unit_price_cents', 300
+         )
+       ),
+       'ee39aaaa-0000-0000-0000-000000000007'::uuid
+     ) $$,
+  '%is sold out%',
+  'append of a sold-out product is rejected (DEC-036 holds on the append path)'
+);
+
+-- In-stock line FIRST so it gets inserted + decremented before the loop
+-- reaches the sold-out line and raises — proving the earlier write rolls
+-- back too.
+select throws_like(
+  $$ select * from public.place_order(
+       'ee390000-0000-0000-0000-000000000001'::uuid,
+       '2026-06-01'::date,
+       'delivery', '123 Additive St', '', '', '',
+       jsonb_build_array(
+         jsonb_build_object('product_id', 'ee390000-0000-0000-0000-aaaa00000001'::text, 'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text, 'qty', 1, 'unit_price_cents', 500),
+         jsonb_build_object('product_id', 'ee390000-0000-0000-0000-aaaa00000002'::text, 'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000002'::text, 'qty', 1, 'unit_price_cents', 300)
+       ),
+       'ee39aaaa-0000-0000-0000-000000000008'::uuid
+     ) $$,
+  '%is sold out%',
+  'multi-line append with one sold-out line is rejected as a whole'
+);
+
+select is(
+  (select qty_available from public.products
+   where id = 'ee390000-0000-0000-0000-aaaa00000001'::uuid),
+  13.00::numeric(10,2),
+  'in-stock line in the rejected multi-line append is NOT decremented (still 13)'
+);
+
+select is(
+  (select count(*)::int from public.order_items
+   where submission_id = 'ee39aaaa-0000-0000-0000-000000000008'::uuid),
+  0,
+  'no order_items rows carry the rejected submission_id'
+);
+
+-- ============================================================
+-- 23–24. Reconciliation recomputes across the whole order on append:
+--        an oversold append (qty > 0 but insufficient) still goes
+--        through (DEC-012) and flips needs_reconciliation.
+-- ============================================================
+select lives_ok(
+  $$ select * from public.place_order(
+       'ee390000-0000-0000-0000-000000000001'::uuid,
+       '2026-06-01'::date,
+       'delivery', '123 Additive St', '', '', '',
+       jsonb_build_array(
+         jsonb_build_object(
+           'product_id',      'ee390000-0000-0000-0000-aaaa00000001'::text,
+           'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text,
+           'qty',             20,
+           'unit_price_cents', 500
+         )
+       ),
+       'ee39aaaa-0000-0000-0000-000000000009'::uuid
+     ) $$,
+  'oversold append (13 left, 20 ordered) is accepted (DEC-012)'
+);
+
+select is(
+  (select needs_reconciliation from public.orders
+   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+     and week_of = '2026-06-01'),
+  true,
+  'needs_reconciliation flipped true by the oversold append'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/place_order_additive.sql
+++ b/supabase/tests/place_order_additive.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(24);
+select plan(25);
 
 -- ============================================================
 -- #211 / DEC-039 — additive orders: place_order appends to the
@@ -22,6 +22,10 @@ select plan(24);
 insert into public.customers (id, name, token)
 values ('ee390000-0000-0000-0000-000000000001'::uuid, 'Additive Customer', 'token-additive-039');
 
+-- Second customer for the foreign-submission_id scoping check.
+insert into public.customers (id, name, token)
+values ('ee390000-0000-0000-0000-000000000002'::uuid, 'Other Customer', 'token-additive-039-b');
+
 -- DEC-037: unit rows are inserted explicitly (nothing spawns them).
 insert into public.products (id, name, qty_available, sort_order, category)
 values ('ee390000-0000-0000-0000-aaaa00000001'::uuid, 'Add Basil', 20.00, 1, 'Herbs');
@@ -30,6 +34,16 @@ insert into public.product_units (id, product_id, label, conversion_to_base, uni
 values ('ee390000-0000-0000-0000-bbbb00000001'::uuid,
         'ee390000-0000-0000-0000-aaaa00000001'::uuid,
         'bunch', 1, 500, true, 'add-basil-ee390000', 0);
+
+-- In-stock product for the foreign-submission_id scoping check (test 25 runs
+-- after Add Basil has been driven oversold-negative, so B needs its own stock).
+insert into public.products (id, name, qty_available, sort_order, category)
+values ('ee390000-0000-0000-0000-aaaa00000003'::uuid, 'Add Scope', 5.00, 3, 'Herbs');
+
+insert into public.product_units (id, product_id, label, conversion_to_base, unit_price_cents, is_active, slug, sort_order)
+values ('ee390000-0000-0000-0000-bbbb00000003'::uuid,
+        'ee390000-0000-0000-0000-aaaa00000003'::uuid,
+        'bunch', 1, 400, true, 'add-scope-ee390000', 0);
 
 -- Zero-stock product for the DEC-036-on-append cases.
 insert into public.products (id, name, qty_available, sort_order, category)
@@ -386,6 +400,32 @@ select is(
      and week_of = '2026-06-01'),
   true,
   'needs_reconciliation flipped true by the oversold append'
+);
+
+-- ============================================================
+-- 25. Foreign-submission_id scoping: customer B replaying customer A's
+--     submission_id must NOT resolve to A's order — the replay check is
+--     scoped to (customer, week), so B gets their own fresh order.
+-- ============================================================
+select isnt(
+  (select t.order_id from public.place_order(
+     'ee390000-0000-0000-0000-000000000002'::uuid,
+     '2026-06-01'::date,
+     'pickup', '', '', 'B pickup', '',
+     jsonb_build_array(
+       jsonb_build_object(
+         'product_id',      'ee390000-0000-0000-0000-aaaa00000003'::text,
+         'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000003'::text,
+         'qty',             1,
+         'unit_price_cents', 400
+       )
+     ),
+     'ee39aaaa-0000-0000-0000-000000000001'::uuid  -- A's submission_id
+   ) t),
+  (select id from public.orders
+    where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+      and week_of = '2026-06-01'),
+  'replaying another customer''s submission_id returns B''s own order, not A''s'
 );
 
 select * from finish();

--- a/supabase/tests/place_order_units.sql
+++ b/supabase/tests/place_order_units.sql
@@ -100,7 +100,11 @@ select is(
 
 -- ============================================================
 -- 5. Oversell-by-unit reconciliation. New customer + product so we get
---    a clean (customer, week) — place_order otherwise no-ops on conflict.
+--    a clean (customer, week) — under DEC-039 a second call for the same
+--    (customer, week) APPENDS to the existing order (the old on-conflict
+--    no-op is gone; the true no-op is a submission_id replay — see
+--    place_order_additive.sql), so isolation here comes from the fresh
+--    customer, not from place_order ignoring the call.
 -- ============================================================
 insert into public.customers (id, name, token)
 values ('dddd0000-0000-0000-0000-000000000002'::uuid, 'Oversell Customer', 'token-oversell-65d');

--- a/tests/customer-additional-orders.spec.ts
+++ b/tests/customer-additional-orders.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect, type Page } from "@playwright/test";
+import { weekOfMondayNY } from "@/lib/week";
+import {
+  TEST_CUSTOMERS,
+  TEST_PRODUCTS,
+  admin,
+  customerIds,
+  customerOrderUrl,
+  resetCustomerOrderState,
+  restoreProductQty,
+  seedOrder,
+  setAllProductsSoldOut,
+  setOrderingOpen,
+} from "./helpers";
+
+// #211 / DEC-039 — additive orders. A customer with an order for the current
+// week can append items to it via the /confirmed hub's "Add to your order"
+// button (→ /c/[token]?add=1, the form's ADD MODE). One orders row per
+// (customer, week) throughout; appends grow order_items.
+
+// Bumps the stepper on a named product to qty without relying on press-and-hold.
+async function stepUp(page: Page, productName: string, qty: number) {
+  const row = page.locator(".item-row", { hasText: productName });
+  for (let i = 0; i < qty; i++) {
+    await row.getByRole("button", { name: "increase" }).click();
+  }
+}
+
+test.describe("/c/[token] additional orders", () => {
+  test.beforeEach(async () => {
+    await resetCustomerOrderState();
+  });
+
+  test.afterAll(async () => {
+    await resetCustomerOrderState();
+  });
+
+  test("happy path: add via ?add=1 appends to the week's order — merged total, one orders row, inventory decremented", async ({
+    page,
+  }) => {
+    // Place the initial order through the real form (kale ×2, delivery).
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    await stepUp(page, TEST_PRODUCTS.kale.name, 2);
+    await page.locator(".submit-btn").click();
+    await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
+
+    // The hub offers the add entry point (store open, products orderable,
+    // order not terminal).
+    const addLink = page.getByRole("link", { name: "Add to your order" });
+    await expect(addLink).toBeVisible();
+    await addLink.click();
+    await page.waitForURL(/\/c\/[^/]+\?add=1$/);
+
+    // Add mode: fulfillment is read-only — no tabs, no editable preference.
+    await expect(page.locator(".fulfill-tabs")).toHaveCount(0);
+    await expect(page.locator("#delivery-pref")).toHaveCount(0);
+    await expect(page.locator(".fulfill")).toContainText("Text Annabel");
+
+    // Append eggs ×1 and submit.
+    await stepUp(page, TEST_PRODUCTS.eggs.name, 1);
+    const submit = page.locator(".submit-btn");
+    await expect(submit).toHaveText("Add to order");
+    await submit.click();
+    await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
+
+    // /confirmed shows the MERGED order: both lines, combined total
+    // (2×$3.00 kale + 1×$6.00 eggs = $12.00).
+    await expect(page.locator(".confirm-list")).toContainText(TEST_PRODUCTS.kale.name);
+    await expect(page.locator(".confirm-list")).toContainText(TEST_PRODUCTS.eggs.name);
+    await expect(page.locator(".confirm-total")).toContainText("12.00");
+
+    // DB: still exactly one orders row for (customer, week); two line items;
+    // inventory decremented for the appended line too.
+    const sb = admin();
+    const ids = await customerIds();
+    const { data: orders } = await sb
+      .from("orders")
+      .select("id, status")
+      .eq("customer_id", ids.farmStand)
+      .eq("week_of", weekOfMondayNY());
+    expect(orders).toHaveLength(1);
+
+    const { data: items } = await sb
+      .from("order_items")
+      .select("id, submission_id")
+      .eq("order_id", orders![0].id);
+    expect(items).toHaveLength(2);
+    // Both submissions carry their idempotency key (per-submission audit).
+    expect(items!.every((i) => i.submission_id !== null)).toBe(true);
+
+    const { data: eggs } = await sb
+      .from("products")
+      .select("qty_available")
+      .eq("id", TEST_PRODUCTS.eggs.id)
+      .single();
+    expect(eggs?.qty_available).toBe(TEST_PRODUCTS.eggs.qty_available - 1);
+  });
+
+  test("add mode shows the existing order's fulfillment read-only", async ({ page }) => {
+    const ids = await customerIds();
+    await seedOrder({
+      customerId: ids.farmStand,
+      weekOf: weekOfMondayNY(),
+      fulfillmentType: "delivery",
+      items: [{ productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 }],
+    });
+
+    await page.goto(`${customerOrderUrl(TEST_CUSTOMERS.farmStand.token)}?add=1`);
+    await expect(page.getByRole("heading", { name: "Going with your order" })).toBeVisible();
+    // seedOrder's delivery address, rendered as text — not an input.
+    await expect(page.locator(".fulfill .addr-text")).toHaveText("123 Test St");
+    await expect(page.locator(".fulfill-tabs")).toHaveCount(0);
+    await expect(page.locator("#delivery-pref")).toHaveCount(0);
+    await expect(page.locator("#pickup-note")).toHaveCount(0);
+    await expect(page.locator(".submit-btn")).toHaveText("Add to order");
+  });
+
+  test("hub gating: closed store hides the add button and explains why", async ({ page }) => {
+    const ids = await customerIds();
+    await seedOrder({
+      customerId: ids.farmStand,
+      weekOf: weekOfMondayNY(),
+      fulfillmentType: "delivery",
+      items: [{ productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 }],
+    });
+    try {
+      await setOrderingOpen(false);
+      await page.goto(`${customerOrderUrl(TEST_CUSTOMERS.farmStand.token)}/confirmed`);
+      await expect(page.getByRole("heading", { name: /Order received/i })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Add to your order" })).toHaveCount(0);
+      await expect(page.getByText("Ordering’s closed for this week.")).toBeVisible();
+    } finally {
+      await setOrderingOpen(true);
+    }
+  });
+
+  test("hub gating: nothing orderable hides the add button", async ({ page }) => {
+    const ids = await customerIds();
+    await seedOrder({
+      customerId: ids.farmStand,
+      weekOf: weekOfMondayNY(),
+      fulfillmentType: "delivery",
+      items: [{ productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 }],
+    });
+    const snapshot = await setAllProductsSoldOut();
+    try {
+      await page.goto(`${customerOrderUrl(TEST_CUSTOMERS.farmStand.token)}/confirmed`);
+      await expect(page.getByRole("heading", { name: /Order received/i })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Add to your order" })).toHaveCount(0);
+    } finally {
+      await restoreProductQty(snapshot);
+    }
+  });
+
+  test("hub gating: terminal order hides the add button; ?add=1 bounces back to /confirmed", async ({
+    page,
+  }) => {
+    const ids = await customerIds();
+    await seedOrder({
+      customerId: ids.farmStand,
+      weekOf: weekOfMondayNY(),
+      fulfillmentType: "pickup",
+      status: "picked-up",
+      items: [{ productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 }],
+    });
+
+    await page.goto(`${customerOrderUrl(TEST_CUSTOMERS.farmStand.token)}/confirmed`);
+    await expect(page.getByRole("heading", { name: /Order received/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Add to your order" })).toHaveCount(0);
+    await expect(page.getByText(/been packed/)).toBeVisible();
+
+    // A stale ?add=1 link can't reach the form against a fulfilled order —
+    // the page bounces it to /confirmed (where the reason copy lives).
+    await page.goto(`${customerOrderUrl(TEST_CUSTOMERS.farmStand.token)}?add=1`);
+    await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
+  });
+});

--- a/tests/customer-place-order.spec.ts
+++ b/tests/customer-place-order.spec.ts
@@ -181,9 +181,11 @@ test.describe("/c/[token] place order", () => {
     await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
 
     // The link is "your weekly order" — revisiting after submit must NOT
-    // re-show the empty form. The page-level redirect handles this; without
-    // it, a curious customer would see the form again and either re-tap
-    // (the RPC's ON CONFLICT catches that) or be confused.
+    // re-show the empty form (adding more goes through ?add=1, which is
+    // customer-additional-orders.spec.ts territory). DEC-039 note: a second
+    // submit with NEW items now APPENDS to the same order row rather than
+    // no-opping — the true no-op is a same-submission_id replay (covered in
+    // pgTAP place_order_additive.sql). Either way the row count below stays 1.
     await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
     await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
     await expect(
@@ -193,9 +195,10 @@ test.describe("/c/[token] place order", () => {
       TEST_PRODUCTS.kale.name,
     );
 
-    // And exactly one orders row exists for the current week — no duplicate.
-    // (Filtered to this week so the global-setup prior-order fixture
-    // doesn't inflate the count.)
+    // And exactly one orders row exists for the current week — DEC-039 keeps
+    // the unique (customer_id, week_of) constraint, so even appends never
+    // create a second row. (Filtered to this week so the global-setup
+    // prior-order fixture doesn't inflate the count.)
     const farmStandId = await getCustomerId(TEST_CUSTOMERS.farmStand.token);
     const sb = admin();
     const { data: orders } = await sb


### PR DESCRIPTION
## Summary
Additive orders (DEC-039, closes #211): a customer can submit **additional items** to their existing `(customer, week)` order while ordering is open. **Model B** — the `unique(customer_id, week_of)` constraint stays; a "second order" appends `order_items` to the week's single order. Built as one atomic feature (the migration is useless without the UI, so they ship together).

**How it works**
- New `order_items.submission_id` (client-generated UUID) replaces `place_order`'s on-conflict idempotency: a replayed submission returns the existing order with no double decrement, and the column doubles as a per-submission audit trail.
- Appends **inherit the existing fulfillment** (type/address/window) — shown read-only in add mode ("text Annabel to change," DEC-015). No second pickup/delivery event.
- An append **resets `confirmed`/`ready` → `new`** (re-enters Annabel's pipeline; stale SMS covered by Re-send) and is **refused when terminal** (picked-up/delivered — box already left).
- Customer entry point: **/confirmed becomes the hub** with an "Add to your order" button gated on store-open + something orderable + non-terminal. Add mode is reached via `/c/[token]?add=1`.

## Files changed
**8.A — DB / RPC**
- `supabase/migrations/20260612170000_place_order_additive.sql` — `order_items.submission_id` + index; `place_order` grows `p_submission_id`, returns `table(order_id, appended)`; replay short-circuit (scoped to customer+week) + **in-lock re-check** closing the create-vs-append race; terminal guard; status reset; notes concat; DEC-036 soldout reject preserved.
- `src/lib/supabase/types.ts` — regenerated.

**8.B — customer flow**
- `src/actions/place-order.ts` — mints the submission UUID, threads `appended` to the alert copy, maps the terminal-reject error.
- `src/lib/notifications/admin-alert-template.ts` — "items added" alert variant.
- `src/app/c/[token]/page.tsx` — `?add=1` renders add mode instead of the /confirmed bounce.
- `src/components/customer/OrderForm.tsx` — add mode (read-only fulfillment, "Add to order", new-items-only payload); submission-id lifecycle.
- `src/app/c/[token]/confirmed/page.tsx` — "Add to your order" hub, gated.
- `src/lib/customer/queries.ts`, `src/lib/admin/orders-queries.ts` — shared `anyOrderable` predicate + `isTerminalStatus` helper.

**Docs:** `docs/DECISIONS.md` — DEC-039.

## Code review
@code-review found a real concurrency bug — the replay guard ran outside the order-row lock, so two concurrent same-`submission_id` requests could both pass it (one creates, one appends) → double decrement. Fixed in `a893ba2`: an in-lock replay re-check after `FOR UPDATE` (the loser short-circuits on the winner's committed items), the replay lookup scoped to `(customer_id, week_of)` so a foreign submission_id can't resolve to another customer's order, the divergent `picked_up` underscore dropped, and the submission-id reset added at the cart-edit site. Added a pgTAP foreign-scoping case.

## Test plan
- [x] `npm run build` green.
- [x] `supabase db reset && supabase test db` → **162 pgTAP pass** (9 files). `place_order_additive.sql` (25 cases) covers append, replay-no-double-decrement, status reset, terminal-rejection-writes-nothing, soldout multi-line atomicity on the append path, and foreign-submission_id scoping.
- [x] Playwright desktop 10/10 + mobile @375px 5/5: add-via-`?add=1` happy path (merged total, one order row, inventory decremented), add-mode read-only fulfillment, hub gating (closed / nothing-orderable / terminal).
- **Preview validation (you):** place an order, then use "Add to your order" from /confirmed — confirm the merged total, that the order pops back to `new` in admin with an "items added" alert, and that a packed/terminal order refuses the add.

## Checklist
- [x] Migration: yes — adds `order_items.submission_id` + rewrites `place_order` (signature change).
- [x] RLS change: no (relies on existing policies; `security invoker`).
- [x] UI change at 375px: add-mode form + /confirmed hub button verified at mobile width.

## Notes
- One overlap with the open #217 (`product_units` only) when both merge: a trivial `DECISIONS.md` (DEC-038/039) + `types.ts` conflict — "Update branch" resolves it.
- 8.C (admin "items added" cue) deferred — the status-reset + Telegram alert already surface additions; fold in later only if Annabel misses one in practice.
