### PR TITLE
#241 Consolidate duplicate order lines across all order views

### DIFF
--- a/src/app/c/[token]/confirmed/page.tsx
+++ b/src/app/c/[token]/confirmed/page.tsx
@@ -9,6 +9,7 @@ import {
   getOrderingScheduleStatus,
 } from "@/lib/customer/queries";
 import { lookupCustomerByToken } from "@/lib/customer/session";
+import { consolidateItems } from "@/lib/order-items";
 import { weekOfLabel } from "@/lib/week";
 
 function formatPrice(cents: number): string {
@@ -75,7 +76,12 @@ export default async function ConfirmedPage({
     );
   }
 
-  const items = order.order_items ?? [];
+  // #241: appends land as separate order_items rows per submission — fold
+  // same (product, unit, price) into one receipt line.
+  const items = consolidateItems(
+    order.order_items ?? [],
+    (i) => `${i.product_id}|${i.product_units?.label ?? ""}|${i.unit_price_cents}`,
+  );
   const total = items.reduce(
     (sum, item) => sum + item.qty * item.unit_price_cents,
     0,

--- a/src/app/c/[token]/confirmed/page.tsx
+++ b/src/app/c/[token]/confirmed/page.tsx
@@ -9,7 +9,7 @@ import {
   getOrderingScheduleStatus,
 } from "@/lib/customer/queries";
 import { lookupCustomerByToken } from "@/lib/customer/session";
-import { consolidateItems } from "@/lib/order-items";
+import { consolidateItems, consolidationKey } from "@/lib/order-items";
 import { weekOfLabel } from "@/lib/week";
 
 function formatPrice(cents: number): string {
@@ -78,9 +78,8 @@ export default async function ConfirmedPage({
 
   // #241: appends land as separate order_items rows per submission — fold
   // same (product, unit, price) into one receipt line.
-  const items = consolidateItems(
-    order.order_items ?? [],
-    (i) => `${i.product_id}|${i.product_units?.label ?? ""}|${i.unit_price_cents}`,
+  const items = consolidateItems(order.order_items ?? [], (i) =>
+    consolidationKey(i.product_id, i.product_units?.label ?? "", i.unit_price_cents),
   );
   const total = items.reduce(
     (sum, item) => sum + item.qty * item.unit_price_cents,

--- a/src/app/c/[token]/page.tsx
+++ b/src/app/c/[token]/page.tsx
@@ -11,7 +11,7 @@ import {
   getOrderingScheduleStatus,
 } from "@/lib/customer/queries";
 import { lookupCustomerByToken } from "@/lib/customer/session";
-import { consolidateItems } from "@/lib/order-items";
+import { consolidateItems, consolidationKey } from "@/lib/order-items";
 import { weekOfLabel } from "@/lib/week";
 
 export default async function CustomerTokenPage({
@@ -93,10 +93,12 @@ export default async function CustomerTokenPage({
               // read-only) above the new additions, not just what's being added.
               // #241: consolidated — same (product, unit, price) reads as one
               // line no matter how many submissions built it.
-              items: consolidateItems(
-                existingOrder.order_items ?? [],
-                (it) =>
-                  `${it.product_id}|${it.product_units?.label ?? ""}|${it.unit_price_cents}`,
+              items: consolidateItems(existingOrder.order_items ?? [], (it) =>
+                consolidationKey(
+                  it.product_id,
+                  it.product_units?.label ?? "",
+                  it.unit_price_cents,
+                ),
               ).map((it) => ({
                 id: it.id,
                 name: it.products?.name ?? "(item)",

--- a/src/app/c/[token]/page.tsx
+++ b/src/app/c/[token]/page.tsx
@@ -11,6 +11,7 @@ import {
   getOrderingScheduleStatus,
 } from "@/lib/customer/queries";
 import { lookupCustomerByToken } from "@/lib/customer/session";
+import { consolidateItems } from "@/lib/order-items";
 import { weekOfLabel } from "@/lib/week";
 
 export default async function CustomerTokenPage({
@@ -90,7 +91,13 @@ export default async function CustomerTokenPage({
               // 9.1/DEC-039 — the query already joins order_items; thread them
               // through so add mode shows the *complete* order (existing lines
               // read-only) above the new additions, not just what's being added.
-              items: (existingOrder.order_items ?? []).map((it) => ({
+              // #241: consolidated — same (product, unit, price) reads as one
+              // line no matter how many submissions built it.
+              items: consolidateItems(
+                existingOrder.order_items ?? [],
+                (it) =>
+                  `${it.product_id}|${it.product_units?.label ?? ""}|${it.unit_price_cents}`,
+              ).map((it) => ({
                 id: it.id,
                 name: it.products?.name ?? "(item)",
                 unitLabel: it.product_units?.label ?? "",

--- a/src/components/admin/order-detail.tsx
+++ b/src/components/admin/order-detail.tsx
@@ -60,7 +60,10 @@ export function OrderDetail({
                 ? (baseRequested - availableBase) / i.conversionToBase
                 : 0;
               return (
-                <li key={i.productId} className={oversold ? "is-oversold" : ""}>
+                <li
+                  key={`${i.productId}-${i.unitLabel}-${i.unitPriceCents}`}
+                  className={oversold ? "is-oversold" : ""}
+                >
                   <span className="ord-li-qty mono">{i.qty}×</span>
                   <span className="ord-li-name">
                     {i.name}

--- a/src/lib/admin/orders-queries.ts
+++ b/src/lib/admin/orders-queries.ts
@@ -1,5 +1,5 @@
 // Admin order-list reads (Phase 5.1). Service-role client — admin only.
-import { consolidateItems } from "@/lib/order-items";
+import { consolidateItems, consolidationKey } from "@/lib/order-items";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { weekOfMondayNY } from "@/lib/week";
 
@@ -258,9 +258,8 @@ async function queryOrders(filter: {
       // (product, unit, price) into one line here so every consumer of
       // OrderRow (detail panel, items preview, packing slips, Wave export)
       // renders the consolidated order.
-      const consolidated = consolidateItems(
-        items,
-        (i) => `${i.productId}|${i.unitLabel}|${i.unitPriceCents}`,
+      const consolidated = consolidateItems(items, (i) =>
+        consolidationKey(i.productId, i.unitLabel, i.unitPriceCents),
       );
       const totalCents = consolidated.reduce(
         (s, i) => s + i.qty * i.unitPriceCents,

--- a/src/lib/admin/orders-queries.ts
+++ b/src/lib/admin/orders-queries.ts
@@ -1,4 +1,5 @@
 // Admin order-list reads (Phase 5.1). Service-role client — admin only.
+import { consolidateItems } from "@/lib/order-items";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { weekOfMondayNY } from "@/lib/week";
 
@@ -253,7 +254,15 @@ async function queryOrders(filter: {
             qtyAvailable: i.products!.qty_available,
           };
         });
-      const totalCents = items.reduce(
+      // #241: appends land as separate rows per submission — fold same
+      // (product, unit, price) into one line here so every consumer of
+      // OrderRow (detail panel, items preview, packing slips, Wave export)
+      // renders the consolidated order.
+      const consolidated = consolidateItems(
+        items,
+        (i) => `${i.productId}|${i.unitLabel}|${i.unitPriceCents}`,
+      );
+      const totalCents = consolidated.reduce(
         (s, i) => s + i.qty * i.unitPriceCents,
         0,
       );
@@ -271,7 +280,7 @@ async function queryOrders(filter: {
         notes: o.notes,
         status: narrowStatus(o.status),
         needsReconciliation: o.needs_reconciliation,
-        items,
+        items: consolidated,
         totalCents,
         confirmSentAt: sent.confirm,
         reminderSentAt:

--- a/src/lib/customer/queries.ts
+++ b/src/lib/customer/queries.ts
@@ -103,6 +103,7 @@ const CUSTOMER_ORDER_SELECT = `
   created_at,
   order_items (
     id,
+    product_id,
     qty,
     unit_price_cents,
     products ( name ),

--- a/src/lib/order-items.ts
+++ b/src/lib/order-items.ts
@@ -14,3 +14,30 @@ export function totalItemCount(items: ReadonlyArray<{ qty: number | string }>): 
   for (const it of items) sum += Number(it.qty) || 0;
   return Math.round(sum * 100) / 100;
 }
+
+// #241: DEC-039 appends insert one order_items row per submission, so the
+// same product+unit can appear N times on one order. The rows stay granular
+// in the DB (submission_id is the idempotency key + audit trail) — but
+// nobody READING an order cares which submission a line arrived in, so
+// every display surface groups through here: same key → one line, qty
+// summed. The first row of a group supplies the rest of the fields (React
+// keys, names, prices — identical within a group by construction).
+//
+// Callers put (product, unit, unit price) in the key. Price belongs there:
+// a price change between a customer's first order and their top-up is an
+// invoicing truth that must stay its own line, not noise to merge away.
+export function consolidateItems<T extends { qty: number }>(
+  items: ReadonlyArray<T>,
+  keyOf: (item: T) => string,
+): T[] {
+  const grouped = new Map<string, T>();
+  for (const it of items) {
+    const key = keyOf(it);
+    const prev = grouped.get(key);
+    grouped.set(
+      key,
+      prev ? { ...prev, qty: Math.round((prev.qty + it.qty) * 100) / 100 } : it,
+    );
+  }
+  return [...grouped.values()];
+}

--- a/src/lib/order-items.ts
+++ b/src/lib/order-items.ts
@@ -23,9 +23,22 @@ export function totalItemCount(items: ReadonlyArray<{ qty: number | string }>): 
 // summed. The first row of a group supplies the rest of the fields (React
 // keys, names, prices — identical within a group by construction).
 //
-// Callers put (product, unit, unit price) in the key. Price belongs there:
-// a price change between a customer's first order and their top-up is an
-// invoicing truth that must stay its own line, not noise to merge away.
+// The key is (product, unit label, unit price) — build it with
+// consolidationKey so every surface groups identically. Unit label is a
+// faithful proxy for product_unit_id (product_units has unique
+// (product_id, label) and order_items.product_unit_id is on-delete-restrict,
+// so the label join can't be null or ambiguous within a product). Price
+// belongs in the key: a price change between a customer's first order and
+// their top-up is an invoicing truth that must stay its own line, not noise
+// to merge away.
+export function consolidationKey(
+  productId: string,
+  unitLabel: string,
+  unitPriceCents: number,
+): string {
+  return `${productId}|${unitLabel}|${unitPriceCents}`;
+}
+
 export function consolidateItems<T extends { qty: number }>(
   items: ReadonlyArray<T>,
   keyOf: (item: T) => string,

--- a/tests/admin-orders.spec.ts
+++ b/tests/admin-orders.spec.ts
@@ -112,6 +112,36 @@ test.describe("admin orders list", () => {
     ).toBeVisible();
   });
 
+  // #241: DEC-039 appends leave one order_items row per submission; the
+  // detail panel folds same (product, unit, price) into one line.
+  test("duplicate product rows consolidate to one line in the detail panel", async ({ page }) => {
+    const ids = await customerIds();
+    const orderId = await seedOrder({
+      customerId: ids.farmStand,
+      weekOf: thisWeek,
+      fulfillmentType: "pickup",
+      items: [
+        { productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 },
+        { productId: TEST_PRODUCTS.kale.id, qty: 2, unitPriceCents: 300 },
+        { productId: TEST_PRODUCTS.eggs.id, qty: 1, unitPriceCents: 600 },
+      ],
+    });
+
+    await page.goto("/admin/orders");
+    const row = page.locator(`tr.ord-row[data-order-id="${orderId}"]`);
+    // Items count sums qty across the raw rows (1 + 2 + 1 = 4)…
+    await expect(row.locator(".ord-items-count")).toContainText("4");
+    await expandRow(row);
+
+    // …but the detail panel shows ONE kale line at the summed qty.
+    const detail = detailRowFor(row, orderId);
+    const kaleLines = detail.locator(".ord-detail-list li", { hasText: TEST_PRODUCTS.kale.name });
+    await expect(kaleLines).toHaveCount(1);
+    await expect(kaleLines.locator(".ord-li-qty")).toHaveText("3×");
+    await expect(kaleLines.locator(".ord-li-amt")).toHaveText("$9.00");
+    await expect(detail.locator(".ord-li-total")).toContainText("$15.00");
+  });
+
   test("delivery order: new → ready → delivered persists across reload", async ({ page }) => {
     const ids = await customerIds();
     const orderId = await seedOrder({

--- a/tests/customer-additional-orders.spec.ts
+++ b/tests/customer-additional-orders.spec.ts
@@ -97,6 +97,53 @@ test.describe("/c/[token] additional orders", () => {
     expect(eggs?.qty_available).toBe(TEST_PRODUCTS.eggs.qty_available - 1);
   });
 
+  // #241: appends insert separate order_items rows per submission (audit +
+  // idempotency), but every view folds same (product, unit, price) into one
+  // line — a customer topping up cherry tomatoes twice must not read as
+  // three cherry-tomato lines.
+  test("same-product append consolidates to one line on receipt + add mode; DB rows stay granular", async ({
+    page,
+  }) => {
+    // Kale ×2 through the form…
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    await stepUp(page, TEST_PRODUCTS.kale.name, 2);
+    await page.locator(".submit-btn").click();
+    await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
+
+    // …then top up the SAME product ×1.
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    await stepUp(page, TEST_PRODUCTS.kale.name, 1);
+    await page.locator(".submit-btn").click();
+    await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
+
+    // Receipt: ONE kale line, qty 3, total 3 × $3.00.
+    const kaleLines = page.locator(".confirm-list li", { hasText: TEST_PRODUCTS.kale.name });
+    await expect(kaleLines).toHaveCount(1);
+    await expect(kaleLines.locator(".confirm-qty")).toHaveText("3×");
+    await expect(page.locator(".confirm-total")).toContainText("9.00");
+
+    // Add mode: the "Already ordered" group also shows one consolidated line.
+    await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
+    const existing = page.locator(".rail-existing:visible");
+    await expect(existing.locator("li", { hasText: TEST_PRODUCTS.kale.name })).toHaveCount(1);
+    await expect(existing).toContainText("3×");
+
+    // DB: still two granular rows, each carrying its submission_id.
+    const sb = admin();
+    const ids = await customerIds();
+    const { data: orders } = await sb
+      .from("orders")
+      .select("id")
+      .eq("customer_id", ids.farmStand)
+      .in("status", ["new", "confirmed", "ready"]);
+    const { data: rows } = await sb
+      .from("order_items")
+      .select("id, submission_id")
+      .eq("order_id", orders![0].id);
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows!.map((r) => r.submission_id)).size).toBe(2);
+  });
+
   test("open order renders the form in add mode with fulfillment read-only", async ({ page }) => {
     const ids = await customerIds();
     await seedOrder({


### PR DESCRIPTION
## Summary
Fold DEC-039's per-submission `order_items` rows into one display line per (product, unit, unit price) — a customer topping up cherry tomatoes twice no longer reads as three cherry-tomato lines. DB rows stay granular (`submission_id` = idempotency key + audit trail).

Closes #241. **Stacked on #240** (which stacks on #239) — merge in order; this diff is the last two commits.

## What changes
- `src/lib/order-items.ts` — `consolidateItems()` + shared `consolidationKey(product, unitLabel, price)`. Price stays in the key: a mid-week price change keeps its own invoice line.
- `src/lib/admin/orders-queries.ts` — consolidation applied once in `queryOrders`, which covers the admin detail panel, items preview, harvest-sheet packing slips, and the Wave export in one spot.
- `/c/[token]/confirmed` + add-mode "Already ordered" group — same grouping (customer select now carries `product_id`).
- `order-detail.tsx` — line key widened to product+unit+price (fixes a pre-existing duplicate-React-key case too).

## Code review
@code-review — clean on correctness (qty is int so rounding is a no-op; totals identical; unit label proven a faithful proxy for `product_unit_id` via the `unique (product_id, label)` constraint; Wave export and harvest sheet verified). Applied: shared `consolidationKey` so the three call sites can't drift. Deferred follow-up: per-product oversold summing in the detail panel when one product legitimately spans lines (price change) — each line passes individually today; rare at this scale, noted for 9.8-adjacent cleanup.

## Test plan
Before testing: needs #239's `supabase db push` on dev/preview (no new schema here).

1. Customer link → order Kale ×2 → submit → reopen link → add Kale ×1 → submit.
2. Receipt shows **one** Kale line, `3×`, $9.00 total — not two lines.
3. Reopen the link: "Already ordered" shows one Kale `3×` line.
4. `/admin/orders` → expand the order: one Kale line `3× · $9.00`; items count still says 3.
5. Export to Wave: one Kale row, qty 3.

CLI: `customer-additional-orders` + `admin-orders` green desktop + mobile (incl. new consolidation tests asserting DB keeps 2 granular rows); `fulfillment-report`, `orders-flow`, `admin-orders-export` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
