### PR TITLE
Open-order pivot core: 9.2 + 9.5 + 9.3a + 9.3b (DEC-040/041/042/044)

### DIFF
--- a/src/actions/place-order.ts
+++ b/src/actions/place-order.ts
@@ -92,15 +92,9 @@ export async function placeOrder(
           "Some items sold out while you were ordering. Reload to see what's still available.",
       };
     }
-    // #211 / DEC-039: appending to a picked-up/delivered order is refused —
-    // the box is already packed and gone. Stale add-mode tab is the only
-    // route here (the /confirmed hub hides the add button on terminal).
-    if (error.message.includes("already fulfilled")) {
-      return {
-        error:
-          "This order's already been packed — text Annabel to add more.",
-      };
-    }
+    // DEC-041: the old "already fulfilled" refusal is gone — a submission
+    // arriving after the open order went terminal simply creates a fresh
+    // open order (fulfilled orders drop out of the identity).
     return { error: error.message };
   }
   const appended = data?.appended ?? false;

--- a/src/app/api/cron/check-schedule/route.ts
+++ b/src/app/api/cron/check-schedule/route.ts
@@ -4,7 +4,10 @@ import type { Database } from "@/lib/supabase/types";
 
 type ScheduleUpdate = Database["public"]["Tables"]["ordering_schedule"]["Update"];
 
-// Vercel Cron calls this every 5 minutes (vercel.json).
+// DORMANT (DEC-040): the vercel.json crons entry was removed — nothing calls
+// this route anymore. The store is always-open; is_open changes only via the
+// manual toggle. Machinery left in place, removable anytime.
+//
 // Checks ordering_schedule and flips is_open based on:
 //   1. override_closes_at — one-shot close; cleared after firing.
 //   2. weekly_open_day/time + weekly_close_day/time — recurring schedule.

--- a/src/app/c/[token]/confirmed/page.tsx
+++ b/src/app/c/[token]/confirmed/page.tsx
@@ -5,11 +5,11 @@ import { isTerminalStatus } from "@/lib/admin/orders-queries";
 import {
   anyOrderable,
   getAvailableProducts,
-  getCurrentWeekOrder,
+  getLatestOrder,
   getOrderingScheduleStatus,
 } from "@/lib/customer/queries";
 import { lookupCustomerByToken } from "@/lib/customer/session";
-import { weekOfLabel, weekOfMondayNY } from "@/lib/week";
+import { weekOfLabel } from "@/lib/week";
 
 function formatPrice(cents: number): string {
   return (cents / 100).toFixed(2);
@@ -51,13 +51,18 @@ export default async function ConfirmedPage({
     return <PausedShell customerName={greetingName} reason="paused" />;
   }
 
-  const order = await getCurrentWeekOrder(customer.id, weekOfMondayNY());
+  // DEC-041/DEC-042 (#227): the receipt is the customer's most recent order
+  // in any status. Open → editable via "Add to your order"; terminal
+  // (picked_up/delivered) → read-only, with a "place a new order" path (the
+  // fulfilled order dropped out of the open-order identity, so a fresh one
+  // is allowed).
+  const order = await getLatestOrder(customer.id);
 
   if (!order) {
-    // Cold-navigation case: someone hit /confirmed without an order this week.
+    // Cold-navigation case: someone hit /confirmed without ever ordering.
     return (
       <StatusShell>
-        <h1 className="status-title">No order on file for this week.</h1>
+        <h1 className="status-title">No order on file.</h1>
         <p className="status-lede">
           Place an order to get started.
         </p>
@@ -80,8 +85,9 @@ export default async function ConfirmedPage({
   // #211 / DEC-039 — "Add to your order" entry point. Gated on the same
   // predicates /c/[token] uses to render the form at all: ordering open
   // (DEC-031 soft hint), at least one orderable product (anyOrderable —
-  // shared helper), and the order not terminal (picked-up/delivered means
-  // the box is gone; place_order refuses the append server-side too).
+  // shared helper), and the order not terminal. A terminal order instead
+  // offers "Place a new order" — under DEC-041 the fulfilled order freed
+  // the identity, and /c/[token] will render a fresh form.
   const [schedule, products] = await Promise.all([
     getOrderingScheduleStatus(),
     getAvailableProducts(),
@@ -193,15 +199,25 @@ export default async function ConfirmedPage({
       <div className="status-actions">
         {canAdd ? (
           <Link
-            href={`/c/${token}?add=1`}
+            href={`/c/${token}`}
             className="btn btn-primary status-btn"
           >
             Add to your order
           </Link>
         ) : terminal ? (
-          <p className="status-fine">
-            This order&rsquo;s been packed — text Annabel to add more.
-          </p>
+          <>
+            <p className="status-fine">
+              This order&rsquo;s been packed — it&rsquo;s on its way.
+            </p>
+            {schedule.is_open && anyOrderable(products) ? (
+              <Link
+                href={`/c/${token}`}
+                className="btn btn-primary status-btn"
+              >
+                Place a new order
+              </Link>
+            ) : null}
+          </>
         ) : !schedule.is_open ? (
           <p className="status-fine">
             Ordering&rsquo;s closed for this week.

--- a/src/app/c/[token]/confirmed/page.tsx
+++ b/src/app/c/[token]/confirmed/page.tsx
@@ -116,7 +116,11 @@ export default async function ConfirmedPage({
       <div className="confirm-card">
         <div className="confirm-card-head">
           <div className="eyebrow">summary</div>
-          <span className="confirm-week">{weekOfLabel().toLowerCase()}</span>
+          {/* Stamped from the ORDER's week — under DEC-041 the latest order
+              can be last week's, and today's clock would mislabel it. */}
+          <span className="confirm-week">
+            {weekOfLabel(new Date(order.week_of)).toLowerCase()}
+          </span>
         </div>
         <ul className="confirm-list">
           {items.map((item) => {

--- a/src/app/c/[token]/page.tsx
+++ b/src/app/c/[token]/page.tsx
@@ -1,28 +1,24 @@
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { AllSoldOutShell } from "@/components/customer/AllSoldOutShell";
 import { ClosedShell } from "@/components/customer/ClosedShell";
 import { OrderForm } from "@/components/customer/OrderForm";
 import { PausedShell } from "@/components/customer/PausedShell";
-import { isTerminalStatus } from "@/lib/admin/orders-queries";
 import {
   anyOrderable,
   getAvailableProducts,
-  getCurrentWeekOrder,
   getLatestDeliveryPreference,
+  getOpenOrder,
   getOrderingScheduleStatus,
 } from "@/lib/customer/queries";
 import { lookupCustomerByToken } from "@/lib/customer/session";
-import { weekOfLabel, weekOfMondayNY } from "@/lib/week";
+import { weekOfLabel } from "@/lib/week";
 
 export default async function CustomerTokenPage({
   params,
-  searchParams,
 }: {
   params: Promise<{ token: string }>;
-  searchParams: Promise<{ add?: string }>;
 }) {
   const { token } = await params;
-  const { add } = await searchParams;
   const customer = await lookupCustomerByToken(token);
   if (!customer) notFound();
 
@@ -39,23 +35,14 @@ export default async function CustomerTokenPage({
     return <PausedShell customerName={greetingName} reason="paused" />;
   }
 
-  // If this customer has already submitted an order for the current NY-time
-  // week, the link is "your weekly order" — bounce to the confirmation rather
-  // than re-showing the empty form. The server-side place_order RPC would
-  // catch a re-submit either way, but seeing the empty form again is
-  // confusing UX.
-  //
-  // #211 / DEC-039: ?add=1 (the /confirmed hub's "Add to your order" link)
-  // skips that bounce and renders the form in ADD MODE — new items append to
-  // the existing order. A terminal order (picked-up/delivered) can't take
-  // appends, so it bounces back to /confirmed, where the gated-off reason
-  // copy lives.
-  const existingOrder = await getCurrentWeekOrder(customer.id, weekOfMondayNY());
-  const addMode = add === "1" && existingOrder !== null;
-  if (existingOrder && !addMode) redirect(`/c/${token}/confirmed`);
-  if (addMode && existingOrder && isTerminalStatus(existingOrder.status)) {
-    redirect(`/c/${token}/confirmed`);
-  }
+  // DEC-041/DEC-042 (#227): the customer's link renders their OPEN order
+  // editable — the form comes up pre-populated in add mode (existing lines
+  // read-only, new items append). No open order (none yet, or the last one
+  // was fulfilled — picked_up/delivered drop out of the open-order identity)
+  // means a fresh form: a new order is allowed the moment the box goes out.
+  // The old bounce-to-/confirmed and its ?add=1 escape hatch are gone; stale
+  // ?add=1 links land here and get the same editable view.
+  const existingOrder = await getOpenOrder(customer.id);
 
   const [products, priorDeliveryPreference, schedule] = await Promise.all([
     getAvailableProducts(),
@@ -88,7 +75,7 @@ export default async function CustomerTokenPage({
       priorDeliveryPreference={priorDeliveryPreference}
       weekLabel={weekOfLabel()}
       existingOrder={
-        addMode && existingOrder
+        existingOrder
           ? {
               fulfillment_type: existingOrder.fulfillment_type,
               delivery_address: existingOrder.delivery_address,

--- a/src/app/c/[token]/page.tsx
+++ b/src/app/c/[token]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { AllSoldOutShell } from "@/components/customer/AllSoldOutShell";
 import { ClosedShell } from "@/components/customer/ClosedShell";
 import { OrderForm } from "@/components/customer/OrderForm";
@@ -53,7 +53,12 @@ export default async function CustomerTokenPage({
   // DEC-031: four customer-side states keyed off ordering_schedule.is_open
   // and product inventory. Server-side `is_open` is a soft UI hint only;
   // submission enforcement remains DEC-012's job.
+  //
+  // With an open order, the closed/sold-out shells must not eat it — the
+  // link is "your order" (DEC-041), so when the form can't render, the
+  // receipt at /confirmed is the right view, not a dead-end shell.
   if (!schedule.is_open) {
+    if (existingOrder) redirect(`/c/${token}/confirmed`);
     return <ClosedShell customerName={greetingName} />;
   }
 
@@ -61,6 +66,7 @@ export default async function CustomerTokenPage({
   // inventory. A product with only a conv=4 unit and qty_available=2 is
   // effectively sold out even though qty_available > 0.
   if (!anyOrderable(products)) {
+    if (existingOrder) redirect(`/c/${token}/confirmed`);
     return <AllSoldOutShell customerName={greetingName} />;
   }
 

--- a/src/components/admin/SettingsScheduleCard.tsx
+++ b/src/components/admin/SettingsScheduleCard.tsx
@@ -14,6 +14,9 @@ type ScheduleRow = {
   weekly_close_time: string | null;
 };
 
+// DORMANT (DEC-040): the schedule this card edits is inert — the cron that
+// acted on it no longer fires (vercel.json crons entry removed). The manual
+// open/close toggle here is the only live control.
 export function SettingsScheduleCard({ schedule }: { schedule: ScheduleRow }) {
   const hasWeekly =
     schedule.weekly_open_day != null &&

--- a/src/components/admin/order-actions.tsx
+++ b/src/components/admin/order-actions.tsx
@@ -23,15 +23,15 @@ export function OrderActions({
   pending: boolean;
 }) {
   const isPickup = order.fulfillmentType === "pickup";
-  const terminalNext: OrderStatus = isPickup ? "picked-up" : "delivered";
+  const terminalNext: OrderStatus = isPickup ? "picked_up" : "delivered";
   const terminalLabel = isPickup ? "Mark picked up" : "Mark delivered";
 
   const readyDone =
     order.status === "ready" ||
-    order.status === "picked-up" ||
+    order.status === "picked_up" ||
     order.status === "delivered";
   const terminalDone =
-    order.status === "picked-up" || order.status === "delivered";
+    order.status === "picked_up" || order.status === "delivered";
 
   return (
     <div className="ord-actions">

--- a/src/components/admin/order-row.tsx
+++ b/src/components/admin/order-row.tsx
@@ -45,7 +45,7 @@ function StatusChip({ status }: { status: OrderStatus }) {
   if (status === "confirmed")
     return <span className="pill pill-confirmed">Confirmed</span>;
   if (status === "ready") return <span className="pill pill-ready">Ready</span>;
-  if (status === "picked-up")
+  if (status === "picked_up")
     return <span className="pill pill-done">Picked up</span>;
   return <span className="pill pill-done">Delivered</span>;
 }

--- a/src/lib/admin/orders-queries.ts
+++ b/src/lib/admin/orders-queries.ts
@@ -2,22 +2,29 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { weekOfMondayNY } from "@/lib/week";
 
-// DEC-035 (amends DEC-010): new → [confirmed] → ready → (picked-up | delivered).
+// DEC-035 (amends DEC-010): new → [confirmed] → ready → (picked_up | delivered).
 // Confirmed is optional. Ordering matches codes.sort_order.
+// DEC-044: snake_case picked_up is canonical — matches the codes table row.
 export type OrderStatus =
   | "new"
   | "confirmed"
   | "ready"
-  | "picked-up"
+  | "picked_up"
   | "delivered";
 
 export const ORDER_STATUSES: OrderStatus[] = [
   "new",
   "confirmed",
   "ready",
-  "picked-up",
+  "picked_up",
   "delivered",
 ];
+
+// DEC-041: the open-order identity set. A customer has at most one order in
+// these statuses (partial unique index orders_one_open_per_customer); a
+// terminal order (picked_up/delivered) drops out and frees a new one. Keep
+// this list identical to the index predicate in the DEC-041 migration.
+export const OPEN_ORDER_STATUSES: OrderStatus[] = ["new", "confirmed", "ready"];
 
 // The no-regress auto-advance rule for confirm-sends (DEC-035): sending the
 // confirmation text moves a new order to confirmed, but must never regress a
@@ -27,15 +34,15 @@ export function statusAfterConfirmSend(current: OrderStatus): OrderStatus {
   return current === "new" ? "confirmed" : current;
 }
 
-// DEC-039: terminal = the box has been handed over. Appending to the week's
-// order is refused at this point (place_order raises; the /confirmed hub and
-// the ?add=1 entry both gate on it). Takes raw text because orders.status is
-// app-enforced text in the DB (DEC-010) — customer-side reads arrive untyped.
+// DEC-041: terminal = the box has been handed over. A terminal order drops
+// out of the open-order identity — /confirmed renders it read-only and the
+// next submission creates a fresh order. Takes raw text because orders.status
+// is app-enforced text in the DB (DEC-010) — customer-side reads arrive untyped.
 export function isTerminalStatus(status: string): boolean {
-  return status === "picked-up" || status === "delivered";
+  return status === "picked_up" || status === "delivered";
 }
 
-// DEC-035 (amends DEC-010): new → [confirmed] → ready → (picked-up | delivered).
+// DEC-035 (amends DEC-010): new → [confirmed] → ready → (picked_up | delivered).
 // Confirmed is optional — new → ready stays valid (Annabel may pack before
 // texting). Fulfillment type pins which terminal state is valid. Pure +
 // exported so advance-order-status.ts (a "use server" module, which can only
@@ -48,7 +55,7 @@ export function isValidTransition(
   if (from === "new" && to === "confirmed") return true;
   if (from === "new" && to === "ready") return true;
   if (from === "confirmed" && to === "ready") return true;
-  if (from === "ready" && to === "picked-up") return fulfillmentType === "pickup";
+  if (from === "ready" && to === "picked_up") return fulfillmentType === "pickup";
   if (from === "ready" && to === "delivered") return fulfillmentType === "delivery";
   return false;
 }
@@ -116,33 +123,55 @@ export function currentWeekOf(): string {
 // Sorted at the DB by created_at desc; reconciliation pinning is applied
 // in the UI so it survives column-sort changes.
 export async function listOrders(weekOf: string): Promise<OrderRow[]> {
+  return queryOrders({ weekOf });
+}
+
+// DEC-041/DEC-042 (#227): every open (non-terminal) order regardless of week.
+// The fulfillment sheet reads this — an order that stays open across a week
+// boundary must keep printing until it's out the door. The admin orders list
+// moves onto this in 9.8 (DEC-045).
+export async function listActiveOrders(): Promise<OrderRow[]> {
+  return queryOrders({ activeOnly: true });
+}
+
+async function queryOrders(filter: {
+  weekOf?: string;
+  activeOnly?: boolean;
+}): Promise<OrderRow[]> {
   const supabase = createAdminClient();
 
-  // Orders + the week's customer_sends (for per-order Send state, #192) in
-  // parallel. customer_sends is keyed (customer_id, week_of, mode); since
-  // there's one order per customer per week, customer_id maps 1:1 to an order.
-  const [{ data, error }, sendsResult] = await Promise.all([
-    supabase
-      .from("orders")
-      .select(
-        `id, customer_id, created_at, week_of, fulfillment_type,
-         delivery_address, delivery_preference, pickup_note, notes,
-         status, needs_reconciliation,
-         customers(id, name, phone),
-         order_items(product_id, qty, unit_price_cents,
-           products(name, description, qty_available,
-             product_units(label, conversion_to_base)),
-           product_units(label, conversion_to_base))`,
-      )
-      .eq("week_of", weekOf)
-      .order("created_at", { ascending: false }),
-    supabase
-      .from("customer_sends")
-      .select("customer_id, mode, sent_at")
-      .eq("week_of", weekOf),
-  ]);
+  let ordersQuery = supabase
+    .from("orders")
+    .select(
+      `id, customer_id, created_at, week_of, fulfillment_type,
+       delivery_address, delivery_preference, pickup_note, notes,
+       status, needs_reconciliation,
+       customers(id, name, phone),
+       order_items(product_id, qty, unit_price_cents,
+         products(name, description, qty_available,
+           product_units(label, conversion_to_base)),
+         product_units(label, conversion_to_base))`,
+    )
+    .order("created_at", { ascending: false });
+  if (filter.weekOf) ordersQuery = ordersQuery.eq("week_of", filter.weekOf);
+  if (filter.activeOnly)
+    ordersQuery = ordersQuery.in("status", OPEN_ORDER_STATUSES);
 
+  const { data, error } = await ordersQuery;
   if (error) throw new Error(`listOrders: ${error.message}`);
+
+  // customer_sends stays week-keyed (DEC-042), so the Send state for each
+  // order is the send row of the order's OWN week_of stamp. Fetched after the
+  // orders because the active view can span weeks — the sends lookup needs
+  // the set of weeks actually present.
+  const weeks = [...new Set((data ?? []).map((o) => o.week_of))];
+  const sendsResult =
+    weeks.length === 0
+      ? { data: [], error: null }
+      : await supabase
+          .from("customer_sends")
+          .select("customer_id, week_of, mode, sent_at")
+          .in("week_of", weeks);
   if (sendsResult.error)
     throw new Error(`listOrders(sends): ${sendsResult.error.message}`);
 
@@ -154,9 +183,13 @@ export async function listOrders(weekOf: string): Promise<OrderRow[]> {
     pickupReminder: string | null;
     deliveryReminder: string | null;
   };
-  const sentByCustomer = new Map<string, SentEntry>();
+  // Keyed (customer_id, week_of): with the active view spanning weeks, one
+  // customer can appear with sends in more than one week — the old per-
+  // customer key silently merged them.
+  const sentByCustomerWeek = new Map<string, SentEntry>();
   for (const s of sendsResult.data ?? []) {
-    const entry = sentByCustomer.get(s.customer_id) ?? {
+    const key = `${s.customer_id}:${s.week_of}`;
+    const entry = sentByCustomerWeek.get(key) ?? {
       confirm: null,
       pickupReminder: null,
       deliveryReminder: null,
@@ -164,14 +197,14 @@ export async function listOrders(weekOf: string): Promise<OrderRow[]> {
     if (s.mode === "order_confirmation") entry.confirm = s.sent_at;
     else if (s.mode === "pickup_reminder") entry.pickupReminder = s.sent_at;
     else if (s.mode === "delivery_reminder") entry.deliveryReminder = s.sent_at;
-    sentByCustomer.set(s.customer_id, entry);
+    sentByCustomerWeek.set(key, entry);
   }
 
   return (data ?? [])
     .filter((o) => o.customers !== null)
     .map((o) => {
       const c = o.customers as { id: string; name: string; phone: string | null };
-      const sent = sentByCustomer.get(c.id) ?? {
+      const sent = sentByCustomerWeek.get(`${c.id}:${o.week_of}`) ?? {
         confirm: null,
         pickupReminder: null,
         deliveryReminder: null,

--- a/src/lib/customer/queries.ts
+++ b/src/lib/customer/queries.ts
@@ -4,6 +4,7 @@
 // queries bypass RLS by design. Don't "fix" these to the anon client —
 // the customer-side RLS policies key off `current_setting('app.customer_id')`
 // which we don't set, so anon reads return empty.
+import { OPEN_ORDER_STATUSES } from "@/lib/admin/orders-queries";
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { Database } from "@/lib/supabase/types";
 
@@ -88,38 +89,58 @@ export async function getLatestDeliveryPreference(
   return data?.delivery_preference ?? null;
 }
 
-// Pulls the customer's order for a specific week (typically the current NY-time
-// week), joined with its line items + product names + per-line unit labels
-// (product_units, DEC-037). Returns null if no order exists for that week.
-// Used by /confirmed (which also gates its "Add to your order" affordance on
-// `status`, DEC-039) and by /c/[token]'s ?add=1 add-mode entry.
-export async function getCurrentWeekOrder(customerId: string, weekOf: string) {
+// Shared join for the customer-facing order reads: line items + product
+// names + per-line unit labels (product_units, DEC-037).
+const CUSTOMER_ORDER_SELECT = `
+  id,
+  week_of,
+  fulfillment_type,
+  delivery_address,
+  delivery_preference,
+  pickup_note,
+  notes,
+  status,
+  created_at,
+  order_items (
+    id,
+    qty,
+    unit_price_cents,
+    products ( name ),
+    product_units ( label )
+  )
+` as const;
+
+// DEC-041 (#227): the customer's OPEN order — the one non-terminal order the
+// partial unique index guarantees (at most one of new/confirmed/ready).
+// Replaces the week-keyed getCurrentWeekOrder: identity is the open order,
+// week_of is just a stamp. /c/[token] renders this order editable
+// (pre-populated add mode); null means the customer is free to start fresh.
+export async function getOpenOrder(customerId: string) {
   const supabase = createAdminClient();
   const { data, error } = await supabase
     .from("orders")
-    .select(
-      `
-      id,
-      week_of,
-      fulfillment_type,
-      delivery_address,
-      delivery_preference,
-      pickup_note,
-      notes,
-      status,
-      created_at,
-      order_items (
-        id,
-        qty,
-        unit_price_cents,
-        products ( name ),
-        product_units ( label )
-      )
-    `,
-    )
+    .select(CUSTOMER_ORDER_SELECT)
     .eq("customer_id", customerId)
-    .eq("week_of", weekOf)
+    .in("status", OPEN_ORDER_STATUSES)
     .maybeSingle();
-  if (error) throw new Error(`getCurrentWeekOrder: ${error.message}`);
+  if (error) throw new Error(`getOpenOrder: ${error.message}`);
+  return data ?? null;
+}
+
+// The customer's most recent order in ANY status. /confirmed renders this as
+// the receipt: an open order gets the add affordance, a terminal one renders
+// read-only with a "place a new order" path (DEC-042 — orders are only ever
+// created open and move forward, so the newest row is the open order
+// whenever one exists).
+export async function getLatestOrder(customerId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("orders")
+    .select(CUSTOMER_ORDER_SELECT)
+    .eq("customer_id", customerId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw new Error(`getLatestOrder: ${error.message}`);
   return data ?? null;
 }

--- a/src/lib/fulfillment/report.ts
+++ b/src/lib/fulfillment/report.ts
@@ -6,7 +6,7 @@
 // so there's no new query or RLS surface. The base-unit fold (qty ×
 // conversion_to_base) is the same math place_order runs on decrement; we never
 // sum raw qty across mixed units (3 bunches + 2 lb ≠ 5).
-import { listOrders } from "@/lib/admin/orders-queries";
+import { listActiveOrders } from "@/lib/admin/orders-queries";
 
 export type HarvestUnit = { unit: string; qty: number };
 
@@ -45,12 +45,12 @@ function round2(n: number): number {
 export async function buildFulfillmentReport(
   weekOf: string,
 ): Promise<FulfillmentReport> {
-  // Fulfilled orders are already out the door — exclude picked-up/delivered so
-  // the sheet only shows what's still to harvest and pack. Negation keeps new,
-  // confirmed (DEC-035), and ready.
-  const orders = (await listOrders(weekOf)).filter(
-    (o) => o.status !== "picked-up" && o.status !== "delivered",
-  );
+  // DEC-041/DEC-042 (#227): the sheet shows every OPEN order regardless of
+  // week — an order that stays open across a week boundary keeps printing
+  // until it's out the door. Fulfilled orders (picked_up/delivered) are
+  // already excluded by the active-status query. weekOf survives only as the
+  // sheet's display stamp.
+  const orders = await listActiveOrders();
 
   // ── consolidated harvest list ──────────────────────────────────────────
   const byProduct = new Map<

--- a/src/lib/week.ts
+++ b/src/lib/week.ts
@@ -9,8 +9,8 @@ export function weekOfLabel(now: Date = new Date()): string {
 
 // Returns the ISO date (YYYY-MM-DD) of Monday of the current week in
 // America/New_York, regardless of where the server is running. Used as
-// orders.week_of so all orders placed during the same NY-time week share
-// a single date for the (customer_id, week_of) unique constraint.
+// orders.week_of — since DEC-041 an informational stamp (feeds the
+// fulfillment sheet + Wave export), no longer order identity.
 //
 // Strategy: take "now in NY" by formatting via Intl, parse back to
 // y/m/d, then shift to Monday. Avoids pulling in a tz library.
@@ -34,10 +34,9 @@ export function weekOfMondayNY(now: Date = new Date()): string {
   // Bushel's order cadence opens Sun/Mon → fulfills Wed/Thu. Sunday is the
   // OPENING of the new order week, so it maps to *tomorrow's* Monday
   // (offset = -1, i.e. add a day). Mon–Sat roll back to this week's Monday.
-  // Don't change this without considering the unique (customer_id, week_of)
-  // constraint — a misaligned Sunday silently buckets an order into last
-  // week, and the second-submit guard in place_order() will redirect the
-  // customer to last week's /confirmed without ever inserting their new order.
+  // A misaligned Sunday silently stamps an order into last week — harmless
+  // to identity since DEC-041, but it mislabels the fulfillment sheet and
+  // keys customer_sends to the wrong week.
   const offset = dayIdx === 0 ? -1 : dayIdx - 1;
 
   const anchor = new Date(Date.UTC(y, m - 1, d));

--- a/supabase/migrations/20260701213000_open_order_identity.sql
+++ b/supabase/migrations/20260701213000_open_order_identity.sql
@@ -1,0 +1,293 @@
+-- #226 / DEC-041 — order identity is the open order, not the week.
+--
+-- A customer has at most one NON-TERMINAL order ('new'/'confirmed'/'ready');
+-- fulfilled orders ('picked_up'/'delivered', DEC-044 snake_case) drop out and
+-- free a new one. week_of is demoted to an informational stamp — still set at
+-- insert, still feeds the fulfillment sheet + Wave export, no longer identity.
+--
+-- Hard cutover (DEC-041): orders / order_items / customer_sends are wiped —
+-- no history, no backfill. The truncate runs HERE, inside the migration, so
+-- the identity swap below can never trip over pre-pivot data (a customer with
+-- two same-week orders, or hyphen-status rows from before DEC-044). products /
+-- product_units / customers are untouched.
+--
+-- The old unique (customer_id, week_of) is dropped IN this migration, not
+-- deferred — it forbids the very second-same-week order the new partial index
+-- exists to allow, so the two cannot coexist through live traffic.
+--
+-- place_order re-key (#218's 9-arg fn, signature unchanged): week_of was
+-- load-bearing in four spots —
+--   1. ON CONFLICT arbiter        → infers the partial index (predicate
+--                                   restated verbatim; the inserted row's
+--                                   status='new' satisfies it). The
+--                                   concurrency linchpin.
+--   2. FOR UPDATE existing lock   → keyed to open status, not the week.
+--   3. Outside-lock replay join   → keyed to customer only. A replayed
+--                                   submission_id short-circuits to whatever
+--                                   order it landed on — even one that has
+--                                   since gone terminal (replay means
+--                                   "already applied", not "apply again").
+--   4. In-lock replay re-check    → keyed on order_id, unchanged.
+--
+-- The old terminal guard ('order already fulfilled') is GONE, structurally:
+-- the lock predicate only ever finds an open order, so a terminal order can
+-- never receive an append. A submission arriving when the customer's last
+-- order is terminal simply creates a fresh open order — that is the point of
+-- DEC-041 ("fulfilled orders drop out, freeing a new one").
+--
+-- Insert-vs-lock race: between the conflicting INSERT and the FOR UPDATE
+-- lock, the open order can go terminal (Annabel marks it picked_up). READ
+-- COMMITTED's EvalPlanQual then excludes the row from the locked SELECT —
+-- zero rows, nothing locked. The create-or-find LOOP retries the INSERT,
+-- which now succeeds (no open row blocks the partial index). Each iteration
+-- either creates or locks, so the loop terminates.
+
+truncate table public.orders, public.order_items, public.customer_sends;
+
+alter table public.orders
+  drop constraint orders_customer_id_week_of_key;
+
+create unique index orders_one_open_per_customer
+  on public.orders (customer_id)
+  where status in ('new', 'confirmed', 'ready');
+
+comment on index public.orders_one_open_per_customer is
+  'DEC-041: at most one non-terminal order per customer. Terminal statuses '
+  '(picked_up/delivered) fall outside the predicate and free a new order.';
+
+-- Same signature + return type as 20260612170000 → CREATE OR REPLACE keeps
+-- the existing grants (service_role execute, revoked from public).
+create or replace function public.place_order(
+  p_customer_id          uuid,
+  p_week_of              date,
+  p_fulfillment_type     text,
+  p_delivery_address     text,
+  p_delivery_preference  text,
+  p_pickup_note          text,
+  p_notes                text,
+  p_items                jsonb,
+  p_submission_id        uuid default null
+)
+returns table(order_id uuid, appended boolean)
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  v_order_id     uuid;
+  v_status       text;
+  v_appended     boolean := false;
+  v_item         jsonb;
+  v_product_id   uuid;
+  v_unit_id      uuid;
+  v_qty          int;
+  v_unit_price   int;
+  v_conv         numeric(10,4);
+  v_negative     boolean;
+begin
+  -- NOTE: `order_id` and `appended` are in scope as OUT variables of the
+  -- RETURNS TABLE clause — every column reference below is table-qualified
+  -- to avoid ambiguity.
+
+  if jsonb_typeof(p_items) is distinct from 'array' or jsonb_array_length(p_items) = 0 then
+    raise exception 'place_order: p_items must be a non-empty json array';
+  end if;
+
+  -- Replay short-circuit (idempotency). If any order_items row already
+  -- carries this submission_id, the submission was applied — return the
+  -- order it landed on without inserting or decrementing anything.
+  if p_submission_id is not null then
+    -- Scoped to this customer: submission_id is a client-supplied UUID with
+    -- no unique constraint, so a replayed FOREIGN submission_id must not
+    -- resolve to someone else's order. A collision/forge finds nothing here
+    -- and falls through to create/append under the caller's own identity.
+    -- (DEC-041: week scope dropped — the customer scope alone is what keeps
+    -- a replay from resolving to the wrong order after a new open order
+    -- replaced a fulfilled one, because the replayed id's items still point
+    -- at the order they originally landed on.)
+    select oi.order_id into v_order_id
+      from public.order_items oi
+      join public.orders o on o.id = oi.order_id
+     where oi.submission_id = p_submission_id
+       and o.customer_id = p_customer_id
+     limit 1;
+    if v_order_id is not null then
+      -- Report `appended` consistently with the original call: the
+      -- submission was an append iff the order carries items from other
+      -- submissions (or pre-DEC-039 null-submission rows).
+      return query
+        select v_order_id,
+               exists (
+                 select 1 from public.order_items oi
+                  where oi.order_id = v_order_id
+                    and oi.submission_id is distinct from p_submission_id
+               );
+      return;
+    end if;
+  end if;
+
+  -- Resolve the customer's OPEN order — create-or-find loop (DEC-041).
+  -- The partial-index-inferring insert is the race-free arbiter of "who
+  -- creates the row"; losing the race falls through to a locked read of the
+  -- open row. If that row goes terminal between the two statements
+  -- (EvalPlanQual excludes it → zero rows), loop back and re-insert.
+  loop
+    insert into public.orders (
+      customer_id, week_of, fulfillment_type,
+      delivery_address, delivery_preference, pickup_note,
+      notes, status, needs_reconciliation
+    )
+    values (
+      p_customer_id, p_week_of, p_fulfillment_type,
+      p_delivery_address, p_delivery_preference, p_pickup_note,
+      p_notes, 'new', false
+    )
+    on conflict (customer_id) where status in ('new', 'confirmed', 'ready')
+    do nothing
+    returning id into v_order_id;
+
+    if v_order_id is not null then
+      exit;  -- created the open order
+    end if;
+
+    -- Lock the existing open order for this transaction so a concurrent
+    -- append/status change serializes behind us.
+    select o.id, o.status into v_order_id, v_status
+      from public.orders o
+     where o.customer_id = p_customer_id
+       and o.status in ('new', 'confirmed', 'ready')
+       for update;
+
+    if v_order_id is not null then
+      v_appended := true;
+      exit;  -- locked the open order — append path
+    end if;
+    -- Open order vanished (went terminal) between insert and lock; retry.
+  end loop;
+
+  if v_appended then
+    -- In-lock replay re-check — closes the create-vs-append race on a shared
+    -- submission_id. The outside-the-lock replay check above is not enough: two
+    -- concurrent requests with the same submission_id can both pass it (neither
+    -- has committed items yet), one wins the arbiter insert and the other
+    -- arrives here. A unique index on submission_id can't arbitrate (one
+    -- submission legitimately inserts many items sharing the id), so we lock the
+    -- order row, then re-check: the winner's items are now committed and visible
+    -- (READ COMMITTED), so we short-circuit instead of decrementing twice.
+    if p_submission_id is not null and exists (
+      select 1 from public.order_items oi
+       where oi.order_id = v_order_id
+         and oi.submission_id = p_submission_id
+    ) then
+      return query
+        select v_order_id,
+               exists (
+                 select 1 from public.order_items oi
+                  where oi.order_id = v_order_id
+                    and oi.submission_id is distinct from p_submission_id
+               );
+      return;
+    end if;
+
+    -- Notes on an append are additive — never clobber what the customer
+    -- already told Annabel.
+    if coalesce(trim(p_notes), '') <> '' then
+      update public.orders o
+         set notes = case
+                       when coalesce(trim(o.notes), '') = '' then p_notes
+                       else o.notes || ' — ' || p_notes
+                     end,
+             updated_at = now()
+       where o.id = v_order_id;
+    end if;
+  end if;
+
+  for v_item in select * from jsonb_array_elements(p_items)
+  loop
+    v_product_id := (v_item->>'product_id')::uuid;
+    v_qty        := (v_item->>'qty')::int;
+    -- product_unit_id is optional in the payload. When absent, the
+    -- order_items_default_unit BEFORE-INSERT trigger (from 6.5a) fills
+    -- in the first active unit for this product. We resolve the unit
+    -- here too so the price snapshot + decrement math match what the
+    -- row will end up with.
+    v_unit_id := nullif(v_item->>'product_unit_id', '')::uuid;
+    if v_unit_id is null then
+      select pu.id into v_unit_id
+        from public.product_units pu
+       where pu.product_id = v_product_id and pu.is_active = true
+       order by pu.sort_order nulls last, pu.created_at
+       limit 1;
+      -- Distinct error path from the cross-product-id case below so the
+      -- message points at the right remedy: re-activate (or seed) a unit
+      -- on this product, not "fix the unit_id in your payload."
+      if v_unit_id is null then
+        raise exception 'place_order: product % has no active units', v_product_id;
+      end if;
+    end if;
+
+    -- Snapshot from product_units, not from the client payload. If a unit
+    -- id was supplied but doesn't belong to this product (mismatched),
+    -- the lookup returns null and we raise — refusing to record a
+    -- cross-product unit reference rather than silently falling through.
+    select pu.unit_price_cents, pu.conversion_to_base
+      into v_unit_price, v_conv
+      from public.product_units pu
+     where pu.id = v_unit_id and pu.product_id = v_product_id;
+
+    if v_unit_price is null then
+      raise exception
+        'place_order: product_unit_id % does not belong to product %', v_unit_id, v_product_id;
+    end if;
+
+    insert into public.order_items (order_id, product_id, product_unit_id, qty, unit_price_cents, submission_id)
+    values (v_order_id, v_product_id, v_unit_id, v_qty, v_unit_price, p_submission_id);
+
+    -- DEC-036: optimistic oversell (DEC-012) applies only while there is
+    -- stock to draw down. The `qty_available > 0` guard makes this a no-op
+    -- on a sold-out product; FOUND is then false and we reject the whole
+    -- order. qty_available > 0 but insufficient still decrements into the
+    -- negative + flags reconciliation below — unchanged "last few" behavior.
+    update public.products p
+       set qty_available = p.qty_available - (v_qty::numeric * v_conv),
+           updated_at = now()
+     where p.id = v_product_id and p.qty_available > 0;
+
+    if not found then
+      raise exception 'place_order: product % is sold out', v_product_id
+        using errcode = 'P0001';
+    end if;
+  end loop;
+
+  -- An append re-enters Annabel's pipeline: a confirmed/ready order goes
+  -- back to 'new' (the stale confirmation SMS is covered by Re-send). A
+  -- 'new' order is untouched; a terminal order is unreachable here (the
+  -- lock predicate only finds open orders).
+  if v_appended then
+    update public.orders o
+       set status = 'new',
+           updated_at = now()
+     where o.id = v_order_id
+       and o.status in ('confirmed', 'ready');
+  end if;
+
+  -- Flip needs_reconciliation if any product touched by this order is now
+  -- negative. The join runs over ALL the order's items (original +
+  -- appended), so an append re-evaluates the whole order.
+  select exists (
+    select 1
+    from public.products p
+    join public.order_items oi on oi.product_id = p.id
+    where oi.order_id = v_order_id
+      and p.qty_available < 0
+  ) into v_negative;
+
+  if v_negative then
+    update public.orders o
+       set needs_reconciliation = true
+     where o.id = v_order_id;
+  end if;
+
+  return query select v_order_id, v_appended;
+end;
+$$;

--- a/supabase/tests/place_order_additive.sql
+++ b/supabase/tests/place_order_additive.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(31);
+select plan(32);
 
 -- ============================================================
 -- #211 / DEC-039 + #226 / DEC-041 — additive orders on the
@@ -450,33 +450,44 @@ select is(
 );
 
 -- ============================================================
--- 30. Replay against a now-terminal order: the replay short-circuit
+-- 30–31. Replay against a now-terminal order: the replay short-circuit
 --     returns the order the submission originally landed on, even
---     though it has since been fulfilled — no new order, no writes.
+--     though it has since been fulfilled — no new order, no writes —
+--     and reports appended = true (the order carries items from other
+--     submissions).
 -- ============================================================
+create temp table s1_replay as
+select * from public.place_order(
+  'ee390000-0000-0000-0000-000000000001'::uuid,
+  '2026-06-01'::date,
+  'delivery', '123 Additive St', '', '', 'first note',
+  jsonb_build_array(
+    jsonb_build_object(
+      'product_id',      'ee390000-0000-0000-0000-aaaa00000001'::text,
+      'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text,
+      'qty',             2,
+      'unit_price_cents', 500
+    )
+  ),
+  'ee39aaaa-0000-0000-0000-000000000001'::uuid
+);
+
 select is(
-  (select t.order_id from public.place_order(
-     'ee390000-0000-0000-0000-000000000001'::uuid,
-     '2026-06-01'::date,
-     'delivery', '123 Additive St', '', '', 'first note',
-     jsonb_build_array(
-       jsonb_build_object(
-         'product_id',      'ee390000-0000-0000-0000-aaaa00000001'::text,
-         'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text,
-         'qty',             2,
-         'unit_price_cents', 500
-       )
-     ),
-     'ee39aaaa-0000-0000-0000-000000000001'::uuid
-   ) t),
+  (select order_id from s1_replay),
   (select oi.order_id from public.order_items oi
    where oi.submission_id = 'ee39aaaa-0000-0000-0000-000000000001'::uuid
    limit 1),
   'replaying a submission whose order went terminal returns that order — no new order created'
 );
 
+select is(
+  (select appended from s1_replay),
+  true,
+  'terminal replay reports appended = true (order carries other submissions'' items)'
+);
+
 -- ============================================================
--- 31. Foreign-submission_id scoping: customer B replaying customer A's
+-- 32. Foreign-submission_id scoping: customer B replaying customer A's
 --     submission_id must NOT resolve to A's order — the replay check is
 --     scoped to the customer, so B gets their own fresh order.
 -- ============================================================

--- a/supabase/tests/place_order_additive.sql
+++ b/supabase/tests/place_order_additive.sql
@@ -1,19 +1,23 @@
 begin;
-select plan(25);
+select plan(31);
 
 -- ============================================================
--- #211 / DEC-039 — additive orders: place_order appends to the
--- week's single (customer, week) order.
+-- #211 / DEC-039 + #226 / DEC-041 — additive orders on the
+-- open-order identity model.
 --
--- Verifies the post-DEC-039 contract:
---   - first submission creates the order (appended = false); later
---     submissions APPEND order_items to it (appended = true) — still
---     exactly one orders row per (customer, week).
+-- Verifies the post-DEC-041 contract:
+--   - first submission creates the customer's OPEN order (appended =
+--     false); later submissions APPEND order_items to it (appended =
+--     true) — at most one open orders row per customer (partial
+--     unique index orders_one_open_per_customer).
 --   - a replay of an already-applied submission_id is a no-op: same
---     order_id back, no new items, no double decrement.
+--     order_id back, no new items, no double decrement — including a
+--     replay whose order has since gone terminal.
 --   - appending to a confirmed/ready order resets status to 'new'
---     (re-enters the pipeline); a picked-up/delivered order refuses
---     the append entirely and writes nothing.
+--     (re-enters the pipeline).
+--   - a terminal order (picked_up/delivered, DEC-044) drops out of
+--     the identity: the next submission CREATES a fresh open order,
+--     leaving the fulfilled one untouched.
 --   - the DEC-036 soldout reject + multi-line atomicity hold on the
 --     append path exactly as on the create path.
 -- ============================================================
@@ -35,7 +39,7 @@ values ('ee390000-0000-0000-0000-bbbb00000001'::uuid,
         'ee390000-0000-0000-0000-aaaa00000001'::uuid,
         'bunch', 1, 500, true, 'add-basil-ee390000', 0);
 
--- In-stock product for the foreign-submission_id scoping check (test 25 runs
+-- In-stock product for the foreign-submission_id scoping check (it runs
 -- after Add Basil has been driven oversold-negative, so B needs its own stock).
 insert into public.products (id, name, qty_available, sort_order, category)
 values ('ee390000-0000-0000-0000-aaaa00000003'::uuid, 'Add Scope', 5.00, 3, 'Herbs');
@@ -55,8 +59,9 @@ values ('ee390000-0000-0000-0000-bbbb00000002'::uuid,
         'bunch', 1, 300, true, 'add-zero-stock-ee390000', 0);
 
 -- ============================================================
--- 1–3. First submission creates the week's order: appended = false,
---      one orders row, inventory decremented.
+-- 1–3. First submission creates the open order: appended = false,
+--      one orders row, inventory decremented. week_of is a stamp,
+--      not identity (DEC-041).
 -- ============================================================
 select is(
   (select t.appended from public.place_order(
@@ -79,8 +84,7 @@ select is(
 
 select is(
   (select count(*)::int from public.orders
-   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
-     and week_of = '2026-06-01'),
+   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid),
   1,
   'exactly one orders row after the first submission'
 );
@@ -93,8 +97,9 @@ select is(
 );
 
 -- ============================================================
--- 4–7. (a) Second submission APPENDS: appended = true, still one
---      orders row, item count grows, inventory decremented again.
+-- 4–7. (a) Second submission APPENDS to the open order: appended =
+--      true, still one orders row, item count grows, inventory
+--      decremented again.
 -- ============================================================
 select is(
   (select t.appended from public.place_order(
@@ -117,17 +122,15 @@ select is(
 
 select is(
   (select count(*)::int from public.orders
-   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
-     and week_of = '2026-06-01'),
+   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid),
   1,
-  'still exactly one orders row after the append (unique constraint holds)'
+  'still exactly one orders row after the append (open-order identity holds)'
 );
 
 select is(
   (select count(*)::int from public.order_items oi
    join public.orders o on o.id = oi.order_id
-   where o.customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
-     and o.week_of = '2026-06-01'),
+   where o.customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid),
   2,
   'append added a line item (2 total)'
 );
@@ -158,17 +161,16 @@ select is(
      ),
      'ee39aaaa-0000-0000-0000-000000000002'::uuid
    ) t),
-  (select id from public.orders
-   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
-     and week_of = '2026-06-01'),
+  (select oi.order_id from public.order_items oi
+   where oi.submission_id = 'ee39aaaa-0000-0000-0000-000000000002'::uuid
+   limit 1),
   'replayed submission_id returns the existing order id'
 );
 
 select is(
   (select count(*)::int from public.order_items oi
    join public.orders o on o.id = oi.order_id
-   where o.customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
-     and o.week_of = '2026-06-01'),
+   where o.customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid),
   2,
   'replay inserted no new items'
 );
@@ -186,8 +188,7 @@ select is(
 --        the stale confirmation SMS).
 -- ============================================================
 update public.orders set status = 'confirmed'
- where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
-   and week_of = '2026-06-01';
+ where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid;
 
 select lives_ok(
   $$ select * from public.place_order(
@@ -209,15 +210,13 @@ select lives_ok(
 
 select is(
   (select status from public.orders
-   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
-     and week_of = '2026-06-01'),
+   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid),
   'new',
   'append resets confirmed → new'
 );
 
 update public.orders set status = 'ready'
- where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
-   and week_of = '2026-06-01';
+ where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid;
 
 select lives_ok(
   $$ select * from public.place_order(
@@ -239,91 +238,139 @@ select lives_ok(
 
 select is(
   (select status from public.orders
-   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
-     and week_of = '2026-06-01'),
+   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid),
   'new',
   'append resets ready → new'
 );
 
 -- ============================================================
--- 15–18. (d) Appending to a terminal order (picked-up / delivered)
---        raises and writes nothing — the box is gone.
+-- 15–19. (d) DEC-041: a terminal order (picked_up) drops out of the
+--        identity — the next submission CREATES a fresh open order
+--        (appended = false), leaving the fulfilled order untouched.
 -- ============================================================
-update public.orders set status = 'picked-up'
- where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
-   and week_of = '2026-06-01';
+update public.orders set status = 'picked_up'
+ where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid;
 
-select throws_like(
-  $$ select * from public.place_order(
-       'ee390000-0000-0000-0000-000000000001'::uuid,
-       '2026-06-01'::date,
-       'delivery', '123 Additive St', '', '', '',
-       jsonb_build_array(
-         jsonb_build_object(
-           'product_id',      'ee390000-0000-0000-0000-aaaa00000001'::text,
-           'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text,
-           'qty',             1,
-           'unit_price_cents', 500
-         )
-       ),
-       'ee39aaaa-0000-0000-0000-000000000005'::uuid
-     ) $$,
-  '%already fulfilled%',
-  'append to a picked-up order is refused'
+create temp table s5_result as
+select * from public.place_order(
+  'ee390000-0000-0000-0000-000000000001'::uuid,
+  '2026-06-08'::date,
+  'delivery', '123 Additive St', '', '', '',
+  jsonb_build_array(
+    jsonb_build_object(
+      'product_id',      'ee390000-0000-0000-0000-aaaa00000001'::text,
+      'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text,
+      'qty',             1,
+      'unit_price_cents', 500
+    )
+  ),
+  'ee39aaaa-0000-0000-0000-000000000005'::uuid
+);
+
+select is(
+  (select appended from s5_result),
+  false,
+  'submission against a picked_up order CREATES a new open order — appended = false'
+);
+
+select isnt(
+  (select order_id from s5_result),
+  (select oi.order_id from public.order_items oi
+   where oi.submission_id = 'ee39aaaa-0000-0000-0000-000000000001'::uuid
+   limit 1),
+  'the new open order is a different row than the fulfilled one'
+);
+
+select is(
+  (select count(*)::int from public.orders
+   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid),
+  2,
+  'two orders rows now: one picked_up, one new open'
 );
 
 select is(
   (select count(*)::int from public.order_items oi
-   join public.orders o on o.id = oi.order_id
-   where o.customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
-     and o.week_of = '2026-06-01'),
+   where oi.order_id = (select o.id from public.orders o
+                        where o.customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+                          and o.status = 'picked_up')),
   4,
-  'refused append wrote no items (still 4 from s1–s4)'
+  'the fulfilled order''s items are untouched (still 4 from s1–s4)'
 );
 
 select is(
   (select qty_available from public.products
    where id = 'ee390000-0000-0000-0000-aaaa00000001'::uuid),
-  13.00::numeric(10,2),
-  'refused append did not decrement inventory (still 13)'
-);
-
-update public.orders set status = 'delivered'
- where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
-   and week_of = '2026-06-01';
-
-select throws_like(
-  $$ select * from public.place_order(
-       'ee390000-0000-0000-0000-000000000001'::uuid,
-       '2026-06-01'::date,
-       'delivery', '123 Additive St', '', '', '',
-       jsonb_build_array(
-         jsonb_build_object(
-           'product_id',      'ee390000-0000-0000-0000-aaaa00000001'::text,
-           'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text,
-           'qty',             1,
-           'unit_price_cents', 500
-         )
-       ),
-       'ee39aaaa-0000-0000-0000-000000000006'::uuid
-     ) $$,
-  '%already fulfilled%',
-  'append to a delivered order is refused'
+  12.00::numeric(10,2),
+  'inventory decremented for the new order (13 - 1 = 12)'
 );
 
 -- ============================================================
--- 19–22. (e) DEC-036 on the append path: a sold-out line rejects the
+-- 20–21. Partial unique index enforcement: a second OPEN order per
+--        customer is refused at the DB level; terminal rows fall
+--        outside the predicate and are allowed.
+-- ============================================================
+select throws_ok(
+  $$ insert into public.orders (customer_id, week_of, fulfillment_type, status)
+     values ('ee390000-0000-0000-0000-000000000001'::uuid, '2026-06-08'::date, 'delivery', 'new') $$,
+  '23505',
+  null,
+  'partial unique index refuses a second open order per customer'
+);
+
+select lives_ok(
+  $$ insert into public.orders (id, customer_id, week_of, fulfillment_type, status)
+     values ('ee390000-0000-0000-0000-dddd00000001'::uuid,
+             'ee390000-0000-0000-0000-000000000001'::uuid,
+             '2026-05-25'::date, 'delivery', 'delivered') $$,
+  'a terminal row is outside the index predicate — inserting one is allowed'
+);
+
+-- Remove the probe row so later counts stay legible.
+delete from public.orders where id = 'ee390000-0000-0000-0000-dddd00000001'::uuid;
+
+-- ============================================================
+-- 22–23. Delivered also frees a new order (both terminal statuses
+--        drop out of the identity).
+-- ============================================================
+update public.orders set status = 'delivered'
+ where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
+   and status = 'new';
+
+select is(
+  (select t.appended from public.place_order(
+     'ee390000-0000-0000-0000-000000000001'::uuid,
+     '2026-06-08'::date,
+     'delivery', '123 Additive St', '', '', '',
+     jsonb_build_array(
+       jsonb_build_object(
+         'product_id',      'ee390000-0000-0000-0000-aaaa00000001'::text,
+         'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text,
+         'qty',             1,
+         'unit_price_cents', 500
+       )
+     ),
+     'ee39aaaa-0000-0000-0000-000000000006'::uuid
+   ) t),
+  false,
+  'a delivered order also frees a new one — appended = false'
+);
+
+select is(
+  (select count(*)::int from public.orders
+   where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid),
+  3,
+  'three orders rows: picked_up, delivered, new open'
+);
+
+-- ============================================================
+-- 24–27. (e) DEC-036 on the append path: a sold-out line rejects the
 --        append; multi-line appends are atomic (the in-stock line's
 --        write rolls back when a later line is sold out).
 -- ============================================================
-update public.orders set status = 'new'
- where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
-   and week_of = '2026-06-01';
-
 select throws_like(
   $$ select * from public.place_order(
        'ee390000-0000-0000-0000-000000000001'::uuid,
-       '2026-06-01'::date,
+       '2026-06-08'::date,
        'delivery', '123 Additive St', '', '', '',
        jsonb_build_array(
          jsonb_build_object(
@@ -345,7 +392,7 @@ select throws_like(
 select throws_like(
   $$ select * from public.place_order(
        'ee390000-0000-0000-0000-000000000001'::uuid,
-       '2026-06-01'::date,
+       '2026-06-08'::date,
        'delivery', '123 Additive St', '', '', '',
        jsonb_build_array(
          jsonb_build_object('product_id', 'ee390000-0000-0000-0000-aaaa00000001'::text, 'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text, 'qty', 1, 'unit_price_cents', 500),
@@ -360,8 +407,8 @@ select throws_like(
 select is(
   (select qty_available from public.products
    where id = 'ee390000-0000-0000-0000-aaaa00000001'::uuid),
-  13.00::numeric(10,2),
-  'in-stock line in the rejected multi-line append is NOT decremented (still 13)'
+  11.00::numeric(10,2),
+  'in-stock line in the rejected multi-line append is NOT decremented (still 11)'
 );
 
 select is(
@@ -372,14 +419,14 @@ select is(
 );
 
 -- ============================================================
--- 23–24. Reconciliation recomputes across the whole order on append:
+-- 28–29. Reconciliation recomputes across the whole order on append:
 --        an oversold append (qty > 0 but insufficient) still goes
 --        through (DEC-012) and flips needs_reconciliation.
 -- ============================================================
 select lives_ok(
   $$ select * from public.place_order(
        'ee390000-0000-0000-0000-000000000001'::uuid,
-       '2026-06-01'::date,
+       '2026-06-08'::date,
        'delivery', '123 Additive St', '', '', '',
        jsonb_build_array(
          jsonb_build_object(
@@ -391,26 +438,52 @@ select lives_ok(
        ),
        'ee39aaaa-0000-0000-0000-000000000009'::uuid
      ) $$,
-  'oversold append (13 left, 20 ordered) is accepted (DEC-012)'
+  'oversold append (11 left, 20 ordered) is accepted (DEC-012)'
 );
 
 select is(
   (select needs_reconciliation from public.orders
    where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
-     and week_of = '2026-06-01'),
+     and status = 'new'),
   true,
   'needs_reconciliation flipped true by the oversold append'
 );
 
 -- ============================================================
--- 25. Foreign-submission_id scoping: customer B replaying customer A's
+-- 30. Replay against a now-terminal order: the replay short-circuit
+--     returns the order the submission originally landed on, even
+--     though it has since been fulfilled — no new order, no writes.
+-- ============================================================
+select is(
+  (select t.order_id from public.place_order(
+     'ee390000-0000-0000-0000-000000000001'::uuid,
+     '2026-06-01'::date,
+     'delivery', '123 Additive St', '', '', 'first note',
+     jsonb_build_array(
+       jsonb_build_object(
+         'product_id',      'ee390000-0000-0000-0000-aaaa00000001'::text,
+         'product_unit_id', 'ee390000-0000-0000-0000-bbbb00000001'::text,
+         'qty',             2,
+         'unit_price_cents', 500
+       )
+     ),
+     'ee39aaaa-0000-0000-0000-000000000001'::uuid
+   ) t),
+  (select oi.order_id from public.order_items oi
+   where oi.submission_id = 'ee39aaaa-0000-0000-0000-000000000001'::uuid
+   limit 1),
+  'replaying a submission whose order went terminal returns that order — no new order created'
+);
+
+-- ============================================================
+-- 31. Foreign-submission_id scoping: customer B replaying customer A's
 --     submission_id must NOT resolve to A's order — the replay check is
---     scoped to (customer, week), so B gets their own fresh order.
+--     scoped to the customer, so B gets their own fresh order.
 -- ============================================================
 select isnt(
   (select t.order_id from public.place_order(
      'ee390000-0000-0000-0000-000000000002'::uuid,
-     '2026-06-01'::date,
+     '2026-06-08'::date,
      'pickup', '', '', 'B pickup', '',
      jsonb_build_array(
        jsonb_build_object(
@@ -422,9 +495,9 @@ select isnt(
      ),
      'ee39aaaa-0000-0000-0000-000000000001'::uuid  -- A's submission_id
    ) t),
-  (select id from public.orders
-    where customer_id = 'ee390000-0000-0000-0000-000000000001'::uuid
-      and week_of = '2026-06-01'),
+  (select oi.order_id from public.order_items oi
+   where oi.submission_id = 'ee39aaaa-0000-0000-0000-000000000001'::uuid
+   limit 1),
   'replaying another customer''s submission_id returns B''s own order, not A''s'
 );
 

--- a/tests/admin-orders.spec.ts
+++ b/tests/admin-orders.spec.ts
@@ -181,7 +181,7 @@ test.describe("admin orders list", () => {
     await expect(row.locator(".pill-ready")).toHaveText("Ready");
   });
 
-  test("pickup order: ready advances to picked-up (not delivered)", async ({ page }) => {
+  test("pickup order: ready advances to picked_up (not delivered)", async ({ page }) => {
     const ids = await customerIds();
     const orderId = await seedOrder({
       customerId: ids.farmStand,
@@ -199,7 +199,7 @@ test.describe("admin orders list", () => {
     // Pickup orders show the "Mark picked up" advance button, not "Delivered".
     await expect(row.getByRole("button", { name: /delivered/i })).toHaveCount(0);
     await row.getByRole("button", { name: /picked up/i }).click();
-    await expect(row).toHaveAttribute("data-status", "picked-up", { timeout: 5000 });
+    await expect(row).toHaveAttribute("data-status", "picked_up", { timeout: 5000 });
 
     // DB confirmation
     const sb = admin();
@@ -215,7 +215,7 @@ test.describe("admin orders list", () => {
         },
         { timeout: 5000 },
       )
-      .toBe("picked-up");
+      .toBe("picked_up");
   });
 
   test("action stack: collapsed shows only the chip; expanded Confirm+Send advances new → confirmed; reminder wording follows fulfillment (#192/#193)", async ({ page }, testInfo) => {

--- a/tests/customer-additional-orders.spec.ts
+++ b/tests/customer-additional-orders.spec.ts
@@ -13,10 +13,11 @@ import {
   setOrderingOpen,
 } from "./helpers";
 
-// #211 / DEC-039 — additive orders. A customer with an order for the current
-// week can append items to it via the /confirmed hub's "Add to your order"
-// button (→ /c/[token]?add=1, the form's ADD MODE). One orders row per
-// (customer, week) throughout; appends grow order_items.
+// #211/DEC-039 + #227/DEC-041/DEC-042 — additive orders on the open-order
+// model. A customer's link renders their OPEN order editable (pre-populated
+// add mode; new items append). A terminal order (picked_up/delivered) drops
+// out of the identity: /confirmed shows it read-only with a "Place a new
+// order" path, and /c/[token] serves a fresh form.
 
 // Bumps the stepper on a named product to qty without relying on press-and-hold.
 async function stepUp(page: Page, productName: string, qty: number) {
@@ -35,7 +36,7 @@ test.describe("/c/[token] additional orders", () => {
     await resetCustomerOrderState();
   });
 
-  test("happy path: add via ?add=1 appends to the week's order — merged total, one orders row, inventory decremented", async ({
+  test("happy path: revisiting the link appends to the open order — merged total, one orders row, inventory decremented", async ({
     page,
   }) => {
     // Place the initial order through the real form (kale ×2, delivery).
@@ -45,11 +46,11 @@ test.describe("/c/[token] additional orders", () => {
     await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
 
     // The hub offers the add entry point (store open, products orderable,
-    // order not terminal).
+    // order not terminal) — it now points at the plain order link.
     const addLink = page.getByRole("link", { name: "Add to your order" });
     await expect(addLink).toBeVisible();
     await addLink.click();
-    await page.waitForURL(/\/c\/[^/]+\?add=1$/);
+    await page.waitForURL(/\/c\/[^/]+$/);
 
     // Add mode: fulfillment is read-only — no tabs, no editable preference.
     await expect(page.locator(".fulfill-tabs")).toHaveCount(0);
@@ -69,15 +70,15 @@ test.describe("/c/[token] additional orders", () => {
     await expect(page.locator(".confirm-list")).toContainText(TEST_PRODUCTS.eggs.name);
     await expect(page.locator(".confirm-total")).toContainText("12.00");
 
-    // DB: still exactly one orders row for (customer, week); two line items;
-    // inventory decremented for the appended line too.
+    // DB: still exactly one OPEN orders row for the customer; two line
+    // items; inventory decremented for the appended line too.
     const sb = admin();
     const ids = await customerIds();
     const { data: orders } = await sb
       .from("orders")
       .select("id, status")
       .eq("customer_id", ids.farmStand)
-      .eq("week_of", weekOfMondayNY());
+      .in("status", ["new", "confirmed", "ready"]);
     expect(orders).toHaveLength(1);
 
     const { data: items } = await sb
@@ -96,7 +97,7 @@ test.describe("/c/[token] additional orders", () => {
     expect(eggs?.qty_available).toBe(TEST_PRODUCTS.eggs.qty_available - 1);
   });
 
-  test("add mode shows the existing order's fulfillment read-only", async ({ page }) => {
+  test("open order renders the form in add mode with fulfillment read-only", async ({ page }) => {
     const ids = await customerIds();
     await seedOrder({
       customerId: ids.farmStand,
@@ -105,7 +106,7 @@ test.describe("/c/[token] additional orders", () => {
       items: [{ productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 }],
     });
 
-    await page.goto(`${customerOrderUrl(TEST_CUSTOMERS.farmStand.token)}?add=1`);
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
     await expect(page.getByRole("heading", { name: "Going with your order" })).toBeVisible();
     // seedOrder's delivery address, rendered as text — not an input.
     await expect(page.locator(".fulfill .addr-text")).toHaveText("123 Test St");
@@ -126,7 +127,7 @@ test.describe("/c/[token] additional orders", () => {
       items: [{ productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 }],
     });
 
-    await page.goto(`${customerOrderUrl(TEST_CUSTOMERS.farmStand.token)}?add=1`);
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
 
     // Already-ordered kale ×1 ($3.00) renders read-only in the summary.
     const existing = page.locator(".rail-existing:visible");
@@ -179,26 +180,49 @@ test.describe("/c/[token] additional orders", () => {
     }
   });
 
-  test("hub gating: terminal order hides the add button; ?add=1 bounces back to /confirmed", async ({
+  // DEC-041: a fulfilled order drops out of the open-order identity — the
+  // receipt goes read-only with a "Place a new order" path, and the order
+  // link serves a fresh form whose submit CREATES a second orders row.
+  test("terminal order: read-only receipt offers a new order; the link serves a fresh form that creates one", async ({
     page,
   }) => {
     const ids = await customerIds();
-    await seedOrder({
+    const fulfilledId = await seedOrder({
       customerId: ids.farmStand,
       weekOf: weekOfMondayNY(),
       fulfillmentType: "pickup",
-      status: "picked-up",
+      status: "picked_up",
       items: [{ productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 }],
     });
 
+    // /confirmed: read-only receipt — no add affordance, packed copy, and
+    // the "Place a new order" path (store open, products orderable).
     await page.goto(`${customerOrderUrl(TEST_CUSTOMERS.farmStand.token)}/confirmed`);
     await expect(page.getByRole("heading", { name: /Order received/i })).toBeVisible();
     await expect(page.getByRole("link", { name: "Add to your order" })).toHaveCount(0);
     await expect(page.getByText(/been packed/)).toBeVisible();
 
-    // A stale ?add=1 link can't reach the form against a fulfilled order —
-    // the page bounces it to /confirmed (where the reason copy lives).
-    await page.goto(`${customerOrderUrl(TEST_CUSTOMERS.farmStand.token)}?add=1`);
+    // The order link serves a FRESH form (not the add-mode view).
+    await page.getByRole("link", { name: "Place a new order" }).click();
+    await page.waitForURL(/\/c\/[^/]+$/);
+    await expect(page.getByRole("heading", { name: /What.s available/i })).toBeVisible();
+    await expect(page.locator(".rail-existing")).toHaveCount(0);
+
+    // Submitting creates a SECOND order — the fulfilled one is untouched.
+    await stepUp(page, TEST_PRODUCTS.eggs.name, 1);
+    await page.locator(".submit-btn").click();
     await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
+
+    const sb = admin();
+    const { data: orders } = await sb
+      .from("orders")
+      .select("id, status")
+      .eq("customer_id", ids.farmStand)
+      .eq("week_of", weekOfMondayNY());
+    expect(orders).toHaveLength(2);
+    const fulfilled = orders!.find((o) => o.id === fulfilledId);
+    expect(fulfilled?.status).toBe("picked_up");
+    const fresh = orders!.find((o) => o.id !== fulfilledId);
+    expect(fresh?.status).toBe("new");
   });
 });

--- a/tests/customer-additional-orders.spec.ts
+++ b/tests/customer-additional-orders.spec.ts
@@ -157,6 +157,12 @@ test.describe("/c/[token] additional orders", () => {
       await expect(page.getByRole("heading", { name: /Order received/i })).toBeVisible();
       await expect(page.getByRole("link", { name: "Add to your order" })).toHaveCount(0);
       await expect(page.getByText("Ordering’s closed for this week.")).toBeVisible();
+
+      // The closed shell must not eat the open order: the customer's link
+      // redirects to the receipt instead of dead-ending at "closed".
+      await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+      await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
+      await expect(page.getByRole("heading", { name: /Order received/i })).toBeVisible();
     } finally {
       await setOrderingOpen(true);
     }

--- a/tests/customer-order-form.spec.ts
+++ b/tests/customer-order-form.spec.ts
@@ -7,9 +7,9 @@ import {
 } from "./helpers";
 
 test.describe("/c/[token] order form", () => {
-  // /c/[token] now redirects to /confirmed whenever an order exists for the
-  // current week, so any prior spec that left an order behind would break
-  // every form test below. Clear the slate before each.
+  // /c/[token] renders an open order as the pre-populated add-mode form
+  // (DEC-041), so any prior spec that left an order behind would break
+  // every fresh-form test below. Clear the slate before each.
   test.beforeEach(async () => {
     await resetCustomerOrderState();
   });

--- a/tests/customer-place-order.spec.ts
+++ b/tests/customer-place-order.spec.ts
@@ -34,11 +34,11 @@ test.describe("/c/[token] place order", () => {
   });
 
   // Without this, the last "happy path" test leaves a freshly-placed order
-  // for the seeded farmStand customer in the current week. The next spec to
-  // alphabetically follow (notifications-flow.spec.ts) opens /c/<token> and
-  // expects to see the "What's available" heading — but the /c page redirects
-  // to /confirmed whenever an order exists for the current week, so the
-  // assertion times out. resetCustomerOrderState clears it.
+  // for the seeded farmStand customer. The next spec to alphabetically
+  // follow (notifications-flow.spec.ts) opens /c/<token> and expects to see
+  // the "What's available" heading — but the /c page renders an open order
+  // as the pre-populated add-mode form (DEC-041), so the assertion times
+  // out. resetCustomerOrderState clears it.
   test.afterAll(async () => {
     await resetCustomerOrderState();
   });
@@ -172,7 +172,7 @@ test.describe("/c/[token] place order", () => {
     expect(eggs?.qty_available).toBe(-4);
   });
 
-  test("revisiting /c/[token] after submit redirects to /confirmed (no empty form)", async ({
+  test("revisiting /c/[token] after submit shows the open order pre-populated (no empty form)", async ({
     page,
   }) => {
     await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
@@ -180,32 +180,31 @@ test.describe("/c/[token] place order", () => {
     await page.locator(".submit-btn").click();
     await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
 
-    // The link is "your weekly order" — revisiting after submit must NOT
-    // re-show the empty form (adding more goes through ?add=1, which is
-    // customer-additional-orders.spec.ts territory). DEC-039 note: a second
-    // submit with NEW items now APPENDS to the same order row rather than
-    // no-opping — the true no-op is a same-submission_id replay (covered in
-    // pgTAP place_order_additive.sql). Either way the row count below stays 1.
+    // DEC-041 (#227): the link renders the OPEN order editable — revisiting
+    // after submit shows the add-mode form pre-populated with what was
+    // ordered, never an empty form and never a bounce. A second submit with
+    // NEW items APPENDS to the same order row (the true no-op is a
+    // same-submission_id replay — pgTAP place_order_additive.sql).
     await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
-    await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
     await expect(
-      page.getByRole("heading", { name: /Order received/i }),
+      page.getByRole("heading", { name: "Going with your order" }),
     ).toBeVisible();
-    await expect(page.locator(".confirm-list")).toContainText(
+    await expect(page.locator(".rail-existing:visible")).toContainText(
       TEST_PRODUCTS.kale.name,
     );
+    await expect(page.locator(".submit-btn")).toHaveText("Update order");
 
-    // And exactly one orders row exists for the current week — DEC-039 keeps
-    // the unique (customer_id, week_of) constraint, so even appends never
-    // create a second row. (Filtered to this week so the global-setup
-    // prior-order fixture doesn't inflate the count.)
+    // And exactly one OPEN orders row exists — the partial unique index
+    // (orders_one_open_per_customer) makes a second one impossible.
+    // (Status-filtered so the global-setup delivered fixture doesn't
+    // inflate the count.)
     const farmStandId = await getCustomerId(TEST_CUSTOMERS.farmStand.token);
     const sb = admin();
     const { data: orders } = await sb
       .from("orders")
       .select("id")
       .eq("customer_id", farmStandId)
-      .eq("week_of", weekOfMondayNY());
+      .in("status", ["new", "confirmed", "ready"]);
     expect(orders).toHaveLength(1);
   });
 });

--- a/tests/customer-token.spec.ts
+++ b/tests/customer-token.spec.ts
@@ -9,8 +9,8 @@ import {
 const COOKIE = "bbf_customer_token";
 
 test.describe("/c/[token] route", () => {
-  // /c/[token] now redirects to /confirmed if an order exists for the week;
-  // these tests assert the form rendered, so reset to keep them deterministic
+  // /c/[token] renders an open order as the add-mode form (DEC-041); these
+  // tests assert the fresh form rendered, so reset to keep them deterministic
   // regardless of spec ordering. #130 added a paused/closed shell that
   // short-circuits before the form, so we also normalise both account-state
   // flags here — otherwise a prior spec leaving send_weekly_link=false on a

--- a/tests/fulfillment-report.spec.ts
+++ b/tests/fulfillment-report.spec.ts
@@ -88,7 +88,7 @@ test("invalid token 404s", async ({ page }) => {
   await expect(page.getByText("This link doesn’t work.")).toBeVisible();
 });
 
-test("excludes picked-up / delivered orders (#200)", async ({ page }) => {
+test("excludes picked_up / delivered orders (#200)", async ({ page }) => {
   const ids = await customerIds();
   const sb = admin();
   // The restaurant's (delivery) order is fulfilled — out the door.
@@ -120,5 +120,38 @@ test("excludes picked-up / delivered orders (#200)", async ({ page }) => {
       .update({ status: "new" })
       .eq("customer_id", ids.restaurant)
       .eq("week_of", WEEK);
+  }
+});
+
+// DEC-041/DEC-042 (#227): the sheet is status-keyed, not week-keyed — an open
+// order that crosses a week boundary keeps printing until it's out the door.
+test("shows open orders from past weeks", async ({ page }) => {
+  const ids = await customerIds();
+  const sb = admin();
+  const [y, m, d] = WEEK.split("-").map((n) => parseInt(n, 10));
+  const lastMonday = new Date(Date.UTC(y, m - 1, d - 7)).toISOString().slice(0, 10);
+  // Re-stamp the farm stand's open order into LAST week (update, not insert —
+  // the partial unique index allows only one open order per customer).
+  await sb
+    .from("orders")
+    .update({ week_of: lastMonday })
+    .eq("customer_id", ids.farmStand)
+    .eq("week_of", WEEK);
+
+  try {
+    await page.goto(`/f/${await fulfillmentToken()}`);
+    await expect(
+      page.locator(".fr-slip", { hasText: TEST_CUSTOMERS.farmStand.name }),
+    ).toHaveCount(1);
+    // Its items still roll into the harvest totals (Kale 3 + restaurant's 2).
+    await expect(
+      page.locator(".fr-hv-row", { hasText: "Kale" }).locator(".fr-hv-unit-qty"),
+    ).toHaveText("5");
+  } finally {
+    await sb
+      .from("orders")
+      .update({ week_of: WEEK })
+      .eq("customer_id", ids.farmStand)
+      .eq("week_of", lastMonday);
   }
 });

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -163,8 +163,10 @@ export default async function globalSetup() {
     throw new Error(`customers upsert failed: ${customersError.message}`);
 
   // Seed a prior delivery order for Test Farm Stand so 3.4 delivery_preference
-  // prefill is testable. week_of is in the past so it doesn't collide with the
-  // current week's order in 3.5+ tests. unique (customer_id, week_of) → upsert.
+  // prefill is testable. week_of is in the past and status terminal so it
+  // neither collides with current-week tests nor occupies the open-order
+  // identity (DEC-041 dropped unique (customer_id, week_of), so this is a
+  // check-then-insert rather than an upsert).
   const { data: farmStandRow, error: lookupError } = await adminClient
     .from("customers")
     .select("id")
@@ -173,23 +175,28 @@ export default async function globalSetup() {
   if (lookupError || !farmStandRow)
     throw new Error(`farm stand lookup failed: ${lookupError?.message ?? "no row"}`);
 
-  const { error: priorOrderError } = await adminClient.from("orders").upsert(
-    [
-      {
-        customer_id: farmStandRow.id,
-        week_of: "2026-04-27",
-        fulfillment_type: "delivery",
-        delivery_address: "100 Farm Stand Way, Lakewood, OH 44107",
-        delivery_preference: "Back door, gate code 4321",
-        status: "delivered",
-        notes: null,
-        pickup_note: null,
-      },
-    ],
-    { onConflict: "customer_id,week_of" },
-  );
-  if (priorOrderError)
-    throw new Error(`prior order upsert failed: ${priorOrderError.message}`);
+  const { data: existingPrior, error: priorLookupError } = await adminClient
+    .from("orders")
+    .select("id")
+    .eq("customer_id", farmStandRow.id)
+    .eq("week_of", "2026-04-27")
+    .maybeSingle();
+  if (priorLookupError)
+    throw new Error(`prior order lookup failed: ${priorLookupError.message}`);
+  if (!existingPrior) {
+    const { error: priorOrderError } = await adminClient.from("orders").insert({
+      customer_id: farmStandRow.id,
+      week_of: "2026-04-27",
+      fulfillment_type: "delivery",
+      delivery_address: "100 Farm Stand Way, Lakewood, OH 44107",
+      delivery_preference: "Back door, gate code 4321",
+      status: "delivered",
+      notes: null,
+      pickup_note: null,
+    });
+    if (priorOrderError)
+      throw new Error(`prior order insert failed: ${priorOrderError.message}`);
+  }
 
   // Sign in to get a real, server-verified session
   const anonClient = createClient(supabaseUrl, anonKey, {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -75,7 +75,7 @@ export type SeedOrderInput = {
   customerId: string;
   weekOf: string;
   fulfillmentType: "pickup" | "delivery";
-  status?: "new" | "confirmed" | "ready" | "picked-up" | "delivered";
+  status?: "new" | "confirmed" | "ready" | "picked_up" | "delivered";
   needsReconciliation?: boolean;
   // Opt-in for delivery orders. Defaults to null — matches admin-orders-export
   // and orders-flow specs' pre-refactor behavior. admin-orders.spec passes
@@ -115,16 +115,17 @@ export async function seedOrder(input: SeedOrderInput): Promise<string> {
   return order.id;
 }
 
-// Clears current-NY-week orders for the seeded test customers and restores
+// Clears the seeded test customers' current-NY-week orders AND any open
+// (non-terminal) order regardless of week, then restores
 // products.qty_available to the seed values. Used by customer-side spec
-// beforeEach hooks so spec ordering can't leak state — the redirect on
-// /c/[token] now hides the form whenever an order exists for the current
-// week, so any leftover order from a prior spec breaks form-interaction
-// tests that come after it.
+// beforeEach hooks so spec ordering can't leak state — /c/[token] renders
+// an open order as a pre-populated add-mode form (DEC-041), so any leftover
+// open order from a prior spec breaks fresh-form tests that come after it,
+// and the partial unique index makes a leaked open row block seedOrder.
 //
-// Scoped to the current week deliberately so the global-setup fixture
-// (a delivered 2026-04-27 prior order used to assert delivery_preference
-// prefill) is preserved.
+// Terminal orders outside the current week are preserved deliberately —
+// the global-setup fixture (a delivered 2026-04-27 prior order used to
+// assert delivery_preference prefill) must survive.
 export async function resetCustomerOrderState(): Promise<void> {
   const sb = admin();
   const currentWeek = weekOfMondayNY();
@@ -139,7 +140,7 @@ export async function resetCustomerOrderState(): Promise<void> {
         .from("orders")
         .delete()
         .eq("customer_id", data.id)
-        .eq("week_of", currentWeek);
+        .or(`week_of.eq.${currentWeek},status.in.(new,confirmed,ready)`);
     }
   }
   for (const p of Object.values(TEST_PRODUCTS)) {

--- a/tests/order-status-transitions.spec.ts
+++ b/tests/order-status-transitions.spec.ts
@@ -16,7 +16,7 @@ test.describe("order status flow (DEC-035)", () => {
       "new",
       "confirmed",
       "ready",
-      "picked-up",
+      "picked_up",
       "delivered",
     ]);
   });
@@ -27,21 +27,21 @@ test.describe("order status flow (DEC-035)", () => {
     // confirmed is optional — new → ready stays valid
     expect(isValidTransition("new", "ready", "pickup")).toBe(true);
     expect(isValidTransition("confirmed", "ready", "delivery")).toBe(true);
-    expect(isValidTransition("ready", "picked-up", "pickup")).toBe(true);
+    expect(isValidTransition("ready", "picked_up", "pickup")).toBe(true);
     expect(isValidTransition("ready", "delivered", "delivery")).toBe(true);
   });
 
   test("terminal state is pinned to fulfillment type", () => {
-    expect(isValidTransition("ready", "picked-up", "delivery")).toBe(false);
+    expect(isValidTransition("ready", "picked_up", "delivery")).toBe(false);
     expect(isValidTransition("ready", "delivered", "pickup")).toBe(false);
   });
 
   test("skips, regressions, and nonsense transitions are rejected", () => {
-    expect(isValidTransition("new", "picked-up", "pickup")).toBe(false);
+    expect(isValidTransition("new", "picked_up", "pickup")).toBe(false);
     expect(isValidTransition("new", "delivered", "delivery")).toBe(false);
     expect(isValidTransition("confirmed", "new", "pickup")).toBe(false);
     expect(isValidTransition("ready", "confirmed", "pickup")).toBe(false);
-    expect(isValidTransition("picked-up", "ready", "pickup")).toBe(false);
+    expect(isValidTransition("picked_up", "ready", "pickup")).toBe(false);
     expect(isValidTransition("delivered", "ready", "delivery")).toBe(false);
   });
 
@@ -49,7 +49,7 @@ test.describe("order status flow (DEC-035)", () => {
     expect(statusAfterConfirmSend("new")).toBe("confirmed");
     expect(statusAfterConfirmSend("confirmed")).toBe("confirmed");
     expect(statusAfterConfirmSend("ready")).toBe("ready");
-    expect(statusAfterConfirmSend("picked-up")).toBe("picked-up");
+    expect(statusAfterConfirmSend("picked_up")).toBe("picked_up");
     expect(statusAfterConfirmSend("delivered")).toBe("delivered");
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,1 @@
-{
-  "crons": [
-    {
-      "path": "/api/cron/check-schedule",
-      "schedule": "*/5 * * * *"
-    }
-  ]
-}
+{}


### PR DESCRIPTION
## Summary
Phase 9 open-order pivot core, bundled: 9.2 cron disable (DEC-040), 9.5 `picked_up` canonicalization (DEC-044), 9.3a open-order identity (DEC-041), 9.3b customer open-order UX (DEC-042).

Closes #225, closes #229, closes #226, closes #227.

## What changes
- **9.2** — `vercel.json` loses the `crons` entry; the check-schedule route + `SettingsScheduleCard` stay in place, marked dormant. `is_open` now changes only via the manual toggle.
- **9.5** — `picked-up` → `picked_up` across `ORDER_STATUSES`, transition guards, `narrowStatus`, `order-actions`, `order-row`, `report.ts`, tests. Fixes fulfilled orders resurfacing as "new" and reprinting on the harvest sheet.
- **9.3a** — migration `20260701213000_open_order_identity.sql`: hard-cutover truncate of `orders`/`order_items`/`customer_sends` (DEC-041), drop `unique (customer_id, week_of)`, create partial unique index `orders_one_open_per_customer`, `CREATE OR REPLACE place_order` re-keying all four `week_of` load-bearing spots (ON CONFLICT arbiter → partial index inference; FOR UPDATE lock → open-status; replay join → customer-scoped; in-lock re-check unchanged) with a create-or-find retry loop closing the insert-vs-lock terminal race. Terminal refusal is now structural: a submission after fulfillment creates a fresh order.
- **9.3b** — `getOpenOrder`/`getLatestOrder` replace `getCurrentWeekOrder`. `/c/[token]` renders the open order as a pre-populated add-mode form (bounce + `?add=1` removed); with an open order, the closed/sold-out shells redirect to the receipt. `/confirmed` keys to the latest order; terminal renders read-only with **Place a new order**. Fulfillment sheet reads all open orders regardless of week (`listActiveOrders`; sends map re-keyed `(customer_id, week_of)`).

## Checklist
- [x] Migration: yes — truncate + index swap + `place_order` re-key (`supabase db push` at deploy; cutover wipe is IN the migration)
- [x] RLS change: no (same-signature `CREATE OR REPLACE` keeps grants; pgTAP green)
- [x] UI change at 375px: yes — terminal receipt + add-mode form verified on mobile project + screenshot

## Code review
@code-review — one real catch, fixed: with an open order, the closed/sold-out shells hid the customer's order; now they redirect to the receipt (regression test added). Also fixed per review: receipt week label stamped from `order.week_of` (not today's clock); pgTAP asserts `appended` on the terminal-replay path. Skipped with rationale: inert schedule-card copy (DEC-040 accepted limitation), admin orders week-filter gap (that is 9.8/DEC-045, next task), lost sends-fetch parallelism on the week path (9.8 rewrites that path).

## Before testing (preview)

The preview deploy runs against the **dev/preview Supabase project, which does not have this migration yet**. Until it's pushed, old never-fulfilled orders from past weeks read as "the open order" (pre-populated add mode on customers you'd expect to be fresh), and a customer with 2+ old open orders will error the page. Push first:

```bash
source .envrc
supabase db push   # already linked to dev/preview; truncates its orders/order_items/customer_sends (DEC-041 cutover)
```

Prod is a separate project — it gets the same push only after merge, at a quiet minute (the truncate wipes Annabel's live orders; that's the accepted DEC-041 cutover, timed deliberately).

## Human test script (preview, post-push)

1. **Fresh order** — open a customer link with no open order → "What's available" form → add items → submit → receipt.
2. **Open order is editable** — reopen the same link → form comes up pre-populated ("Going with your order", existing items read-only, "Update order" button) — no bounce to the receipt. Add an item → submit → receipt shows the merged order; `/admin/orders` still shows one order.
3. **Fulfillment frees the identity** — in `/admin/orders`: Mark ready → Mark picked up. Reopen the customer link → fresh empty form. The receipt page shows the old order read-only with a "Place a new order" button.
4. **Closed store doesn't eat the order** — with an open order, toggle ordering closed in `/admin` → the customer link lands on the receipt, not the "closed" shell. Toggle back.
5. **Harvest sheet** — `/f/<token>` lists every open order; mark one picked up → it drops off on reload.
6. **(Optional) cross-week** — there is no "next week" to simulate: identity ignores the week. To see the display side anyway, in the dev SQL editor: `update orders set week_of = week_of - 7 where status = 'new';` → link still editable, sheet still prints it (the old code dropped it). Known gap until 9.8: that order is invisible in `/admin/orders`' week filter.

## CLI verification (already run)

- `supabase test db` — 186 pgTAP green on a clean DB (32 in `place_order_additive.sql`: identity, replay incl. terminal, index enforcement, DEC-036 on append, reconciliation, foreign-submission scoping)
- `npx playwright test tests/customer-additional-orders.spec.ts tests/customer-place-order.spec.ts --project=desktop --project=mobile` — open-order add mode, terminal → new order e2e, closed-shell redirect
- `npx playwright test tests/fulfillment-report.spec.ts tests/admin-orders.spec.ts tests/orders-flow.spec.ts tests/notifications-flow.spec.ts tests/admin-send.spec.ts tests/customer-order-form.spec.ts tests/customer-token.spec.ts tests/order-status-transitions.spec.ts --project=desktop` — green
- Preview: place an order → revisit link (pre-populated add mode) → append → admin marks picked_up → revisit link (fresh form) → place second order; `/f/<token>` keeps showing the open order after re-stamping its week

🤖 Generated with [Claude Code](https://claude.com/claude-code)

