### PR TITLE
Phase 9 setup: open-order pivot — DEC-040–045 + plan + issues

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -466,6 +466,78 @@ PWA push notification remains the stretch upgrade per DEC-027's framing.
 
 ---
 
+## DEC-040 — Store is always-open; scheduled-close cron disabled (amends DEC-030)
+
+**Decision:** `ordering_schedule.is_open` is operated **only** by the manual `toggleOrdering` button. The scheduled-close cron is **disabled** — the `crons` entry is removed from `vercel.json` so `/api/cron/check-schedule` never fires. The machinery (`save-schedule.ts`, the cron route, `SettingsScheduleCard`, and the `weekly_*` / `override_closes_at` columns) is **left in place, dormant** — removable anytime.
+
+**Why:** The farm wants continuous open, closed only by deliberate action. The cron is the *only* schedule-driven writer of `is_open` (the order page treats `is_open` as a soft UI hint; `toggle-ordering.ts` is the only other writer), so disabling it makes open/closed a manual-only decision and neutralizes the cron's UTC `getDay()`/`getHours()` timezone-edge bugs — without ripping out code.
+
+**Revised from the planning memo:** the original DEC-040 proposed *deleting* the machinery + dropping 5 schedule columns. Softened to disable-the-cron — it's built and harmless, removal can happen later. Saves a migration.
+
+**Accepted limitation:** `SettingsScheduleCard` stays settable but inert (no cron acts on a set schedule). Harmless; hiding it is deferred to whenever the machinery is fully removed.
+
+**Supersedes (DEC-030):** "scheduled close opt-in" — there is no scheduled close now, only the manual toggle.
+
+---
+
+## DEC-041 — Order identity is the open order, not the week
+
+**Decision:** Replace `orders`' `UNIQUE (customer_id, week_of)` with a **partial unique index**:
+
+```sql
+CREATE UNIQUE INDEX orders_one_open_per_customer
+  ON public.orders (customer_id)
+  WHERE status IN ('new', 'confirmed', 'ready');
+```
+
+A customer has at most one **non-terminal** order; fulfilled orders (`picked_up`/`delivered`) drop out, freeing a new one. `week_of` is **demoted to an informational stamp** — still set at insert, still feeds the fulfillment sheet + Wave export, no longer identity. `place_order`'s find-existing clause (from #218/DEC-039) re-keys week → open-status; the `submission_id` replay guard is untouched.
+
+**Why:** "Always open + edit until fulfilled + new one after" is exactly "one row per (customer, non-terminal-status)." Postgres expresses it natively; no `week_of` arithmetic in the hot path. Demoting rather than dropping `week_of` keeps the weekly reports working.
+
+**The RPC re-key is NOT a one-clause change.** `week_of` is load-bearing in four spots in #218's `place_order`: the `ON CONFLICT` arbiter (must infer the partial index — the concurrency linchpin), the `FOR UPDATE` existing-order lock, the outside-lock replay join, and the in-lock re-check (order-keyed, fine). Three are concurrency-critical; sized 5pt accordingly (architect pass, 2026-06-22).
+
+**Cutover (hard cutover):** at go-live, wipe `orders` / `order_items` / `customer_sends`; keep `products` / `product_units` / `customers`. No history, no backfill. The old `UNIQUE (customer_id, week_of)` is dropped **in** the cutover, **not deferred** — it cannot coexist with the partial index through live traffic (it forbids the very second-same-week order the index allows). A brief quiet-minute outage is accepted.
+
+---
+
+## DEC-042 — Open-order edits: additive, terminal-only lock; send-state stays weekly
+
+**Decision:** Adopt #218's append semantics unchanged. A customer may append items to a non-terminal order (`new`/`confirmed`/`ready`); appending a `confirmed`/`ready` order resets it to `new` and re-enters the send pipeline (existing Re-send covers the stale SMS); appending a terminal order is refused server-side. Editing is **add/increase only** — no removal or decrease ("remove an item" = text Annabel, DEC-015).
+
+**Why:** Add-only keeps the `qty_available` decrement monotonic; allowing removal means re-incrementing, which races other carts and reopens the DEC-012 oversell window from the wrong side. The earlier "lock at `ready`" idea is dropped for #218's already-UAT'd through-`ready` behavior — a stray late append is a text-Annabel fix.
+
+**Send-state stays week-keyed (decided against re-keying).** `customer_sends` keeps PK `(customer_id, week_of, mode)`. Considered re-keying to `(order_id, mode)` to handle a same-week re-order after fulfillment, but **rejected**: the weekly blast (`weekly_update`) is sent *before* any order exists, so order-keying it is wrong, and a habitual always-has-an-open-order customer would be mishandled. The weekly reset is the correct operator model — Annabel sends once a week. **Accepted limitation:** in the rare case a customer is fulfilled mid-week and re-orders before the Sunday reset, their second order inherits the first's send-state (no re-send nudge) — the same text-Annabel escape hatch.
+
+---
+
+## DEC-043 — Per-unit editable SKU; `description` leaves the Wave export
+
+**Decision:** Add editable `sku text` (nullable) to **`product_units`**, exposed in the units drawer labeled **"SKU."** Repoint the Wave export: Item Number ← the line's `product_units.sku`, falling back to `product_units.slug`, then blank. Remove `products.description` from the export entirely — it reverts to its sole purpose, the customer-facing long description.
+
+**Why:** `description` is conflicted — the inventory editor presents it as the customer-facing long description while `export-orders.ts` emits it as Wave's Item Number, so a customer note silently becomes an invoice item number. Under multi-unit, SKU is a **per-unit** truth (one product → multiple Wave line items). Editable (not the auto `slug`) lets Annabel match Bushel's SKUs to her existing Wave item catalog.
+
+**Migration:** add `product_units.sku`; backfill NULL (Annabel fills as needed); `slug` stays as fallback.
+
+---
+
+## DEC-044 — Canonicalize `order_status` to snake_case (`picked_up`) — BUG
+
+**Decision:** `picked_up` (underscore) is canonical everywhere. Migrate the TS layer — `ORDER_STATUSES`, transition guards, `narrowStatus`, `order-actions.tsx`, `order-row.tsx`, `report.ts` — from the hyphen form to underscore. No data backfill: `orders` is wiped at cutover.
+
+**Why / symptom:** DB `codes` stores `picked_up`; the TS layer uses `picked-up`. `narrowStatus(s)` returns `"new"` for any DB value not in the hyphen-keyed `ORDER_STATUSES`, so a `picked_up` row reads back as **new** — fulfilled orders resurface as new in the admin list, and `report.ts`'s `o.status !== "picked-up"` exclusion misses them, so fulfilled orders keep printing on the harvest sheet. Underscore matches the DB convention (`needs_reconciliation`, `is_active`).
+
+---
+
+## DEC-045 — Admin orders list keyed to the open-order model (follows DEC-041)
+
+**Decision:** `/admin/orders` drops its current-week filter (`listOrders`' `.eq("week_of", weekOf)`) and defaults to **active (non-terminal)** orders, with a way to browse fulfilled/past orders. The stale `customer_sends` sends-join comment + logic ("one order per customer per week → `customer_id` maps 1:1 to an order") is corrected — the join stays week-keyed per DEC-042; only the broken 1:1 assumption is fixed.
+
+**Why:** Under DEC-041 orders are no longer week-aligned, so a week-filtered list silently drops orders that stay open across a week boundary. Fulfilled orders persist as rows (the open-order model only removes them from the partial index + the editable view), so "view past orders" is a read/UI feature — and this is its natural home.
+
+**Scope:** admin-only. Customer-facing history (#136, `/c/[token]/history`) stays in the backlog.
+
+---
+
 ## Open / Pending Product Owner Discussion
 
 - **Minimum delivery amount (in dollars).** Threshold below which delivery is unavailable, or above which delivery is free. Phase 7+ candidate.

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -218,6 +218,31 @@ Forecast at 0.80 active h/pt (Phase 7 headline) → ~6.4h active for the opening
 
 ---
 
+## Phase 9 — Open-Order Pivot (21 pts → ~17 h active @ 0.80 h/pt)
+
+Re-keys order identity from the week to the open order, kills the scheduled-close cron, fixes the SKU/`description` export landmine and the `picked_up` status split, and reworks the admin orders list for the new model. Design locked in the planning memo + an `@architect` pass (2026-06-22, Opus — Fable unavailable). DEC-040–045.
+
+**Hard cutover** at go-live: wipe `orders`/`order_items`/`customer_sends`, keep `products`/`product_units`/`customers` — no history, no backfill, brief quiet-minute outage accepted (DEC-041).
+
+**Step 0 (infra gate, not a task):** bootstrap the `production` deploy branch (`git checkout -b production main && git push -u origin production`) + repoint Vercel's Production Branch to `production` **before** `main` takes Phase 9 work — else WIP auto-deploys to prod (DEC-S022).
+
+**Sequencing:** 9.1 (merge #218) before 9.3a (`CREATE OR REPLACE` of #218's `place_order`); 9.3a before 9.3b; 9.5 before 9.3b (shared `report.ts` lines).
+
+| # | Task | Pts | Status |
+|---|---|---|---|
+| 9.1 | Merge #211/#218 additive orders + whole-order summary + "Update order" copy | 2 | [#224](https://github.com/mobiustripper42/bushel/issues/224) |
+| 9.2 | Disable scheduled-close cron — always-open (DEC-040) | 1 | [#225](https://github.com/mobiustripper42/bushel/issues/225) |
+| 9.3a | Open-order identity — partial unique index + `place_order` re-key (DEC-041) | 5 | [#226](https://github.com/mobiustripper42/bushel/issues/226) |
+| 9.3b | Customer open-order UX — editable open order, terminal read-only (DEC-042) | 3 | [#227](https://github.com/mobiustripper42/bushel/issues/227) |
+| 9.4 | Per-unit editable SKU; remove `description` from Wave export (DEC-043) | 3 | [#228](https://github.com/mobiustripper42/bushel/issues/228) |
+| 9.5 | BUG: canonicalize `order_status` to `picked_up` (DEC-044) | 2 | [#229](https://github.com/mobiustripper42/bushel/issues/229) |
+| 9.6 | Inventory hidden-state visual — "Hidden" pill + accent bar | 2 | [#230](https://github.com/mobiustripper42/bushel/issues/230) |
+| 9.8 | Admin orders list — drop week filter, active + past-orders view (DEC-045) | 3 | [#231](https://github.com/mobiustripper42/bushel/issues/231) |
+
+DEC-039 (#218's additive-orders decision) lands in `DECISIONS.md` when 9.1 merges; DEC-040–045 are already written. Customer-facing order history (#136) stays in the backlog.
+
+---
+
 ## `seeds` Backports (track via `/sync-config`)
 
 1. **Test scaffolding** — Playwright config, pgTAP layout, `supabase/seed.sql`, GitHub Actions workflow. Coordinate with parallel session.


### PR DESCRIPTION
Planning artifacts for **Phase 9 — the open-order pivot**. No code changes — `DECISIONS.md` + `PROJECT_PLAN.md` only. Design locked via the planning memo + an `@architect` pass (2026-06-22, Opus — Fable unavailable).

## What's here
- **DEC-040–045** written to `docs/DECISIONS.md`.
- **Phase 9 section** added to `docs/PROJECT_PLAN.md` (21 pts, task table → issues #224–#231).

## The bundle
| # | Task | Pts | Issue |
|---|---|--:|---|
| 9.1 | Merge #218 additive orders + whole-order summary + "Update order" copy | 2 | #224 |
| 9.2 | Disable scheduled-close cron — always-open (DEC-040) | 1 | #225 |
| 9.3a | Open-order identity — partial unique index + `place_order` re-key (DEC-041) | 5 | #226 |
| 9.3b | Customer open-order UX — editable open order, terminal read-only (DEC-042) | 3 | #227 |
| 9.4 | Per-unit SKU; remove `description` from Wave export (DEC-043) | 3 | #228 |
| 9.5 | BUG: canonicalize `order_status` → `picked_up` (DEC-044) | 2 | #229 |
| 9.6 | Inventory hidden-state visual | 2 | #230 |
| 9.8 | Admin orders list — drop week filter, active + past-orders (DEC-045) | 3 | #231 |

## Key calls baked in
- **Hard cutover** — wipe `orders`/`order_items`/`customer_sends`, keep `products`/`product_units`/`customers`. No history, no backfill.
- **9.2 disable-not-remove** — kill the cron, leave the schedule machinery dormant.
- **Send-state stays week-keyed** — rejected re-keying `customer_sends` to the order (the weekly blast has no order at send time); accepted the rare same-week-reorder blind spot.

## Merge ordering
`#218` (task 9.1) brings **DEC-039** into `DECISIONS.md`. Expect a one-line resolve when these two meet — DEC-039 slots in just above the 040–045 here. Sequencing rule: **#218 merges before 9.3a** (it's a `CREATE OR REPLACE` of #218's `place_order`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
