### PR TITLE
Clear tsc + eslint debt (restore zero-error typecheck/lint)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,10 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Hand-built HTML/JSX design mockups — reference artifacts, not app code
+    // (no React import, prose with raw apostrophes). Not part of the build; the
+    // authoritative UI spec, but not linted as source.
+    "design/**",
   ]),
 ]);
 

--- a/src/components/admin/SettingsScheduleCard.tsx
+++ b/src/components/admin/SettingsScheduleCard.tsx
@@ -135,7 +135,7 @@ export function SettingsScheduleCard({ schedule }: { schedule: ScheduleRow }) {
           <div className="set-row">
             <div className="set-row-key">
               Default close
-              <small>When the order form locks. Customers see a "closed" state after this.</small>
+              <small>When the order form locks. Customers see a &ldquo;closed&rdquo; state after this.</small>
             </div>
             <div className="set-row-val">
               <select

--- a/src/components/admin/intro-note-card.tsx
+++ b/src/components/admin/intro-note-card.tsx
@@ -25,8 +25,10 @@ export function IntroNoteCard({ initialValue }: IntroNoteCardProps) {
   // edits when the user hasn't typed anything new — `saved` is captured in
   // a ref so the effect can be tied to `initialValue` alone.
   const savedRef = useRef(saved);
+  // eslint-disable-next-line react-hooks/refs -- intentional: mirror latest `saved` into a ref so the effect can key on `initialValue` alone; not read during render.
   savedRef.current = saved;
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: prop-driven resync of server state, not a cascading render loop.
     setSaved(initialValue);
     setValue((v) => (v === savedRef.current ? initialValue : v));
   }, [initialValue]);

--- a/src/components/admin/inventory-editor.tsx
+++ b/src/components/admin/inventory-editor.tsx
@@ -110,6 +110,7 @@ export function InventoryEditor({ initialRows, initialUnits, soldByProductId, we
   // pulls in the other tab's changes. Accepted tradeoff for single-
   // admin V1.
   const dirtyRef = useRef(dirty);
+  // eslint-disable-next-line react-hooks/refs -- intentional: mirror latest `dirty` into a ref read only inside the effect below (guards a mid-edit resync); not used during render.
   dirtyRef.current = dirty;
   // Only adopt fresh server data when it actually differs from our current
   // baseline. This guards two cases that would otherwise clobber an edit:
@@ -123,6 +124,7 @@ export function InventoryEditor({ initialRows, initialUnits, soldByProductId, we
   // A genuine change (router.refresh() after save / prepopulate, or a
   // concurrent-tab write) differs in content and resyncs as before.
   const baselineRef = useRef(baseline);
+  // eslint-disable-next-line react-hooks/refs -- intentional: mirror latest `baseline` into a ref read only inside the effect below (content-diff guard); not used during render.
   baselineRef.current = baseline;
   useEffect(() => {
     if (dirtyRef.current) return;

--- a/src/components/customer/OrderForm.tsx
+++ b/src/components/customer/OrderForm.tsx
@@ -124,6 +124,7 @@ function Stepper({
 
   useEffect(() => {
     valueRef.current = value;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: mirror the numeric `value` prop into the editable draft string when it changes upstream.
     setDraft(value.toString());
   }, [value]);
 
@@ -331,6 +332,7 @@ export function OrderForm({
   // is harmless: itemsWithQty filters against the live product list and unitFor
   // falls back to the first active unit.
   useEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect -- intentional: one-time mount hydration of draft state from sessionStorage (client-only, SSR-safe); each field is an independent restore, not a cascading render. */
     try {
       const raw = sessionStorage.getItem(draftKey);
       if (raw) {
@@ -346,6 +348,7 @@ export function OrderForm({
       // Corrupt/unreadable draft — start fresh.
     }
     setHydrated(true);
+    /* eslint-enable react-hooks/set-state-in-effect */
     // Mount-only; draftKey is stable for the component's life (customer.id).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/tests/admin-orders-export.spec.ts
+++ b/tests/admin-orders-export.spec.ts
@@ -25,6 +25,7 @@ function mockOrder(over: Partial<OrderRow> = {}): OrderRow {
     id: "order-1",
     customerId: "cust-1",
     customerName: "Test Customer",
+    phone: null,
     placedAt: "2026-05-12T15:30:00Z",
     weekOf: "2026-05-11",
     fulfillmentType: "pickup",
@@ -40,12 +41,16 @@ function mockOrder(over: Partial<OrderRow> = {}): OrderRow {
         name: "Kale",
         description: "KALE-BUNCH",
         unit: "bunch",
+        unitLabel: "bunch",
+        conversionToBase: 1,
         qty: 2,
         unitPriceCents: 300,
         qtyAvailable: 10,
       },
     ],
     totalCents: 600,
+    confirmSentAt: null,
+    reminderSentAt: null,
     ...over,
   };
 }
@@ -60,6 +65,8 @@ test("toCsv: no header row; line items only, RFC 4180 quoting", () => {
           name: "Heirloom\ntomatoes",
           description: "HEIRLOOM-LB",
           unit: "lb",
+          unitLabel: "lb",
+          conversionToBase: 1,
           qty: 3,
           unitPriceCents: 550,
           qtyAvailable: 10,
@@ -92,6 +99,8 @@ test("toCsv: empty Item Number when product description (slug) is null", () => {
           name: "Garlic scapes",
           description: null,
           unit: "bunch",
+          unitLabel: "bunch",
+          conversionToBase: 1,
           qty: 4,
           unitPriceCents: 400,
           qtyAvailable: 10,
@@ -110,14 +119,14 @@ test("toCsv: one row per line item; multi-item order keeps per-line slugs", () =
     mockOrder({
       customerName: "A",
       items: [
-        { productId: "p1", name: "Kale", description: "KALE-BU", unit: "bunch", qty: 1, unitPriceCents: 300, qtyAvailable: 5 },
-        { productId: "p2", name: "Eggs", description: "EGG-DZ", unit: "dozen", qty: 2, unitPriceCents: 600, qtyAvailable: 5 },
+        { productId: "p1", name: "Kale", description: "KALE-BU", unit: "bunch", unitLabel: "bunch", conversionToBase: 1, qty: 1, unitPriceCents: 300, qtyAvailable: 5 },
+        { productId: "p2", name: "Eggs", description: "EGG-DZ", unit: "dozen", unitLabel: "dozen", conversionToBase: 1, qty: 2, unitPriceCents: 600, qtyAvailable: 5 },
       ],
     }),
     mockOrder({
       customerName: "B",
       items: [
-        { productId: "p3", name: "Honey", description: "HON-JAR", unit: "jar", qty: 1, unitPriceCents: 1200, qtyAvailable: 5 },
+        { productId: "p3", name: "Honey", description: "HON-JAR", unit: "jar", unitLabel: "jar", conversionToBase: 1, qty: 1, unitPriceCents: 1200, qtyAvailable: 5 },
       ],
     }),
   ]);
@@ -142,6 +151,8 @@ test("toTsv: tab-separated, strips embedded tabs/newlines from fields", () => {
           name: "Has\nnewline",
           description: "SLUG-WITH\nNEWLINE",
           unit: "lb",
+          unitLabel: "lb",
+          conversionToBase: 1,
           qty: 1,
           unitPriceCents: 100,
           qtyAvailable: 5,
@@ -161,7 +172,7 @@ test("ordersToRows: itemNumber = product description (slug); description = produ
   const rows = ordersToRows([
     mockOrder({
       items: [
-        { productId: "p", name: "Honey", description: "HONEY-JAR", unit: "jar", qty: 7, unitPriceCents: 125, qtyAvailable: 10 },
+        { productId: "p", name: "Honey", description: "HONEY-JAR", unit: "jar", unitLabel: "jar", conversionToBase: 1, qty: 7, unitPriceCents: 125, qtyAvailable: 10 },
       ],
     }),
   ]);


### PR DESCRIPTION
## Summary
Restore `tsc --noEmit` and `npm run lint` to **zero errors**. Neither is a CI gate (CI runs build + Playwright + pgTAP), so both had silently drifted — 57 lint problems + 8 tsc errors. No app logic changes: comments, config, JSX-entity escapes, and test-fixture type fills only.

## Files changed
- `eslint.config.mjs` — ignore `design/**` (hand-built HTML/JSX mockups; reference artifacts, not app code — ~48 of the 57 lint problems).
- `src/components/admin/intro-note-card.tsx`, `inventory-editor.tsx`, `src/components/customer/OrderForm.tsx` — justified `eslint-disable` (per-line + one balanced block) for `react-hooks/refs` + `react-hooks/set-state-in-effect`, newly errored by `eslint-plugin-react-hooks@7` (via `next@16.2.4`) on deliberate, commented ref-sync + mount-hydration patterns. Comments only.
- `src/components/admin/SettingsScheduleCard.tsx` — escape two `"` → `&ldquo;`/`&rdquo;` (`react/no-unescaped-entities`).
- `tests/admin-orders-export.spec.ts` — fill missing required fields on stale mocks: `OrderItem.unitLabel`/`conversionToBase` (6.5f) on 8 item literals + `OrderRow.phone`/`confirmSentAt`/`reminderSentAt` on the `mockOrder` base (single-unit-equivalent / null defaults).

## Code review
`@code-review` (Sonnet) — **Clean bill of health.** Verified: (1) every disable names the correct rule and the block disable/enable pair is balanced + single-rule (no over-suppression; `exhaustive-deps` disable untouched); (2) all disables sit on genuinely intentional patterns, not silenced bugs — notably the Stepper's in-effect `valueRef.current = value` correctly gets *no* `refs` disable; (3) `export-orders.ts` reads none of the added fields, so the fixtures are inert to CSV/TSV output. One pre-existing `jsx-a11y` `aria-sort`-on-`button` **warning** left unfixed (a warning, not an error) — noted as a follow-up.

## Test plan
- `npx tsc --noEmit` → exit 0 (was 8 errors).
- `npm run lint` → 0 errors (1 pre-existing a11y warning; was 42 errors + 15 warnings).
- `npm run build` → green.
- `npx playwright test tests/admin-orders-export.spec.ts tests/admin-settings.spec.ts --project=desktop` → **14/14 green** (covers the changed export fixtures + the re-quoted SettingsScheduleCard text). Other touched files are comment-only.
- No migration, no RLS.

## Follow-ups (not in this PR)
- **Add `tsc --noEmit` + `npm run lint` as CI gates** so this can't silently recur — pending your call.
- Fix the `jsx-a11y` `aria-sort`-on-`button` warning.
