### PR TITLE
9.1 (#224): whole-order summary in add mode + "Update order" copy

### DIFF
--- a/src/app/c/[token]/page.tsx
+++ b/src/app/c/[token]/page.tsx
@@ -94,6 +94,16 @@ export default async function CustomerTokenPage({
               delivery_address: existingOrder.delivery_address,
               delivery_preference: existingOrder.delivery_preference,
               pickup_note: existingOrder.pickup_note,
+              // 9.1/DEC-039 — the query already joins order_items; thread them
+              // through so add mode shows the *complete* order (existing lines
+              // read-only) above the new additions, not just what's being added.
+              items: (existingOrder.order_items ?? []).map((it) => ({
+                id: it.id,
+                name: it.products?.name ?? "(item)",
+                unitLabel: it.product_units?.label ?? "",
+                qty: it.qty,
+                unit_price_cents: it.unit_price_cents,
+              })),
             }
           : null
       }

--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -757,7 +757,9 @@ export function OrderForm({
                 {addMode && existingOrder ? (
                   <ExistingItemsGroup items={existingOrder.items} />
                 ) : null}
-                {addMode ? <div className="rail-adding-head">Adding now</div> : null}
+                {addMode && existingOrder && existingOrder.items.length > 0 ? (
+                  <div className="rail-adding-head">Adding now</div>
+                ) : null}
                 {lineCount === 0 ? (
                   <div className="rail-empty">
                     Nothing selected yet. Tap <span className="mono">+</span> on
@@ -831,7 +833,9 @@ export function OrderForm({
               {addMode && existingOrder ? (
                 <ExistingItemsGroup items={existingOrder.items} />
               ) : null}
-              {addMode ? <div className="rail-adding-head">Adding now</div> : null}
+              {addMode && existingOrder && existingOrder.items.length > 0 ? (
+                <div className="rail-adding-head">Adding now</div>
+              ) : null}
               {lineCount === 0 ? (
                 <div className="rail-empty">
                   Nothing selected yet. Tap <span className="mono">+</span> on
@@ -890,8 +894,13 @@ export function OrderForm({
       <div className={"sticky-bar" + (lineCount > 0 ? " is-active" : "")}>
         <div className="sticky-summary">
           <div className="sticky-count">
+            {addMode ? "Adding " : ""}
             {itemCount} item{itemCount !== 1 ? "s" : ""}
           </div>
+          {/* 9.1 — the sticky bar is scoped to the additions (its count is the
+              additions count + its button is "Review", not submit), so it keeps
+              the additions subtotal. The "Adding" label distinguishes it from
+              the summary card's grand total. */}
           <div className="sticky-total mono">${formatPrice(subtotalCents)}</div>
         </div>
         <button

--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -14,11 +14,22 @@ type Customer = {
 // this existing (customer, week) order. Fulfillment is shown read-only
 // (inherited from the order; change = text Annabel, DEC-015) and the submit
 // payload sends only the new line items — never fulfillment fields.
+export type ExistingOrderItem = {
+  id: string;
+  name: string;
+  unitLabel: string;
+  qty: number;
+  unit_price_cents: number;
+};
+
 export type ExistingOrderFulfillment = {
   fulfillment_type: string;
   delivery_address: string | null;
   delivery_preference: string | null;
   pickup_note: string | null;
+  // 9.1/DEC-039 — the order's already-placed lines, rendered read-only above
+  // the editable additions so the summary shows the complete order.
+  items: ExistingOrderItem[];
 };
 
 type Props = {
@@ -33,6 +44,33 @@ type Mode = "delivery" | "pickup";
 
 function formatPrice(cents: number): string {
   return (cents / 100).toFixed(2);
+}
+
+// 9.1/DEC-039 — the already-placed lines, shown read-only above the editable
+// additions in each "your order" card (rendered in both the inline summary and
+// the desktop rail, hence a shared component rather than a duplicated .map).
+function ExistingItemsGroup({ items }: { items: ExistingOrderItem[] }) {
+  if (items.length === 0) return null;
+  return (
+    <div className="rail-existing">
+      <div className="rail-existing-head">Already ordered</div>
+      <ul className="rail-list rail-list-existing">
+        {items.map((it) => (
+          <li key={it.id}>
+            <span className="rail-name">
+              <span className="rail-qty mono">{it.qty}×</span> {it.name}
+              {it.unitLabel ? (
+                <span className="rail-unit"> · {it.unitLabel}</span>
+              ) : null}
+            </span>
+            <span className="rail-amt mono">
+              ${formatPrice(it.qty * it.unit_price_cents)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }
 
 // A server action's redirect() throws NEXT_REDIRECT on the client, which lands
@@ -361,6 +399,16 @@ export function OrderForm({
     [itemsWithQty, qty],
   );
   const lineCount = itemsWithQty.length;
+
+  // 9.1/DEC-039 — in add mode the "your order" total is the *grand* total:
+  // already-ordered lines + new additions. Submit still appends only the
+  // additions (the RPC is unchanged); the total is informational (no charge
+  // at submit — Annabel invoices via Wave).
+  const existingSubtotalCents = (existingOrder?.items ?? []).reduce(
+    (sum, it) => sum + it.qty * it.unit_price_cents,
+    0,
+  );
+  const grandTotalCents = existingSubtotalCents + subtotalCents;
 
   const setItemQty = (id: string, n: number) => {
     // Belt-and-suspenders with the persist effect: editing the cart starts a
@@ -706,6 +754,10 @@ export function OrderForm({
             <section className="submit-block">
               <div className="submit-summary">
                 <div className="eyebrow">your order</div>
+                {addMode && existingOrder ? (
+                  <ExistingItemsGroup items={existingOrder.items} />
+                ) : null}
+                {addMode ? <div className="rail-adding-head">Adding now</div> : null}
                 {lineCount === 0 ? (
                   <div className="rail-empty">
                     Nothing selected yet. Tap <span className="mono">+</span> on
@@ -729,7 +781,9 @@ export function OrderForm({
                 <div className="rail-totals">
                   <div className="rail-row rail-row-total">
                     <span>Total</span>
-                    <span className="mono">${formatPrice(subtotalCents)}</span>
+                    <span className="mono">
+                      ${formatPrice(addMode ? grandTotalCents : subtotalCents)}
+                    </span>
                   </div>
                 </div>
                 <div className="summary-sub">
@@ -754,7 +808,7 @@ export function OrderForm({
                 {isPending ? (
                   <span className="btn-spinner" aria-hidden="true" />
                 ) : addMode ? (
-                  "Add to order"
+                  "Update order"
                 ) : (
                   "Submit order"
                 )}
@@ -774,6 +828,10 @@ export function OrderForm({
           <aside className="page-rail">
             <div className="rail-card">
               <div className="eyebrow">your order</div>
+              {addMode && existingOrder ? (
+                <ExistingItemsGroup items={existingOrder.items} />
+              ) : null}
+              {addMode ? <div className="rail-adding-head">Adding now</div> : null}
               {lineCount === 0 ? (
                 <div className="rail-empty">
                   Nothing selected yet. Tap <span className="mono">+</span> on
@@ -797,7 +855,9 @@ export function OrderForm({
               <div className="rail-totals">
                 <div className="rail-row rail-row-total">
                   <span>Total</span>
-                  <span className="mono">${formatPrice(subtotalCents)}</span>
+                  <span className="mono">
+                    ${formatPrice(addMode ? grandTotalCents : subtotalCents)}
+                  </span>
                 </div>
               </div>
               <button
@@ -810,7 +870,7 @@ export function OrderForm({
                 {isPending ? (
                   <span className="btn-spinner" aria-hidden="true" />
                 ) : addMode ? (
-                  "Add to order"
+                  "Update order"
                 ) : (
                   "Submit order"
                 )}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1420,6 +1420,21 @@
 .rail-submit { width: 100%; margin-top: 6px; }
 .rail-fine { margin-top: 10px; font-size: 0.78rem; color: var(--ink-500); }
 
+/* 9.1/DEC-039 — add-mode "your order" card shows the complete order: the
+   already-placed lines read-only (muted) above the editable additions. */
+.rail-existing-head,
+.rail-adding-head {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-500);
+  margin: 6px 0 2px;
+}
+.rail-list-existing { margin: 4px 0 10px; opacity: 0.72; }
+.rail-list-existing .rail-qty { color: var(--ink-500); }
+.rail-adding-head { border-top: 1px dashed var(--ink-200); padding-top: 8px; }
+.rail-unit { color: var(--ink-500); font-size: 0.85em; }
+
 .page-foot {
   margin-top: 24px;
   padding-top: 14px;

--- a/tests/customer-additional-orders.spec.ts
+++ b/tests/customer-additional-orders.spec.ts
@@ -59,7 +59,7 @@ test.describe("/c/[token] additional orders", () => {
     // Append eggs ×1 and submit.
     await stepUp(page, TEST_PRODUCTS.eggs.name, 1);
     const submit = page.locator(".submit-btn");
-    await expect(submit).toHaveText("Add to order");
+    await expect(submit).toHaveText("Update order");
     await submit.click();
     await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
 
@@ -112,7 +112,34 @@ test.describe("/c/[token] additional orders", () => {
     await expect(page.locator(".fulfill-tabs")).toHaveCount(0);
     await expect(page.locator("#delivery-pref")).toHaveCount(0);
     await expect(page.locator("#pickup-note")).toHaveCount(0);
-    await expect(page.locator(".submit-btn")).toHaveText("Add to order");
+    await expect(page.locator(".submit-btn")).toHaveText("Update order");
+  });
+
+  // 9.1/DEC-039 — the "your order" card shows the COMPLETE order: already-placed
+  // lines read-only above the editable additions, with a grand total.
+  test("add mode summary shows existing items read-only + grand total", async ({ page }) => {
+    const ids = await customerIds();
+    await seedOrder({
+      customerId: ids.farmStand,
+      weekOf: weekOfMondayNY(),
+      fulfillmentType: "delivery",
+      items: [{ productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 }],
+    });
+
+    await page.goto(`${customerOrderUrl(TEST_CUSTOMERS.farmStand.token)}?add=1`);
+
+    // Already-ordered kale ×1 ($3.00) renders read-only in the summary.
+    const existing = page.locator(".rail-existing:visible");
+    await expect(existing).toContainText("Already ordered");
+    await expect(existing).toContainText(TEST_PRODUCTS.kale.name);
+
+    // Append eggs ×1 ($6.00). The additions list is the non-existing rail-list.
+    await stepUp(page, TEST_PRODUCTS.eggs.name, 1);
+    const additions = page.locator(".rail-list:not(.rail-list-existing):visible");
+    await expect(additions).toContainText(TEST_PRODUCTS.eggs.name);
+
+    // Total is the GRAND total: existing $3.00 + new $6.00 = $9.00.
+    await expect(page.locator(".rail-row-total:visible")).toContainText("9.00");
   });
 
   test("hub gating: closed store hides the add button and explains why", async ({ page }) => {


### PR DESCRIPTION
## Summary
Phase 9.1 (open-order pivot) — the two UAT tweaks on top of the already-merged additive-orders mechanism (#218/DEC-039): the add-mode "your order" card now shows the **complete** order, and the add-mode button reads **"Update order"**.

- Add mode renders the order's already-placed lines read-only ("Already ordered", muted) above the editable additions ("Adding now") — in both the inline summary and the desktop rail.
- The card **Total** in add mode is the **grand total** (existing + additions). Submit still appends only the new items — `place_order` is unchanged (DEC-039).
- Both add-mode button sites: `"Add to order"` → `"Update order"`.
- Mobile sticky bar is labeled **"Adding N items"** so its additions subtotal doesn't read as a contradictory grand total against the card.

## Files changed
- `src/app/c/[token]/page.tsx` — thread `getCurrentWeekOrder`'s already-joined `order_items` into the `existingOrder` prop (normalized like the `/confirmed` embed).
- `src/components/customer/OrderForm.tsx` — new `ExistingOrderItem` type; shared `ExistingItemsGroup`; `existingSubtotalCents` + `grandTotalCents`; render in both summary cards; sticky-bar label; button copy.
- `src/styles/app.css` — muted read-only group + "Adding now" divider (one-file rule).
- `tests/customer-additional-orders.spec.ts` — two copy asserts flipped to "Update order"; new case asserts existing items render read-only with a $9.00 grand total.

## Code review
`@code-review` (Sonnet), advisory. One real catch, fixed in `1852fb1`: the mobile sticky bar showed additions-only while the cards showed the grand total (a $6-vs-$56 contradiction at 375px) — now labeled "Adding N items". Also addressed a cosmetic finding: the "Adding now" divider is gated on `items.length > 0` so its dashed border never floats. Remaining note (not in scope): the two "your order" cards are still duplicated top-to-bottom — a future `<OrderSummaryCard>` extraction, tracked as tech debt. No bugs, no RLS/data-shape concerns (reuses the proven admin-client embed pattern).

## Test plan
- `npx playwright test tests/customer-additional-orders.spec.ts --project=desktop --project=mobile` → **12/12 green** (incl. the new grand-total case at both viewports).
- Manual (preview): open a customer with an existing open order → tap "Add to your order" (`?add=1`). Expect: "Already ordered" lines (read-only, muted) above the "Adding now" section; button reads "Update order"; the card Total = existing + additions; the mobile sticky bar (375px) reads "Adding N items" with the additions subtotal. Submit → `/confirmed` shows the merged order (one `orders` row, appended `order_items`).
- No migration, no RLS change — `supabase test db` not required.

closes #224
