### PR TITLE
Admin orders: action stack into the detail grid (row-height fix)

### DIFF
--- a/src/components/admin/order-detail.tsx
+++ b/src/components/admin/order-detail.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import type { OrderRow as OrderRowData } from "@/lib/admin/orders-queries";
 
 function formatMoney(cents: number): string {
@@ -13,7 +15,16 @@ function fmtQty(n: number): string {
   return n.toFixed(2).replace(/\.?0+$/, "");
 }
 
-export function OrderDetail({ order }: { order: OrderRowData }) {
+export function OrderDetail({
+  order,
+  actions,
+}: {
+  order: OrderRowData;
+  // The per-order action stack (#192), rendered as the grid's third column
+  // so its top aligns with Line items / Fulfillment. Owned by OrderRow —
+  // advance state and error handling live there.
+  actions?: ReactNode;
+}) {
   return (
     <div className="ord-detail">
       <div className="ord-detail-grid">
@@ -138,6 +149,10 @@ export function OrderDetail({ order }: { order: OrderRowData }) {
             </div>
           )}
         </div>
+
+        {actions && (
+          <div className="ord-detail-section ord-detail-actions">{actions}</div>
+        )}
       </div>
     </div>
   );

--- a/src/components/admin/order-row.tsx
+++ b/src/components/admin/order-row.tsx
@@ -117,25 +117,33 @@ export function OrderRow({ order, isOpen, onToggle }: Props) {
         <td className="col-o-status" onClick={(e) => e.stopPropagation()}>
           <div className="status-stack">
             <StatusChip status={view.status} />
-            {isOpen && (
-              <OrderActions
-                order={view}
-                onAdvance={handleAdvance}
-                pending={pending}
-              />
-            )}
-            {error && (
-              <div className="ord-row-error" role="alert">
-                {error}
-              </div>
-            )}
           </div>
         </td>
       </tr>
       {isOpen && (
-        <tr className="ord-detail-row">
+        <tr className="ord-detail-row" data-order-id={order.id}>
           <td colSpan={7}>
-            <OrderDetail order={view} />
+            {/* Action stack renders as the detail grid's third column so its
+                top lines up with Line items / Fulfillment — parking it under
+                the chip stretched the whole row and left the detail floating
+                below a band of dead space. */}
+            <OrderDetail
+              order={view}
+              actions={
+                <>
+                  <OrderActions
+                    order={view}
+                    onAdvance={handleAdvance}
+                    pending={pending}
+                  />
+                  {error && (
+                    <div className="ord-row-error" role="alert">
+                      {error}
+                    </div>
+                  )}
+                </>
+              }
+            />
           </td>
         </tr>
       )}

--- a/src/components/admin/order-row.tsx
+++ b/src/components/admin/order-row.tsx
@@ -39,7 +39,8 @@ function itemsPreview(items: OrderRowData["items"]): string {
 }
 
 // Collapsed rows show only the chip (#192). The advance + send controls live
-// in OrderActions, rendered under the chip when the row is expanded.
+// in OrderActions, rendered in the detail grid's third column when the row
+// is expanded.
 function StatusChip({ status }: { status: OrderStatus }) {
   if (status === "new") return <span className="pill pill-new">New</span>;
   if (status === "confirmed")
@@ -114,9 +115,16 @@ export function OrderRow({ order, isOpen, onToggle }: Props) {
         <td className="col-o-total">
           <div className="ord-total mono">{formatMoney(view.totalCents)}</div>
         </td>
-        <td className="col-o-status" onClick={(e) => e.stopPropagation()}>
+        <td className="col-o-status">
           <div className="status-stack">
             <StatusChip status={view.status} />
+            {/* Advance errors surface here (not in the detail panel) so a
+                failed advance stays visible even after the row collapses. */}
+            {error && (
+              <div className="ord-row-error" role="alert">
+                {error}
+              </div>
+            )}
           </div>
         </td>
       </tr>
@@ -130,18 +138,11 @@ export function OrderRow({ order, isOpen, onToggle }: Props) {
             <OrderDetail
               order={view}
               actions={
-                <>
-                  <OrderActions
-                    order={view}
-                    onAdvance={handleAdvance}
-                    pending={pending}
-                  />
-                  {error && (
-                    <div className="ord-row-error" role="alert">
-                      {error}
-                    </div>
-                  )}
-                </>
+                <OrderActions
+                  order={view}
+                  onAdvance={handleAdvance}
+                  pending={pending}
+                />
               }
             />
           </td>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2605,9 +2605,14 @@
   border-top: 1px dashed var(--leaf-100);
 }
 .ord-detail-grid {
-  display: grid; grid-template-columns: 1.2fr 1fr;
+  /* Third column is the per-order action stack (#192) — living here (not in
+     the row's status cell) keeps the collapsed-row height and lines the
+     stack's top up with Line items / Fulfillment. Width echoes .col-o-status
+     (200px) minus the cell padding so the buttons sit under the chip. */
+  display: grid; grid-template-columns: 1.2fr 1fr 186px;
   gap: 32px;
 }
+.ord-detail-actions { display: flex; flex-direction: column; gap: 8px; }
 .ord-detail-label {
   font-size: 0.7rem; font-weight: 600;
   text-transform: uppercase; letter-spacing: 0.08em;
@@ -2862,6 +2867,9 @@
     grid-template-columns: 1fr;
     gap: 20px;
   }
+  /* Card layout: keep the tap targets in thumb reach — actions render first
+     in the detail panel, directly under the card, items/fulfillment below. */
+  .ord-detail-actions { order: -1; }
   .ord-detail-list li {
     grid-template-columns: 28px 1fr auto;
     gap: 8px;

--- a/tests/admin-orders.spec.ts
+++ b/tests/admin-orders.spec.ts
@@ -249,7 +249,9 @@ test.describe("admin orders list", () => {
     // Collapsed: chip only, no action stack.
     const pickupRow = page.locator(`tr.ord-row[data-order-id="${pickupId}"]`);
     await expect(pickupRow.locator(".pill-new")).toHaveText("New");
-    await expect(detailRowFor(pickupRow, pickupId).locator(".ord-actions")).toHaveCount(0);
+    // No detail row at all while collapsed, and no action stack anywhere.
+    await expect(detailRowFor(pickupRow, pickupId)).toHaveCount(0);
+    await expect(page.locator(".ord-actions")).toHaveCount(0);
 
     // Pickup order expanded → has a Pickup reminder send action.
     await expandRow(pickupRow);

--- a/tests/admin-orders.spec.ts
+++ b/tests/admin-orders.spec.ts
@@ -19,6 +19,12 @@ async function expandRow(row: Locator): Promise<void> {
   await row.locator(".col-o-cust").click();
 }
 
+// The action stack lives in the expanded detail row (third grid column),
+// not the ord-row's status cell — locate buttons through the detail row.
+function detailRowFor(row: Locator, orderId: string): Locator {
+  return row.page().locator(`tr.ord-detail-row[data-order-id="${orderId}"]`);
+}
+
 test.describe("admin orders list", () => {
   test.use({ storageState: ADMIN_STORAGE_STATE });
 
@@ -122,7 +128,7 @@ test.describe("admin orders list", () => {
 
     const sb = admin();
 
-    await row.getByRole("button", { name: /mark ready/i }).click();
+    await detailRowFor(row, orderId).getByRole("button", { name: /mark ready/i }).click();
     await expect(row).toHaveAttribute("data-status", "ready", { timeout: 5000 });
     // Wait for first transition to commit to DB before chaining the next click.
     // useTransition + revalidatePath can swallow a second click while the first
@@ -137,7 +143,7 @@ test.describe("admin orders list", () => {
       )
       .toBe("ready");
 
-    const deliveredBtn = row.getByRole("button", { name: /delivered/i });
+    const deliveredBtn = detailRowFor(row, orderId).getByRole("button", { name: /delivered/i });
     await expect(deliveredBtn).toBeEnabled();
     await deliveredBtn.click();
     await expect(row).toHaveAttribute("data-status", "delivered", { timeout: 5000 });
@@ -176,7 +182,7 @@ test.describe("admin orders list", () => {
     await expect(row.locator(".pill-confirmed")).toHaveText("Confirmed");
     await expandRow(row);
 
-    await row.getByRole("button", { name: /mark ready/i }).click();
+    await detailRowFor(row, orderId).getByRole("button", { name: /mark ready/i }).click();
     await expect(row).toHaveAttribute("data-status", "ready", { timeout: 5000 });
     await expect(row.locator(".pill-ready")).toHaveText("Ready");
   });
@@ -197,8 +203,8 @@ test.describe("admin orders list", () => {
     await expandRow(row);
 
     // Pickup orders show the "Mark picked up" advance button, not "Delivered".
-    await expect(row.getByRole("button", { name: /delivered/i })).toHaveCount(0);
-    await row.getByRole("button", { name: /picked up/i }).click();
+    await expect(detailRowFor(row, orderId).getByRole("button", { name: /delivered/i })).toHaveCount(0);
+    await detailRowFor(row, orderId).getByRole("button", { name: /picked up/i }).click();
     await expect(row).toHaveAttribute("data-status", "picked_up", { timeout: 5000 });
 
     // DB confirmation
@@ -243,18 +249,18 @@ test.describe("admin orders list", () => {
     // Collapsed: chip only, no action stack.
     const pickupRow = page.locator(`tr.ord-row[data-order-id="${pickupId}"]`);
     await expect(pickupRow.locator(".pill-new")).toHaveText("New");
-    await expect(pickupRow.locator(".ord-actions")).toHaveCount(0);
+    await expect(detailRowFor(pickupRow, pickupId).locator(".ord-actions")).toHaveCount(0);
 
     // Pickup order expanded → has a Pickup reminder send action.
     await expandRow(pickupRow);
-    const pickupActions = pickupRow.locator(".ord-actions");
+    const pickupActions = detailRowFor(pickupRow, pickupId).locator(".ord-actions");
     await expect(pickupActions).toBeVisible();
     await expect(pickupActions.getByText("Pickup reminder")).toBeVisible();
 
     // Delivery order expanded → Confirm + a Delivery reminder (#193), not Pickup.
     const deliveryRow = page.locator(`tr.ord-row[data-order-id="${deliveryId}"]`);
     await expandRow(deliveryRow);
-    const deliveryActions = deliveryRow.locator(".ord-actions");
+    const deliveryActions = detailRowFor(deliveryRow, deliveryId).locator(".ord-actions");
     await expect(deliveryActions.getByText("Confirm order")).toBeVisible();
     await expect(deliveryActions.getByText("Delivery reminder")).toBeVisible();
     await expect(deliveryActions.getByText("Pickup reminder")).toHaveCount(0);
@@ -310,7 +316,7 @@ test.describe("admin orders list", () => {
     await expect(detail.locator(".ord-li-name")).toContainText("Honey");
 
     // (d) The expanded action stack's advance button is ≥44px tall (WCAG 2.5.5).
-    const advanceBtn = firstRow.getByRole("button", { name: /mark ready/i });
+    const advanceBtn = detailRowFor(firstRow, reconId).getByRole("button", { name: /mark ready/i });
     const box = await advanceBtn.boundingBox();
     expect(box, "Status-advance button should be visible").not.toBeNull();
     expect(box!.height).toBeGreaterThanOrEqual(44);

--- a/tests/orders-flow.spec.ts
+++ b/tests/orders-flow.spec.ts
@@ -92,11 +92,12 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
 
     const row = adminPage.locator(`tr.ord-row[data-order-id="${orderId}"]`);
     await expect(row).toHaveAttribute("data-status", "new");
-    // #192: advance buttons live in the expanded row — open it first.
+    // #192: advance buttons live in the expanded detail row — open it first.
     await row.locator(".col-o-cust").click();
+    const detailRow = adminPage.locator(`tr.ord-detail-row[data-order-id="${orderId}"]`);
 
     // new → ready
-    await row.getByRole("button", { name: /mark ready/i }).click();
+    await detailRow.getByRole("button", { name: /mark ready/i }).click();
     await expect(row).toHaveAttribute("data-status", "ready", { timeout: 5000 });
     await expect
       .poll(async () => {
@@ -106,7 +107,7 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
       .toBe("ready");
 
     // ready → delivered (farmStand defaults to delivery)
-    const deliveredBtn = row.getByRole("button", { name: /delivered/i });
+    const deliveredBtn = detailRow.getByRole("button", { name: /delivered/i });
     await expect(deliveredBtn).toBeEnabled();
     await deliveredBtn.click();
     await expect(row).toHaveAttribute("data-status", "delivered", { timeout: 5000 });


### PR DESCRIPTION
## Summary
Admin orders alignment fix (Eric's ask): the #192 action stack under the status chip stretched the expanded row, leaving the Line items / Fulfillment panel below a band of dead space. The stack now renders as the detail grid's third column — the row stays compact and "Line items" tops out level with "Confirm order".

**Stacked on #239** (task/9.x-open-order-core) — merge that first; this diff is the last two commits.

## What changes
- `order-row.tsx` — status cell keeps the chip (+ advance errors, so a failure stays visible after collapse); actions render in the detail row, which gains `data-order-id`.
- `order-detail.tsx` — optional `actions` prop as third grid section.
- `app.css` — `.ord-detail-grid` → `1.2fr 1fr 186px` desktop; mobile cards float actions to the top of the detail panel (`order: -1`) for thumb reach.
- Specs re-scope action-button locators to the detail row.

## Checklist
- Migration: no · RLS: no · 375px: yes (mobile project green; actions land directly under the card)

## Code review
@code-review — 1 behavioral catch fixed (advance error was gated behind the open row; moved back to the always-visible status cell), vacuous collapsed-state assertion tightened, stale comment fixed. Verified: no click-propagation regressions, grid widths consistent at both breakpoints.

## Test plan
Before testing: none beyond #239's `db push` — no schema changes here.

1. `/admin/orders` → click a row (not the status chip) → detail opens: Line items, Fulfillment, and the Confirm order/Mark buttons all start at the same height; no dead space under the collapsed columns.
2. Collapse the row → just the chip, normal row height.
3. Mark ready / Mark picked up from the detail panel → chip updates in the row above.
4. At 375px: tap a card → actions appear at the top of the detail panel, ≥44px touch targets.

CLI run: `npx playwright test tests/admin-orders.spec.ts tests/orders-flow.spec.ts --project=desktop` + admin-orders on mobile — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
