### PR TITLE
auto-sync downstream — 2026-06-13

### DIFF
--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: retro
-description: Phase-end retrospective. Closes the current phase. Under DEC-S013, retro is also where per-session time math runs — for every session in the phase window, it computes wall_clock and active time (active = wall_clock - breaks, breaks inferred from the transcript JSONL) from `started`, `ended`. Aggregates to one phase velocity: active h/pt. Marks PROJECT_PLAN.md `[x]`, reconciles drift, writes RETROSPECTIVES.md, runs version bumps (patch per merged PR + minor at phase close on dev projects), prompts retro notes. Optionally chains into `/start-phase`.
+description: Phase-end retrospective. Closes the current phase. Under DEC-S013 retro owns the phase velocity math; under DEC-S026 that math is throughput (points per calendar week) computed from GitHub issue `closedAt` dates + `points:N` labels, plus an estimate-calibration tally — no session transcript is read. Marks PROJECT_PLAN.md `[x]`, reconciles drift, writes RETROSPECTIVES.md, runs version bumps (patch per merged PR + minor at phase close on dev projects), prompts retro notes. Optionally chains into `/start-phase`.
 tools: Read, Edit, Write, Bash, Glob, Grep, Agent
 ---
 
 You are running the phase-end retrospective. Work for this phase is complete (or you've decided to call it done and move scope).
 
-Under DEC-S013, this skill **owns all per-session time math** that used to live in `/its-dead` and **all version bumps** that used to live in `/its-dead` (patch per merge) and `/retro` (minor at close). Session files are atomic event logs; retro is where they get turned into numbers.
+Under DEC-S013 this skill **owns the phase velocity math** that used to live in `/its-dead` and **all version bumps** (patch per merge + minor at close). Under DEC-S026 that velocity math is **throughput + estimate calibration**, computed from GitHub issue dates + `points:N` labels — the transcript-based `active = wall − breaks` model is retired. Session files are atomic event logs; GitHub is the velocity data source.
 
 ## Step 0 — Identify the current phase
 
@@ -32,61 +32,68 @@ For each open issue, ask the user: "Move to next phase, leave open, or close as 
 - **Leave open:** record in retro.
 - **Close as won't-do:** `gh issue close <N> --reason "not planned" --comment "Closed at Phase N retro — descoped."`
 
-## Step 2 — Per-session time math (DEC-S013 — moved from `/its-dead`)
+## Step 2 — Phase throughput + estimate calibration (DEC-S026 — replaces transcript-based time math)
 
-Find every session file in the phase window. Phase window = first issue's `createdAt` → last issue's `closedAt` (use `gh issue list --label "phase:<N>" --state all --json createdAt,closedAt`).
+DEC-S026 retired the `active = wall_clock − breaks` model. **No session transcript is read in this step.** Two numbers come out of it, both from data GitHub already holds: the phase's **throughput** (points per calendar week) and an **estimate-calibration tally** (did the points hold their value). Fleet validation showed solo phases are burst-shaped — most clear inside a single calendar week — so throughput is a coarse capacity signal, not a precise rate; the calibration tally is what keeps the point unit honest.
 
-For each session file in `.sessions-worktree/sessions/` whose `started:` falls within the phase window (or `started:` < phase_start AND `ended:` is within — span sessions count too):
+Phase window: `phase_first_created` = first issue's `createdAt`, `phase_last_closed` = last issue's `closedAt`.
 
-### Step 2.1 — Read frontmatter
-
-Parse `started`, `ended`, `pr_numbers`, `points`, `transcript` from the session file's YAML frontmatter. Required: `started`, `ended`. If `ended` is empty (session was abandoned or unclosed), skip with a note in the retro.
-
-### Step 2.2 — wall_clock
-
-`wall_clock = (ended − started) in hours, rounded to nearest 0.083h`. Always defined.
-
-### Step 2.3 — Break inference from transcript
-
-If `transcript` is set and the file is readable:
-1. Read the JSONL line by line; parse each line's `timestamp` field.
-2. Sort timestamps ascending.
-3. Walk pairwise. Any gap > 15 min counts as idle.
-4. Sum idle minutes within `[started, ended]` to get `total_breaks_hours`.
-
-If the transcript is unreadable or missing, set `total_breaks_hours = 0` and note `inference: transcript-unavailable` in the per-session line of the retro.
-
-### Step 2.4 — active_time (the headline number)
+### Step 2.1 — Phase points + dates (GitHub only)
 
 ```
-active_time = max(0, wall_clock - total_breaks_hours)
+gh issue list --label "phase:<N>" --state closed --json number,createdAt,closedAt,labels --limit 200
 ```
 
-Active time is wall-clock minus inferred idle — the time actually spent at the keyboard on this session's work. Round to nearest 0.083 h (5 min). This is the **single** velocity input. No PR timestamps are fetched; no time is split into "dev" vs "review."
+- `phase_points` = Σ of each closed issue's `points:M` label value. Issues with **no** `points:` label are skipped — list them in the retro so they're visible; never guess a value.
+- `phase_first_created` = min `createdAt`; `phase_last_closed` = max `closedAt`; `phase_span_days = (phase_last_closed − phase_first_created)` in days.
 
-**Why there is no dev/review split anymore (retiring the DEC-S015 per-PR window model).** Through Phase 7 the retro also computed `dev_time` and `review_time` via per-PR windows. That math is retired. It assumed each PR was merged before the next opened, but the actual workflow opens PRs in a burst and merges them whenever ("merge PRs whenever — order doesn't matter" — CLAUDE.md). Under that real pattern the per-PR anchors collapse: `dev_time` falls to a fictional ~0.03–0.09 h/pt and the overlapping review windows sum past wall-clock (a real case: Session 25 reported 26.8h of "review" inside a 9.2h session — physically impossible). Every retro since Phase 3 footnoted the split as untrustworthy and forecast on active anyway. So we keep the number that was always the headline and drop the two that were always disclaimed. There is no cheap fix for the split — correctly attributing per-task time would require reconstructing keystroke spans from the transcript, which is exactly what `active = wall - breaks` already approximates.
+This keys the phase to issues, not PRs — robust to merging PRs in any order (DEC-S022). **Never re-pair PR-open → PR-merge to recover "effort"** — that window math is the exact bug DEC-S024 died on. Dates are not windows.
 
-### Step 2.5 — Per-session line for the retro
-
-Build one row per session for the RETROSPECTIVES.md table:
+### Step 2.2 — Throughput (the headline)
 
 ```
-| Session N | YYYY-MM-DD | wall_clock | breaks | active | points | PRs |
+phase_calendar_weeks = phase_span_days / 7
+throughput           = phase_points / phase_calendar_weeks    # points per calendar week
 ```
 
-Hold these numbers — they get summed in Step 3. (`PRs` is just the `pr_numbers` list from frontmatter, for reference — no timestamps.)
+- **If `phase_span_days < 7`** (phase opened and closed inside one week — a *burst* phase): do **not** quote a per-week rate. A sub-week denominator explodes it into nonsense (a phase done in an afternoon reads as hundreds of pts/wk). Record `throughput: burst (<7d) — <phase_points> pts over <phase_span_days>d` instead. Most solo phases land here; the point total + span is the honest record.
+- **Companion (optional):** `active_weeks` = ISO weeks in the span containing ≥1 close; `active_throughput = phase_points / active_weeks` = intensity when actually shipping (strips idle/off weeks).
+
+Throughput is capacity **including availability** — a slow week and an off week look identical. Correct for "when does the *next* phase ship," wrong for "at-keyboard speed." Never quote it as the latter. It is an active-time rate; a calendar forecast = throughput ÷ your real availability, which only you know.
+
+### Step 2.3 — wall_clock (gut-check only — NOT a velocity)
+
+`/its-dead` already displayed each session's `wall_clock = ended − started` on-screen as a sanity gut-check. That is its only role. **It is not aggregated, not divided by points, and not quoted as a velocity** — `wall_clock / point` is the number the guide forbids (it carries overnight gaps and idle). No transcript is read; no breaks are inferred; there is no `active_time`. (This is the DEC-S024 model being retired — see DEC-S026.)
+
+### Step 2.4 — Estimate-calibration tally
+
+Throughput alone rots: if points quietly shrink, "throughput" rises while nothing actually got faster. This tally is the guard, and it replaces the old per-session h/pt spread as the estimate-health signal.
+
+From PROJECT_PLAN.md's estimate column + this phase's session notes:
+- `re_estimated` = count of tasks whose points changed between original estimate and final (re-pointed mid-flight).
+- `net_drift` = Σ(final points) − Σ(original points). Positive = tasks ran bigger than pointed (under-estimating); negative = smaller.
+
+Record `re-estimated: <K> tasks, net drift: <±D> pts`. A stable point unit shows few re-estimates and near-zero net drift. Persistent positive drift = under-pointing; persistent **shrink alongside rising throughput** = point inflation — the failure mode throughput can't see on its own.
+
+### Step 2.5 — Per-phase line for the retro
+
+One phase row (there is no longer a per-session time table — the transcript that fed it is gone):
+
+```
+| Phase N | <phase_last_closed date> | <points> | <span_days>d | <throughput or "burst"> | <re_estimated> | <net_drift> | <sessions> | <PRs> |
+```
+
+`sessions` = count of session files in the window (reference only); `PRs` = merged PRs in the window. Hold these for Step 3.
 
 ## Step 3 — Phase metrics
 
-Sum the per-session numbers:
-- `phase_wall_clock` = Σ wall_clock
-- `phase_breaks` = Σ breaks
-- `phase_active` = Σ active   (= `phase_wall_clock - phase_breaks`)
-- `phase_points` = Σ points (also confirm against `points:N` label sum from closed issues — flag mismatch)
-- `phase_sessions` = count
+From Step 2:
+- `phase_points` — Σ `points:N` on closed phase issues (cross-check against PROJECT_PLAN's estimate column; flag mismatch).
+- `throughput` — points per calendar week (or `burst` for sub-week phases). **The headline** — but never reported without the calibration tally beside it.
+- `re_estimated` + `net_drift` — the estimate-calibration tally.
+- `phase_sessions` = session-file count in the window; `phase_prs` = merged PRs in the window.
 
-One velocity:
-- `active / point` — active hours per effort point. **This is the headline and the only number to forecast on.** `wall_clock` is kept as raw bookkeeping (it carries overnight gaps and idle), but `wall_clock / point` is not a velocity — don't quote it as one.
+There is no `active`, no `breaks`, no `dev_time`/`review_time`, and no `h/pt` — all retired by DEC-S026.
 
 ## Step 4 — Update PROJECT_PLAN.md
 
@@ -97,14 +104,14 @@ Mark all closed phase tasks `[x]`. For each row:
 
 Reconcile drift: issues with `phase:<N>` labels that don't appear in PROJECT_PLAN.md (added mid-phase). Add rows with status `[x] [#N](url)` and inline note `Added during P<N> retro`.
 
-Update the velocity table at the top:
+Update the velocity table at the top (DEC-S026 columns):
 ```
-| Phase | Sessions | Points | Wall (h) | Breaks (h) | Active (h) | h/pt (active) |
-|-------|----------|--------|----------|------------|------------|---------------|
-| N     | <count>  | <pts>  | <wall>   | <breaks>   | <active>   | <active_pt>   |
+| Phase | Points | Span (d) | Throughput | Re-est'd | Net drift | Sessions |
+|-------|--------|----------|------------|----------|-----------|----------|
+| N     | <pts>  | <days>   | <pts/wk or burst> | <K> | <±D> | <count> |
 ```
 
-Append one row per phase as they complete.
+Append one row per phase as they complete. **Don't rewrite history:** phases closed before DEC-S026 carry the retired `Wall / Breaks / Active / h-pt` columns — leave those rows as written and note the metric change inline (the full table migration is a separate deferred task).
 
 ## Step 5 — Prompt retro notes
 
@@ -115,7 +122,7 @@ Ask three questions, one at a time, capture verbatim:
 
 ## Step 5.5 — PM retro commentary
 
-Invoke `@pm` (Sonnet) with the full retro context: phase number + name, metrics from Step 3, user's verbatim answers, the per-session table from Step 2.6, closed-issue list with descoped/moved notes, and `docs/RETROSPECTIVES.md` for cross-phase comparison. Let `@pm` read the session files themselves for in-the-trenches detail.
+Invoke `@pm` (Sonnet) with the full retro context: phase number + name, metrics from Step 3 (throughput + calibration tally), user's verbatim answers, the phase line from Step 2.5, closed-issue list with descoped/moved notes, and `docs/RETROSPECTIVES.md` for cross-phase comparison. Let `@pm` read the session files themselves for in-the-trenches detail.
 
 `@pm` returns 3–5 short paragraphs on pace, scope, patterns, a reaction to the user's answers (not a paraphrase), and a forward-looking note.
 
@@ -137,18 +144,17 @@ Read `docs/RETROSPECTIVES.md` first (Edit requires a prior Read). If it doesn't 
 ```
 ## Phase <N> — <YYYY-MM-DD>
 
-**Sessions:** <count>
 **Points:** <points completed> / <planned> (<%>)
-**Wall clock:** <wall>h  (raw elapsed — includes overnight + idle)
-**Breaks:** <breaks>h
-**Active time (wall - breaks):** <active>h ← honest headline
-**Velocity:** <active/pt> h/pt active  ← the only forecast number
+**Span:** <span_days> days (<first_created> → <last_closed>)
+**Throughput:** <pts/wk> pts/calendar-week  ← headline (or: `burst — <pts> pts in <days>d` for sub-week phases)
+**Estimate calibration:** <K> tasks re-estimated, net drift <±D> pts  ← keeps the point unit honest
+**Sessions:** <count>   **PRs merged:** <count>
 **Issues:** <created> created, <closed> closed, <moved> moved to Phase <N+1>
 
-### Per-session breakdown
-| Session | Date | Wall | Breaks | Active | Points | PRs |
-|---------|------|------|--------|--------|--------|-----|
-| <row>   | ...  | ...  | ...    | ...    | ...    | ... |
+### Phase throughput line
+| Phase | Date | Points | Span(d) | Throughput | Re-est'd | Net drift | Sessions | PRs |
+|-------|------|--------|---------|------------|----------|-----------|----------|-----|
+| <row> | ...  | ...    | ...     | ...        | ...      | ...       | ...      | ... |
 
 ### What worked
 - <verbatim>
@@ -172,7 +178,7 @@ Session files were already finalized by `/its-dead` and are not modified by this
 
 ```
 git add docs/PROJECT_PLAN.md docs/RETROSPECTIVES.md
-git commit -m "Phase <N> retro — <points> pts in <active>h active (<active/pt> h/pt)"
+git commit -m "Phase <N> retro — <points> pts, throughput <pts/wk or burst>, drift <±D>"
 git push origin <BRANCH>
 ```
 
@@ -226,7 +232,7 @@ a. `NEW_VERSION=$(npm version minor --no-git-tag-version | tr -d 'v')` — zeros
 b. CHANGELOG entry:
    ```
    ## [<NEW_VERSION>] - <YYYY-MM-DD> — Phase <N>
-   - <points> pts shipped across <session count> sessions (<active/pt> h/pt active)
+   - <points> pts shipped across <session count> sessions (throughput <pts/wk or burst>)
    - See `docs/RETROSPECTIVES.md` for the full retro
    ```
 
@@ -255,8 +261,8 @@ Echo: `Phase <N> closed at v<NEW_VERSION>` (and `tagged` if main).
 
 ```
 Phase <N> closed.
-Points: <P> in <active>h active time (<active/pt> h/pt)
-Wall: <wall>h | Breaks: <breaks>h | Sessions: <count>
+Points: <P> | Throughput: <pts/wk or burst> | Calibration: <K> re-est'd, <±D> drift
+Span: <days>d | Sessions: <count> | PRs merged: <count>
 Issues: <closed>/<created> closed; <moved> moved to Phase <N+1>
 Retro: docs/RETROSPECTIVES.md
 Version: v<NEW_VERSION>  (dev projects only; skipped if no package.json)
@@ -265,6 +271,7 @@ Version: v<NEW_VERSION>  (dev projects only; skipped if no package.json)
 ## Notes
 
 - **Session files are read-only here.** Retro reads them; never writes. DEC-S013 atomicity.
-- **GitHub queries can fail.** Time math no longer touches GitHub at all — active time comes from the session file + transcript. `gh` is only used for issue accounting (Steps 1 and 3's points cross-check) and version bumps (Step 8). If it's down, skip those, note it, and let the user rerun. Don't guess.
-- **The headline velocity is `active / point`, and it's the only one.** `active = wall_clock - breaks`. Wall-clock velocity is inflated by overnight gaps and idle — don't quote `wall / point` as a velocity. There is no `dev_time` or `review_time` (retired — see Step 2.4).
-- **Old retros carry dead columns.** Phase retros written under the per-PR model have `Dev` / `Review` columns and a dev/review velocity, all artifacts — the `Active` figure in those same retros was always the real headline. Phases that predate active time have only a legacy `Velocity: X hrs/pt` and no active number; **don't blend those with active h/pt** — they're a different, older metric (the standalone velocity extractor handles this split for you).
+- **No transcript is read anywhere.** DEC-S026 retired break inference and `active = wall − breaks` — the model whose `breaks = 0 → active = wall_clock` fallback was the bug that triggered the change.
+- **GitHub IS the velocity data source now.** Step 2 reads issue `createdAt`/`closedAt` + `points:N` labels — that's the throughput input. `gh` is also used for issue accounting (Step 1), the points cross-check (Step 3), and version bumps (Step 8). If `gh` is down, Step 2 can't compute throughput; note it and let the user rerun. Don't guess.
+- **The headline is throughput (points / calendar week), never reported without the calibration tally.** There is no `active`, `wall/pt`, `dev_time`, or `review_time` — all retired by DEC-S026. `wall_clock` survives only as the `/its-dead` on-screen gut-check.
+- **Old retros carry retired columns.** Phases closed before DEC-S026 carry `Wall / Breaks / Active / h-pt` (or older `Dev / Review`) columns and an h/pt velocity — all retired, all on a different denominator. **Don't blend them with throughput.** History stays as written (DEC-S024 precedent); the standalone extractor `dev/claude/scripts/throughput.py` recomputes throughput straight from GitHub and is independent of any old retro prose.

--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -1,4 +1,4 @@
-SEEDS WORKFLOW CHEATSHEET                                v2026-05-05
+SEEDS WORKFLOW CHEATSHEET                                v2026-06-12
 
   /its-alive  ->  [ work ]  ->  /kill-this  ->  /its-dead
                      ^                              v
@@ -11,14 +11,14 @@ SESSION
   /pause-this      walking away. build check + WIP commit.
   /restart-this    resume from /pause-this. reloads context.
   /kill-this       end pt 1. build + commit + PR + @code-review.
-  /its-dead        end pt 2. duration + points + finalize file.
-                   arg: "subtract 30 minutes for lunch"
+  /its-dead        end pt 2. stamps ended, tallies points,
+                   shows wall_clock gut-check, finalizes file.
 
 PHASE
   /start-phase     materialize current phase as Issues
                    ( phase:N + points:X labels )
   /retro           close phase. mark [x], reconcile drift,
-                   compute velocity, write retro, bump minor.
+                   compute throughput, write retro, bump minor.
 
 SEMVER  ( dev projects only — needs package.json )
   /bump-major      breaking change. manual. tag on main.

--- a/docs/VELOCITY_AND_POKER_GUIDE.md
+++ b/docs/VELOCITY_AND_POKER_GUIDE.md
@@ -6,39 +6,54 @@ A lightweight solo-dev process for tracking effort, estimating work, and knowing
 
 ## Part 1: Velocity Tracking
 
+> **The quick version** — how to *read* the numbers, with worked examples — lives in [`THROUGHPUT_QUICKREF.md`](THROUGHPUT_QUICKREF.md). This part is the *why*. The full decision record is DEC-S026 in `DECISIONS.md`.
+
 ### What it measures
 
-**Velocity = active hours per effort point (active h/pt).** Active time is wall-clock minus idle: `active = wall_clock - breaks`. Lower is faster. It's the time you were actually at the keyboard on the work — and it's the only velocity number you forecast on.
+**Velocity = throughput: effort points shipped per calendar week.** Higher is faster. It's read straight from GitHub — issue `closedAt` dates + `points:N` labels — so it measures the rate at which work *clears the board*, not hours at the keyboard.
+
+Two lifetime rates come out of it:
+- **points / calendar-week** — realized pace, *including* idle weeks. This is your honest clearance rate.
+- **points / active-week** — intensity in the weeks you actually shipped something.
+
+This is the metric *after* three failed attempts (DEC-S013 → S015 → S024) to measure "active hours per point" by reconstructing keyboard time from the session transcript. That metric is **retired** — the transcript lives on an unreachable path for nearly every web/Desktop session, so the number rotted by default. For a solo + Claude shop the insight was that effort-hours aren't even the scarce quantity: Claude does the labor, so what you actually care about is *calendar clearance rate* and *estimate stability*. Both are measurable from GitHub forever. (Full autopsy: DEC-S026.)
 
 ### Where it comes from — you don't log anything
 
-There is no tracker to maintain and no "log your hours" step. The numbers are extracted after the fact from data you keep anyway:
+There is no tracker to maintain and no "log your hours" step — same promise as before, now actually kept, because the inputs are data GitHub holds whether you think about it or not:
 
-- Each session file records `started` and `ended` (stamped by `/its-alive` and `/its-dead`) plus the path to its transcript.
-- `/retro` does the math at phase close: `wall_clock = ended - started`; `breaks` = idle gaps > 15 min inferred from the transcript; `active = wall_clock - breaks`; `active / points` = the velocity.
-- Results land in two places: **`docs/RETROSPECTIVES.md`** (the source of truth — one block per phase, carrying the raw active hours + points so the number is always recomputable) and the **velocity table at the top of `docs/PROJECT_PLAN.md`** (an at-a-glance mirror).
+- Every task is a GitHub Issue with a `points:N` label (added by `/start-phase`) and a `closedAt` date (stamped when its PR merges). That's the entire dataset.
+- `/retro` does the math at phase close: it groups closed issues by phase, sums points, and divides by the calendar span — no session file, no transcript, no `started`/`ended` arithmetic.
+- The **source of truth is GitHub itself.** RETROSPECTIVES.md and the PROJECT_PLAN.md table are now *mirrors* of a number that's always recomputable from issue dates + labels — they can't drift the headline, because the headline isn't stored in them.
 
-If a number ever feels off, it's recomputable from `started`/`ended` + the transcript. Nothing depends on you remembering to write hours down — that's the whole point. The moment velocity becomes a logging chore it gets abandoned; here it's a read, not a chore.
+The one thing that makes a project invisible: no `points:N` labels. Throughput reaches back exactly as far as the labelling ritual and no further — a project from before you labelled issues returns nothing (same blind spot the old metric had).
 
 ### Your overall number, and across projects
 
-For one phase, read RETROSPECTIVES.md. For your lifetime number — or a combined number across several repos — run the **velocity extractor** (`dev/claude/scripts/velocity.py`): it reads points off closed issues + active hours out of each repo's retros and prints lifetime active h/pt, a per-phase breakdown, and how much your per-session pace scatters.
+For your lifetime number — or a combined number across several repos — run the **throughput extractor** (`dev/claude/scripts/throughput.py`), pointing it at one or more project paths:
 
-**Do not average the per-phase h/pt numbers.** Correct overall velocity is `Σ active-hours ÷ Σ points`, not the mean of each phase's ratio — averaging ratios silently overweights small phases. The extractor sums them properly. Grep for a quick eyeball; run the extractor for the real number.
+```bash
+python3 dev/claude/scripts/throughput.py ~/bushel
+python3 dev/claude/scripts/throughput.py ~/bushel ~/muster ~/helm   # cross-repo rollup
+python3 dev/claude/scripts/throughput.py --issues ~/bushel          # + points histogram
+```
+
+It reads GitHub directly (needs `gh` installed and authed): points off closed issues, dates off the issues and merged PRs. It prints the two lifetime rates, a per-phase breakdown with pointing-stability and span, and PR merge latency. A project with no `points:N`-labelled closed issues prints "nothing to measure" — not an error, just a project that predates the ritual.
 
 ### Reading the numbers
 
-- **`active / point` is the forecast number.** That's it. `wall_clock` is kept as raw bookkeeping (it includes overnight gaps and idle), but `wall / point` is *not* a velocity — don't quote it as one.
-- **Ignore `Dev` / `Review` columns in older retros.** They came from a retired per-PR split that mis-attributed time on multi-PR sessions (it once reported more "review" hours than the session was even long). The `Active` figure in those same retros was always the real headline.
-- **Velocity is project-shape-specific.** A Supabase CRUD app and an agent pipeline have very different active h/pt. Don't forecast one from the other's history.
-- **Use the ramp, not your best-ever.** Early phases on a new project run high (dialing in the workflow) and settle later; a new project starts at the high end again, so quote the early band, not your record phase. (Phases predating the active-time model carry only a legacy `Velocity: X hrs/pt` — a different, older metric; don't blend it with active h/pt.)
+- **Throughput is an active-time rate, not a calendar date.** A slow week and a vacation week look identical to it. To forecast "when does it ship," divide remaining points by *your* real availability — the tool measures the work, you supply the calendar. Never quote it as at-keyboard speed.
+- **Pointing stability (`pts/issue`) is the estimate-calibration signal.** The per-phase breakdown prints a `tight` / `drifting` verdict on how consistent your `pts/issue` is. Tight = your estimates hold their value over time; drifting = scope is growing or points are inflating. This is the number to watch, and the one the old metric was secretly also trying to measure.
+- **Per-phase `pts/wk` only appears for phases spanning ≥7 days.** A phase you closed in an afternoon has no meaningful weekly rate — it's recorded as `burst — N pts over Dd` instead. Dividing points by a sub-week denominator produces nonsense (one project showed 516 pts/wk off a single 1-pointer).
+- **PR merge latency is flow-health, NOT effort.** The extractor reports median + p85 hours from PR-open to merge. That answers "do my PRs sit unmerged?" — it does **not** scale with task size (the PR opens *after* the build is done, so it can't see build time; it comes back flat across 2/3/5-pointers by design). Read it as "is the pipe clogged," nothing more.
+- **Throughput is even more project-shape-specific than the old metric.** Never forecast a new project from another's throughput — project shapes differ too much. The number describes the project you ran it on, full stop. (Historical phases closed under the retired model keep their old columns; `throughput.py` recomputes from GitHub independently, so history needs no backfill.)
 
 ### Rules of thumb
 
-- **It only works if your pointing is consistent.** Velocity is a conversion factor between your estimate and clock time; if you point the same task a 3 on Tuesday and an 8 on Friday, velocity is measuring estimation noise, not speed. Consistent-but-biased pointing is fine — the bias is in both the history and the forecast, so it cancels. Random pointing is not. The extractor's per-session h/pt spread is the test: tight = your pointing holds; scattered = it doesn't.
+- **It only works if your pointing is consistent.** Throughput converts your estimate into a clearance rate; if you point the same task a 3 on Tuesday and an 8 on Friday, the rate measures estimation noise, not speed. Consistent-but-biased pointing is fine — the bias is in both the history and the forecast, so it cancels. Random pointing is not. The `pts/issue` stability verdict is the test: tight = your pointing holds; drifting = it doesn't.
+- **It's coarse — treat it as ±50%.** Solo work is bursty (every project in the fleet has been a 1–6 week sprint, then done). Read the headline as a band ("ships in ~5–8 weeks"), never a precise date.
 - **Don't fudge.** The point is accurate forecasting, not looking fast.
 - **Re-estimate when surprised** — if a 3 turns into an 8, update the plan. That's data, not failure.
-- **Velocity stabilizes after ~10 sessions.** Before that, take projections with a grain of salt.
 
 ---
 
@@ -101,16 +116,16 @@ Claude: "Agreed — 8. I'll note the merge complexity in the task description."
 
 ### Rhythm
 
-**Per session:** run `/its-alive` at the start and `/its-dead` at the end. That's the entire time-tracking obligation — those two stamps plus the transcript are everything `/retro` needs. No timer, no logging.
+**Per phase start:** run `/start-phase`. It turns the phase's tasks into GitHub Issues with `points:N` labels — which *is* the throughput dataset. No labels, no velocity, so this is the step that matters.
 
-**Per phase boundary:** run `/retro`. It computes the per-session and phase active h/pt, writes RETROSPECTIVES.md, and updates the PROJECT_PLAN.md velocity table. If you're starting a new phase, do estimation poker (Part 2) on its tasks.
+**Per phase boundary:** run `/retro`. It computes the phase throughput + the pointing-stability tally off GitHub issue dates and labels, writes RETROSPECTIVES.md, and updates the PROJECT_PLAN.md velocity table. If you're starting a new phase, do estimation poker (Part 2) on its tasks.
 
-**When you want the big picture:** run the velocity extractor (Part 1) for your lifetime or cross-repo number. Check it against your remaining points — if projected active hours exceed the time you've got before a deadline, cut scope (PROJECT_PLAN.md has a cuttable-tasks list). The number doesn't lie.
+**When you want the big picture:** run the throughput extractor (Part 1) for your lifetime or cross-repo number. Check remaining points against *your* available calendar time — throughput is a clearance rate, not a date, so you supply the availability. If the work won't fit before a deadline, cut scope (PROJECT_PLAN.md has a cuttable-tasks list).
 
 ### Cross-project tracking
 
-Each project keeps its own RETROSPECTIVES.md and PROJECT_PLAN.md velocity table. Velocity is per-project and per-shape — don't average a CRUD app against an agent pipeline. When you want a combined view, the extractor takes multiple repo paths and reports each repo plus the properly-summed total (`Σ active ÷ Σ points`).
+Each project's throughput is read from its own GitHub issues. Throughput is per-project and per-shape — don't average a CRUD app against an agent pipeline. When you want a combined view, the extractor takes multiple repo paths and reports each repo plus the rollup.
 
 ### The one thing that matters
 
-**Point consistently and run the two stamps.** Everything downstream — the per-phase velocity, the forecasts, the cross-repo rollup — is recomputed from `started`/`ended` + the transcript, so there's nothing to log and nothing to forget. The only input that can quietly poison the number is inconsistent pointing, because velocity can't tell "I got slower" from "I pointed it lower." Keep your pointing honest and the system does the rest.
+**Point consistently and label every issue.** Everything downstream — the per-phase throughput, the forecasts, the cross-repo rollup — is recomputed from GitHub issue dates + `points:N` labels, so there's nothing to log and nothing to forget. The only input that can quietly poison the number is inconsistent pointing, because throughput can't tell "I got slower" from "I pointed it lower." Keep your pointing honest and the system does the rest.


### PR DESCRIPTION
Base: main
Source: seeds@cfc54da

## Step 3 — Classification (action rows only)

| File | Hunk | Provenance | Classification | Action |
|------|------|------------|----------------|--------|
| `.claude/skills/retro/SKILL.md` | hash mismatch | Class: logic | Forward-port | logic-drift — full-file overwrite from seeds |
| `docs/CHEATSHEET.md` | version stamp v2026-05-05 → v2026-06-12 | Template-only | Forward-port | Forward-ported |
| `docs/CHEATSHEET.md` | `/its-dead` description revised (drops obsolete `subtract` arg, adds wall_clock gut-check line) | Template-only | Forward-port | Forward-ported |
| `docs/CHEATSHEET.md` | `/retro` line: "compute velocity" → "compute throughput" (DEC-S026) | Template-only | Forward-port | Forward-ported |
| `docs/VELOCITY_AND_POKER_GUIDE.md` | Part 1 (Velocity Tracking) rewritten — active h/pt → throughput (pts/calendar-week) per DEC-S026; adds quick-version pointer, throughput extractor script ref, pts/issue stability verdict, PR merge latency caveat | Template-only | Forward-port | Forward-ported |
| `docs/VELOCITY_AND_POKER_GUIDE.md` | Rhythm + Cross-project + final paragraph updated to throughput vocabulary | Template-only | Forward-port | Forward-ported |

## Files changed

- `.claude/skills/retro/SKILL.md`
- `docs/CHEATSHEET.md`
- `docs/VELOCITY_AND_POKER_GUIDE.md`

## Pattern flags

None.

## Step 6 — Skip summary

- Skipped (logic, hash-equal, 14 files) — `agents/sync-config`, `agents/tape-reader`, and 12 skills (`bump-major`, `doc-consistency-check`, `its-alive`, `its-dead`, `kill-this`, `pause-this`, `promote-production`, `pull-seeds`, `push-seeds`, `read-the-tape`, `restart-this`, `start-phase`).
- Skipped (hybrid, equal under whitespace-ignore, 6 files): `agents/architect.md`, `agents/code-review.md`, `agents/pm.md`, `agents/doc-consistency.md`, `CLAUDE.md`, `docs/AGENTS.md`.
- Skipped (hybrid Project-only, PULL preserves project substitutions, 1 file): `agents/ui-reviewer.md` — 4 hunks substituting `[Project]` → `bushel` and the generic description with a bushel-specific one. Project-side concretions preserved.
- Skipped (class:context, 6 files): `docs/SPEC.md`, `docs/BRAND.md`, `docs/DECISIONS.md`, `docs/PROJECT_PLAN.md`, `docs/RETROSPECTIVES.md`, `docs/USER_STORIES.md` — context-class per file-class registry.
- Project-type gating: bushel is `webapp` — no files dropped (manifest gates only `agents/ui-reviewer.md` to `webapp`, which is in-scope here).
- Already-proposed check: open PR #218 (additive orders feature) does not touch any synced files. No duplicates.

## Operational notes

- Logic-drift on `skills/retro/SKILL.md` reflects DEC-S026's throughput model — the same change that drove the `docs/CHEATSHEET.md` and `docs/VELOCITY_AND_POKER_GUIDE.md` forward-ports. Bushel's `docs/PROJECT_PLAN.md` and historical retros still use the old `active h/pt` vocabulary; those are context-class (project-owned history) and intentionally left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1aGajuSKcaE5LwZrr5vCm)_