### PR TITLE
#231 Admin orders: Active/Fulfilled views replace the week filter (DEC-045)

### DIFF
--- a/src/app/(admin)/admin/orders/page.tsx
+++ b/src/app/(admin)/admin/orders/page.tsx
@@ -1,5 +1,8 @@
 import { OrdersPage } from "@/components/admin/orders-page";
 import {
+  OPEN_ORDER_STATUSES,
+  TERMINAL_ORDER_STATUSES,
+  countOrdersByStatus,
   currentWeekOf,
   listActiveOrders,
   listFulfilledOrders,
@@ -23,22 +26,24 @@ export default async function OrdersRoute({
   const params = await searchParams;
   const view = resolveView(params.view);
 
-  // Both lists fetched so the tab counts are always live. Fine at this
-  // scale (single-digit customers, weekly cadence); revisit with pagination
-  // if Fulfilled ever grows past a few hundred rows.
-  const [activeOrders, fulfilledOrders, harvestSheetToken] = await Promise.all([
-    listActiveOrders(),
-    listFulfilledOrders(),
+  // Full fetch for the displayed view only; the other tab just needs its
+  // count (Fulfilled grows without bound — its joined fetch shouldn't ride
+  // along on every Active-view load).
+  const [orders, otherCount, harvestSheetToken] = await Promise.all([
+    view === "active" ? listActiveOrders() : listFulfilledOrders(),
+    countOrdersByStatus(
+      view === "active" ? TERMINAL_ORDER_STATUSES : OPEN_ORDER_STATUSES,
+    ),
     getFulfillmentToken(),
   ]);
 
   return (
     <OrdersPage
-      orders={view === "active" ? activeOrders : fulfilledOrders}
+      orders={orders}
       view={view}
       weekOf={currentWeekOf()}
-      activeCount={activeOrders.length}
-      fulfilledCount={fulfilledOrders.length}
+      activeCount={view === "active" ? orders.length : otherCount}
+      fulfilledCount={view === "fulfilled" ? orders.length : otherCount}
       harvestSheetToken={harvestSheetToken}
     />
   );

--- a/src/app/(admin)/admin/orders/page.tsx
+++ b/src/app/(admin)/admin/orders/page.tsx
@@ -1,45 +1,44 @@
 import { OrdersPage } from "@/components/admin/orders-page";
-import { currentWeekOf, listOrders } from "@/lib/admin/orders-queries";
+import {
+  currentWeekOf,
+  listActiveOrders,
+  listFulfilledOrders,
+} from "@/lib/admin/orders-queries";
 import { getFulfillmentToken } from "@/lib/fulfillment/link";
-import { shiftWeek } from "@/lib/week";
 
 export const metadata = { title: "Orders — Bay Branch Farm" };
 
-function resolveWeekFilter(raw: string | undefined): "this" | "last" {
-  return raw === "last" ? "last" : "this";
+// DEC-045 (#231): orders are no longer week-aligned (DEC-041), so the list
+// keys on status, not week — Active (non-terminal, any week) by default,
+// Fulfilled (the browsable past) behind the second tab.
+function resolveView(raw: string | undefined): "active" | "fulfilled" {
+  return raw === "fulfilled" ? "fulfilled" : "active";
 }
 
 export default async function OrdersRoute({
   searchParams,
 }: {
-  searchParams: Promise<{ week?: string }>;
+  searchParams: Promise<{ view?: string }>;
 }) {
   const params = await searchParams;
-  const weekFilter = resolveWeekFilter(params.week);
-  const thisWeek = currentWeekOf();
-  const lastWeek = shiftWeek(thisWeek, -1);
-  const selectedWeek = weekFilter === "last" ? lastWeek : thisWeek;
+  const view = resolveView(params.view);
 
-  const [orders, thisWeekOrders, lastWeekOrders, harvestSheetToken] =
-    await Promise.all([
-      listOrders(selectedWeek),
-      weekFilter === "this" ? Promise.resolve(null) : listOrders(thisWeek),
-      weekFilter === "last" ? Promise.resolve(null) : listOrders(lastWeek),
-      getFulfillmentToken(),
-    ]);
-
-  const thisWeekCount =
-    weekFilter === "this" ? orders.length : (thisWeekOrders?.length ?? 0);
-  const lastWeekCount =
-    weekFilter === "last" ? orders.length : (lastWeekOrders?.length ?? 0);
+  // Both lists fetched so the tab counts are always live. Fine at this
+  // scale (single-digit customers, weekly cadence); revisit with pagination
+  // if Fulfilled ever grows past a few hundred rows.
+  const [activeOrders, fulfilledOrders, harvestSheetToken] = await Promise.all([
+    listActiveOrders(),
+    listFulfilledOrders(),
+    getFulfillmentToken(),
+  ]);
 
   return (
     <OrdersPage
-      orders={orders}
-      weekFilter={weekFilter}
-      weekOf={selectedWeek}
-      thisWeekCount={thisWeekCount}
-      lastWeekCount={lastWeekCount}
+      orders={view === "active" ? activeOrders : fulfilledOrders}
+      view={view}
+      weekOf={currentWeekOf()}
+      activeCount={activeOrders.length}
+      fulfilledCount={fulfilledOrders.length}
       harvestSheetToken={harvestSheetToken}
     />
   );

--- a/src/components/admin/export-orders-button.tsx
+++ b/src/components/admin/export-orders-button.tsx
@@ -7,10 +7,13 @@ import type { OrderRow } from "@/lib/admin/orders-queries";
 
 type Props = {
   orders: OrderRow[];
-  weekOf: string;
+  // Goes into the download filename verbatim (e.g. "active-2026-06-29") —
+  // a label, not a date. DEC-045's views span weeks, so no single week_of
+  // describes an export's contents.
+  filenameLabel: string;
 };
 
-export function ExportOrdersButton({ orders, weekOf }: Props) {
+export function ExportOrdersButton({ orders, filenameLabel }: Props) {
   const [open, setOpen] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
@@ -36,7 +39,7 @@ export function ExportOrdersButton({ orders, weekOf }: Props) {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = csvFilename(weekOf);
+    a.download = csvFilename(filenameLabel);
     document.body.appendChild(a);
     a.click();
     a.remove();

--- a/src/components/admin/orders-page.tsx
+++ b/src/components/admin/orders-page.tsx
@@ -12,10 +12,12 @@ type SortDir = "asc" | "desc";
 
 type Props = {
   orders: OrderRowData[];
-  weekFilter: "this" | "last";
+  // DEC-045: status-keyed views — Active (non-terminal, any week) is the
+  // working list; Fulfilled is the browsable past.
+  view: "active" | "fulfilled";
   weekOf: string;
-  thisWeekCount: number;
-  lastWeekCount: number;
+  activeCount: number;
+  fulfilledCount: number;
   harvestSheetToken: string;
 };
 
@@ -57,7 +59,7 @@ function SortHeader({
   );
 }
 
-export function OrdersPage({ orders, weekFilter, weekOf, thisWeekCount, lastWeekCount, harvestSheetToken }: Props) {
+export function OrdersPage({ orders, view, weekOf, activeCount, fulfilledCount, harvestSheetToken }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -87,10 +89,10 @@ export function OrdersPage({ orders, weekFilter, weekOf, thisWeekCount, lastWeek
     });
   }
 
-  function setWeek(next: "this" | "last") {
+  function setView(next: "active" | "fulfilled") {
     const params = new URLSearchParams(searchParams.toString());
-    if (next === "this") params.delete("week");
-    else params.set("week", "last");
+    if (next === "active") params.delete("view");
+    else params.set("view", "fulfilled");
     const qs = params.toString();
     router.push(`/admin/orders${qs ? `?${qs}` : ""}`);
   }
@@ -121,37 +123,38 @@ export function OrdersPage({ orders, weekFilter, weekOf, thisWeekCount, lastWeek
             </svg>
             Harvest sheet
           </a>
-          <ExportOrdersButton orders={sorted} weekOf={weekOf} />
+          {/* Export ships whatever view is on screen; a fulfilled export gets
+              a distinct filename so it can't be mistaken for the week's book. */}
+          <ExportOrdersButton
+            orders={sorted}
+            weekOf={view === "fulfilled" ? `fulfilled-${weekOf}` : weekOf}
+          />
         </div>
       </div>
 
       <div className="ord-filters">
         <button
           type="button"
-          className={"chip-tab" + (weekFilter === "this" ? " is-on" : "")}
-          onClick={() => setWeek("this")}
+          className={"chip-tab" + (view === "active" ? " is-on" : "")}
+          onClick={() => setView("active")}
         >
-          This week <span className="chip-count">{thisWeekCount}</span>
+          Active <span className="chip-count">{activeCount}</span>
         </button>
         <button
           type="button"
-          className={"chip-tab" + (weekFilter === "last" ? " is-on" : "")}
-          onClick={() => setWeek("last")}
+          className={"chip-tab" + (view === "fulfilled" ? " is-on" : "")}
+          onClick={() => setView("fulfilled")}
         >
-          Last week <span className="chip-count">{lastWeekCount}</span>
-        </button>
-        <button
-          type="button"
-          className="chip-tab"
-          disabled
-          title="Coming in Phase 6"
-        >
-          Custom range
+          Fulfilled <span className="chip-count">{fulfilledCount}</span>
         </button>
       </div>
 
       {orders.length === 0 ? (
-        <div className="ord-empty">No orders for this week yet.</div>
+        <div className="ord-empty">
+          {view === "active"
+            ? "No active orders — everything's fulfilled."
+            : "No fulfilled orders yet."}
+        </div>
       ) : (
         <div className="ord-tableCard">
           <table className="ord-table" aria-label="Orders">

--- a/src/components/admin/orders-page.tsx
+++ b/src/components/admin/orders-page.tsx
@@ -123,11 +123,13 @@ export function OrdersPage({ orders, view, weekOf, activeCount, fulfilledCount, 
             </svg>
             Harvest sheet
           </a>
-          {/* Export ships whatever view is on screen; a fulfilled export gets
-              a distinct filename so it can't be mistaken for the week's book. */}
+          {/* Export ships whatever view is on screen. Both filenames carry
+              the view name — under DEC-045 neither view is week-scoped, so a
+              bare week in the filename would claim a scope the data doesn't
+              have. weekOf just stamps when the export was cut. */}
           <ExportOrdersButton
             orders={sorted}
-            weekOf={view === "fulfilled" ? `fulfilled-${weekOf}` : weekOf}
+            filenameLabel={`${view}-${weekOf}`}
           />
         </div>
       </div>

--- a/src/lib/admin/export-orders.ts
+++ b/src/lib/admin/export-orders.ts
@@ -110,6 +110,6 @@ export function toTsv(orders: OrderRow[]): string {
     .join("\n");
 }
 
-export function csvFilename(weekOf: string): string {
-  return `bushel-orders-${weekOf}.csv`;
+export function csvFilename(label: string): string {
+  return `bushel-orders-${label}.csv`;
 }

--- a/src/lib/admin/orders-queries.ts
+++ b/src/lib/admin/orders-queries.ts
@@ -120,24 +120,30 @@ export function currentWeekOf(): string {
   return weekOfMondayNY();
 }
 
-// Lists orders for a given week, joined with customer + items + products.
-// Sorted at the DB by created_at desc; reconciliation pinning is applied
-// in the UI so it survives column-sort changes.
-export async function listOrders(weekOf: string): Promise<OrderRow[]> {
-  return queryOrders({ weekOf });
-}
-
+// Orders joined with customer + items + products, sorted at the DB by
+// created_at desc; reconciliation pinning is applied in the UI so it
+// survives column-sort changes. DEC-045 dropped the week-keyed listOrders —
+// the two status-keyed views below are the only entry points.
+//
 // DEC-041/DEC-042 (#227): every open (non-terminal) order regardless of week.
-// The fulfillment sheet reads this — an order that stays open across a week
-// boundary must keep printing until it's out the door. The admin orders list
-// moves onto this in 9.8 (DEC-045).
+// The fulfillment sheet and the admin orders list's default view (DEC-045)
+// read this — an order that stays open across a week boundary must stay
+// visible until it's out the door.
 export async function listActiveOrders(): Promise<OrderRow[]> {
   return queryOrders({ activeOnly: true });
+}
+
+// DEC-045 (#231): the browsable past — terminal orders persist as rows under
+// the open-order model (nothing deletes them), newest first via the shared
+// created_at sort.
+export async function listFulfilledOrders(): Promise<OrderRow[]> {
+  return queryOrders({ terminalOnly: true });
 }
 
 async function queryOrders(filter: {
   weekOf?: string;
   activeOnly?: boolean;
+  terminalOnly?: boolean;
 }): Promise<OrderRow[]> {
   const supabase = createAdminClient();
 
@@ -157,9 +163,11 @@ async function queryOrders(filter: {
   if (filter.weekOf) ordersQuery = ordersQuery.eq("week_of", filter.weekOf);
   if (filter.activeOnly)
     ordersQuery = ordersQuery.in("status", OPEN_ORDER_STATUSES);
+  if (filter.terminalOnly)
+    ordersQuery = ordersQuery.in("status", ["picked_up", "delivered"]);
 
   const { data, error } = await ordersQuery;
-  if (error) throw new Error(`listOrders: ${error.message}`);
+  if (error) throw new Error(`queryOrders: ${error.message}`);
 
   // customer_sends stays week-keyed (DEC-042), so the Send state for each
   // order is the send row of the order's OWN week_of stamp. Fetched after the
@@ -174,7 +182,7 @@ async function queryOrders(filter: {
           .select("customer_id, week_of, mode, sent_at")
           .in("week_of", weeks);
   if (sendsResult.error)
-    throw new Error(`listOrders(sends): ${sendsResult.error.message}`);
+    throw new Error(`queryOrders(sends): ${sendsResult.error.message}`);
 
   // Reminder mode is per-fulfillment (#193): pickup orders use pickup_reminder,
   // delivery orders use delivery_reminder — tracked separately, resolved per

--- a/src/lib/admin/orders-queries.ts
+++ b/src/lib/admin/orders-queries.ts
@@ -23,9 +23,14 @@ export const ORDER_STATUSES: OrderStatus[] = [
 
 // DEC-041: the open-order identity set. A customer has at most one order in
 // these statuses (partial unique index orders_one_open_per_customer); a
-// terminal order (picked_up/delivered) drops out and frees a new one. Keep
-// this list identical to the index predicate in the DEC-041 migration.
+// terminal order drops out and frees a new one. Keep this list identical to
+// the index predicate in the DEC-041 migration.
 export const OPEN_ORDER_STATUSES: OrderStatus[] = ["new", "confirmed", "ready"];
+
+// The complement — every status is in exactly one of these two sets, so an
+// order can never fall out of both admin views (DEC-045). isTerminalStatus
+// and the Fulfilled-view filter both derive from this single list.
+export const TERMINAL_ORDER_STATUSES: OrderStatus[] = ["picked_up", "delivered"];
 
 // The no-regress auto-advance rule for confirm-sends (DEC-035): sending the
 // confirmation text moves a new order to confirmed, but must never regress a
@@ -40,7 +45,7 @@ export function statusAfterConfirmSend(current: OrderStatus): OrderStatus {
 // next submission creates a fresh order. Takes raw text because orders.status
 // is app-enforced text in the DB (DEC-010) — customer-side reads arrive untyped.
 export function isTerminalStatus(status: string): boolean {
-  return status === "picked_up" || status === "delivered";
+  return (TERMINAL_ORDER_STATUSES as string[]).includes(status);
 }
 
 // DEC-035 (amends DEC-010): new → [confirmed] → ready → (picked_up | delivered).
@@ -140,6 +145,22 @@ export async function listFulfilledOrders(): Promise<OrderRow[]> {
   return queryOrders({ terminalOnly: true });
 }
 
+// Bare row counts for the orders-page tab chips — the view NOT being
+// displayed only needs its number, not the full joined fetch (Fulfilled
+// grows without bound; its full fetch shouldn't ride along on every
+// Active-view load).
+export async function countOrdersByStatus(
+  statuses: OrderStatus[],
+): Promise<number> {
+  const supabase = createAdminClient();
+  const { count, error } = await supabase
+    .from("orders")
+    .select("id", { count: "exact", head: true })
+    .in("status", statuses);
+  if (error) throw new Error(`countOrdersByStatus: ${error.message}`);
+  return count ?? 0;
+}
+
 async function queryOrders(filter: {
   weekOf?: string;
   activeOnly?: boolean;
@@ -164,7 +185,7 @@ async function queryOrders(filter: {
   if (filter.activeOnly)
     ordersQuery = ordersQuery.in("status", OPEN_ORDER_STATUSES);
   if (filter.terminalOnly)
-    ordersQuery = ordersQuery.in("status", ["picked_up", "delivered"]);
+    ordersQuery = ordersQuery.in("status", TERMINAL_ORDER_STATUSES);
 
   const { data, error } = await ordersQuery;
   if (error) throw new Error(`queryOrders: ${error.message}`);

--- a/src/lib/fulfillment/report.ts
+++ b/src/lib/fulfillment/report.ts
@@ -2,7 +2,7 @@
 //
 // Read-only derivation over the week's orders, regenerated on every view so a
 // Tuesday-night oversell fix moves the totals and slips with it. Reuses
-// listOrders() — which already joins order_items → products → product_units —
+// listActiveOrders() — which already joins order_items → products → product_units —
 // so there's no new query or RLS surface. The base-unit fold (qty ×
 // conversion_to_base) is the same math place_order runs on decrement; we never
 // sum raw qty across mixed units (3 bunches + 2 lb ≠ 5).

--- a/tests/admin-orders-export.spec.ts
+++ b/tests/admin-orders-export.spec.ts
@@ -229,7 +229,7 @@ test.describe("admin orders export — UI", () => {
       page.waitForEvent("download"),
       page.getByRole("button", { name: /download csv/i }).click(),
     ]);
-    expect(download.suggestedFilename()).toBe(`bushel-orders-${thisWeek}.csv`);
+    expect(download.suggestedFilename()).toBe(`bushel-orders-active-${thisWeek}.csv`);
     const stream = await download.createReadStream();
     let text = "";
     for await (const chunk of stream) text += chunk.toString();

--- a/tests/admin-orders.spec.ts
+++ b/tests/admin-orders.spec.ts
@@ -10,7 +10,7 @@ import {
   seedOrder,
   setProductQty,
 } from "./helpers";
-import { weekOfMondayNY } from "@/lib/week";
+import { shiftWeek, weekOfMondayNY } from "@/lib/week";
 import type { Locator } from "@playwright/test";
 
 // #192: the per-order action stack (Mark/Confirm/Send buttons) renders only
@@ -112,6 +112,46 @@ test.describe("admin orders list", () => {
     ).toBeVisible();
   });
 
+  // DEC-045 (#231): the list keys on status, not week — Active shows open
+  // orders from ANY week (the DEC-041 cross-boundary case the old week
+  // filter silently dropped); Fulfilled holds the terminal ones.
+  test("active view shows cross-week open orders; fulfilled view holds terminal ones", async ({ page }) => {
+    const ids = await customerIds();
+    const lastWeek = shiftWeek(thisWeek, -1);
+    await clearOrdersForWeek(lastWeek);
+    const crossWeekId = await seedOrder({
+      customerId: ids.farmStand,
+      weekOf: lastWeek,
+      fulfillmentType: "pickup",
+      items: [{ productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 }],
+    });
+    const fulfilledId = await seedOrder({
+      customerId: ids.restaurant,
+      weekOf: thisWeek,
+      fulfillmentType: "delivery",
+      status: "delivered",
+      items: [{ productId: TEST_PRODUCTS.honey.id, qty: 1, unitPriceCents: 1200 }],
+    });
+
+    try {
+      await page.goto("/admin/orders");
+      // Active (default): the last-week open order is visible; terminal is not.
+      await expect(page.locator(`tr.ord-row[data-order-id="${crossWeekId}"]`)).toHaveCount(1);
+      await expect(page.locator(`tr.ord-row[data-order-id="${fulfilledId}"]`)).toHaveCount(0);
+
+      // Fulfilled: flipped.
+      await page.getByRole("button", { name: /^fulfilled/i }).click();
+      await expect(page).toHaveURL(/view=fulfilled/);
+      await expect(page.locator(`tr.ord-row[data-order-id="${fulfilledId}"]`)).toHaveCount(1);
+      await expect(page.locator(`tr.ord-row[data-order-id="${crossWeekId}"]`)).toHaveCount(0);
+      await expect(page.locator(`tr.ord-row[data-order-id="${fulfilledId}"] .pill-done`)).toHaveText("Delivered");
+    } finally {
+      // A leaked last-week open order would occupy farmStand's open-order
+      // identity and break later specs' fresh-form assumptions.
+      await clearOrdersForWeek(lastWeek);
+    }
+  });
+
   // #241: DEC-039 appends leave one order_items row per submission; the
   // detail panel folds same (product, unit, price) into one line.
   test("duplicate product rows consolidate to one line in the detail panel", async ({ page }) => {
@@ -188,8 +228,11 @@ test.describe("admin orders list", () => {
       .toBe("delivered");
 
     // Hard navigation (not page.reload — RSC streaming can hang reload after
-    // chained server actions in dev mode).
+    // chained server actions in dev mode). DEC-045: a delivered order leaves
+    // the Active view — it persists in Fulfilled.
     await page.goto("/admin/orders");
+    await expect(page.locator(`tr.ord-row[data-order-id="${orderId}"]`)).toHaveCount(0);
+    await page.goto("/admin/orders?view=fulfilled");
     const reloadedRow = page.locator(`tr.ord-row[data-order-id="${orderId}"]`);
     await expect(reloadedRow).toHaveAttribute("data-status", "delivered");
     await expect(reloadedRow.locator(".pill-done")).toHaveText("Delivered");

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -167,6 +167,11 @@ export default async function globalSetup() {
   // neither collides with current-week tests nor occupies the open-order
   // identity (DEC-041 dropped unique (customer_id, week_of), so this is a
   // check-then-insert rather than an upsert).
+  //
+  // Deliberately ITEMLESS: it appears in the admin Fulfilled view (DEC-045),
+  // and orders-flow's "export respects the active view" test relies on it
+  // emitting zero CSV rows (export is per line item). Adding items here
+  // breaks that spec's not-toContain assertions.
   const { data: farmStandRow, error: lookupError } = await adminClient
     .from("customers")
     .select("id")

--- a/tests/orders-flow.spec.ts
+++ b/tests/orders-flow.spec.ts
@@ -118,10 +118,13 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
       }, { timeout: 5000 })
       .toBe("delivered");
 
-    // Export → CSV contains the just-placed order's line item.
+    // Export → CSV contains the just-fulfilled order's line item. DEC-045:
+    // the delivered order lives in the Fulfilled view now — flip there first.
     // No invoice-number column anymore (Wave assigns on import) — match on
     // customer name + product name; column shape is
     //   Customer Name, Item Number, Quantity, Unit Price, Description, …
+    await adminPage.getByRole("button", { name: /^fulfilled/i }).click();
+    await expect(adminPage).toHaveURL(/view=fulfilled/);
     await adminPage.getByRole("button", { name: /export to wave/i }).click();
     const [download] = await Promise.all([
       adminPage.waitForEvent("download"),
@@ -148,7 +151,7 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
     await adminCtx.close();
   });
 
-  test("reconciliation pin holds across both column sort and week filter changes", async ({
+  test("reconciliation pin holds across both column sort and view changes", async ({
     browser,
   }, testInfo) => {
     test.skip(testInfo.project.name === "mobile", "Sort headers are hidden on mobile (card-stack layout); pin behavior is covered by the admin-orders mobile-specific test.");
@@ -193,11 +196,11 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
     await adminPage.getByRole("button", { name: /^Customer/i }).click();
     expect(await topOrderId()).toBe(recId);
 
-    // Flip to last week and back — pin must hold after a route change too
-    await adminPage.getByRole("button", { name: /^last week/i }).click();
-    await expect(adminPage).toHaveURL(/week=last/);
-    await adminPage.getByRole("button", { name: /^this week/i }).click();
-    await expect(adminPage).not.toHaveURL(/week=last/);
+    // Flip to Fulfilled and back — pin must hold after a route change too
+    await adminPage.getByRole("button", { name: /^fulfilled/i }).click();
+    await expect(adminPage).toHaveURL(/view=fulfilled/);
+    await adminPage.getByRole("button", { name: /^active/i }).click();
+    await expect(adminPage).not.toHaveURL(/view=fulfilled/);
     expect(await topOrderId()).toBe(recId);
     expect(await adminPage.locator("tr.ord-row").count()).toBe(2);
 
@@ -209,60 +212,68 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
     await adminCtx.close();
   });
 
-  test("export respects the active week filter", async ({ browser }) => {
+  test("export respects the active view (DEC-045)", async ({ browser }) => {
     await clearOrdersForWeek(thisWeek);
     await clearOrdersForWeek(lastWeek);
 
     const ids = await customerIds();
-    // farmStand=delivery this week with Kale; restaurant=pickup last week with
-    // Honey. Customer + product names are the unique markers — no invoice-
-    // number column anymore, so identification has to come from these.
+    // farmStand OPEN with Kale (stamped last week — cross-boundary orders
+    // must still export from Active); restaurant DELIVERED with Honey.
+    // Customer + product names are the unique markers. The global-setup
+    // prior-order fixture (farmStand, delivered, 2026-04-27) sits in the
+    // Fulfilled view but carries no items, so it emits no CSV rows.
     await seedOrder({
       customerId: ids.farmStand,
-      weekOf: thisWeek,
+      weekOf: lastWeek,
       fulfillmentType: "delivery",
       items: [{ productId: TEST_PRODUCTS.kale.id, qty: 3, unitPriceCents: 300 }],
     });
     await seedOrder({
       customerId: ids.restaurant,
-      weekOf: lastWeek,
+      weekOf: thisWeek,
       fulfillmentType: "pickup",
+      status: "delivered",
       items: [{ productId: TEST_PRODUCTS.honey.id, qty: 2, unitPriceCents: 1200 }],
     });
 
     const adminCtx = await browser.newContext({ storageState: ADMIN_STORAGE_STATE });
     const adminPage = await adminCtx.newPage();
 
-    // This-week default: export contains only this-week's line items
-    await adminPage.goto("/admin/orders");
-    await adminPage.getByRole("button", { name: /export to wave/i }).click();
-    const [thisDl] = await Promise.all([
-      adminPage.waitForEvent("download"),
-      adminPage.getByRole("button", { name: /download csv/i }).click(),
-    ]);
-    expect(thisDl.suggestedFilename()).toBe(`bushel-orders-${thisWeek}.csv`);
-    const thisText = await readDownloadText(thisDl);
-    expect(thisText).toContain(TEST_CUSTOMERS.farmStand.name);
-    expect(thisText).toContain(TEST_PRODUCTS.kale.name);
-    expect(thisText).not.toContain(TEST_CUSTOMERS.restaurant.name);
-    expect(thisText).not.toContain(TEST_PRODUCTS.honey.name);
+    try {
+      // Active default: only the open order's line items, any week.
+      await adminPage.goto("/admin/orders");
+      await adminPage.getByRole("button", { name: /export to wave/i }).click();
+      const [activeDl] = await Promise.all([
+        adminPage.waitForEvent("download"),
+        adminPage.getByRole("button", { name: /download csv/i }).click(),
+      ]);
+      expect(activeDl.suggestedFilename()).toBe(`bushel-orders-${thisWeek}.csv`);
+      const activeText = await readDownloadText(activeDl);
+      expect(activeText).toContain(TEST_CUSTOMERS.farmStand.name);
+      expect(activeText).toContain(TEST_PRODUCTS.kale.name);
+      expect(activeText).not.toContain(TEST_CUSTOMERS.restaurant.name);
+      expect(activeText).not.toContain(TEST_PRODUCTS.honey.name);
 
-    // Switch to Last week — re-export
-    await adminPage.getByRole("button", { name: /^last week/i }).click();
-    await expect(adminPage).toHaveURL(/week=last/);
-    await adminPage.getByRole("button", { name: /export to wave/i }).click();
-    const [lastDl] = await Promise.all([
-      adminPage.waitForEvent("download"),
-      adminPage.getByRole("button", { name: /download csv/i }).click(),
-    ]);
-    expect(lastDl.suggestedFilename()).toBe(`bushel-orders-${lastWeek}.csv`);
-    const lastText = await readDownloadText(lastDl);
-    expect(lastText).toContain(TEST_CUSTOMERS.restaurant.name);
-    expect(lastText).toContain(TEST_PRODUCTS.honey.name);
-    expect(lastText).not.toContain(TEST_CUSTOMERS.farmStand.name);
-    expect(lastText).not.toContain(TEST_PRODUCTS.kale.name);
-
-    await adminCtx.close();
+      // Switch to Fulfilled — re-export ships the terminal orders instead.
+      await adminPage.getByRole("button", { name: /^fulfilled/i }).click();
+      await expect(adminPage).toHaveURL(/view=fulfilled/);
+      await adminPage.getByRole("button", { name: /export to wave/i }).click();
+      const [doneDl] = await Promise.all([
+        adminPage.waitForEvent("download"),
+        adminPage.getByRole("button", { name: /download csv/i }).click(),
+      ]);
+      expect(doneDl.suggestedFilename()).toBe(`bushel-orders-fulfilled-${thisWeek}.csv`);
+      const doneText = await readDownloadText(doneDl);
+      expect(doneText).toContain(TEST_CUSTOMERS.restaurant.name);
+      expect(doneText).toContain(TEST_PRODUCTS.honey.name);
+      expect(doneText).not.toContain(TEST_CUSTOMERS.farmStand.name);
+      expect(doneText).not.toContain(TEST_PRODUCTS.kale.name);
+    } finally {
+      // The last-week open order would leak into other specs' Active view
+      // (and block farmStand's open-order identity).
+      await clearOrdersForWeek(lastWeek);
+      await adminCtx.close();
+    }
   });
 
   // 6.5f — multi-unit cross-cutting end-to-end. Exercises the full path:

--- a/tests/orders-flow.spec.ts
+++ b/tests/orders-flow.spec.ts
@@ -247,7 +247,7 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
         adminPage.waitForEvent("download"),
         adminPage.getByRole("button", { name: /download csv/i }).click(),
       ]);
-      expect(activeDl.suggestedFilename()).toBe(`bushel-orders-${thisWeek}.csv`);
+      expect(activeDl.suggestedFilename()).toBe(`bushel-orders-active-${thisWeek}.csv`);
       const activeText = await readDownloadText(activeDl);
       expect(activeText).toContain(TEST_CUSTOMERS.farmStand.name);
       expect(activeText).toContain(TEST_PRODUCTS.kale.name);


### PR DESCRIPTION
## Summary
Bundle C: `/admin/orders` drops its week filter for status-keyed **Active** / **Fulfilled** views (DEC-045). An order that stays open across a week boundary no longer vanishes from the list — the exact gap left standing after #239.

Closes #231. Based on `main` (the #239→#242 chain is merged).

## What changes
- **Active (default)** — every non-terminal order, any week. **Fulfilled** — the browsable past (terminal orders are never deleted). URL: `?view=fulfilled`.
- Week chips + the dead "Custom range" stub removed; week-keyed `listOrders` deleted — `listActiveOrders` / `listFulfilledOrders` are the only entry points.
- The hidden tab's count comes from a head-only count query, so Fulfilled's unbounded joined fetch doesn't ride on every Active load.
- Export ships the on-screen view; filenames are `bushel-orders-active-<week>.csv` / `bushel-orders-fulfilled-<week>.csv` (neither view is week-scoped, so a bare week in the filename would lie).
- `TERMINAL_ORDER_STATUSES` single source — `isTerminalStatus` and the Fulfilled filter derive from it; a future status can't fall out of both views.
- Empty-state copy per view. The stale sends-join 1:1 comment from the issue was already fixed in #239.

## Code review
@code-review — verified param round-trip, count/list consistency, sends display for cross-week fulfilled orders, no stale week references, mobile chips. Applied all four findings: Active export filename mislabel, terminal-set triplication, unbounded hidden-tab fetch, undocumented itemless-fixture dependency. Deferred: status/customer-keyed test-reset helper (week-keyed clearing still fits the test-reset contract; revisit on first flake).

## Test plan
Before testing: no schema changes; dev/preview already has #239's migration.

1. `/admin/orders` → chips read **Active [n] / Fulfilled [n]**; default shows only open orders.
2. In the dev SQL editor stamp an open order into last week (`update orders set week_of = week_of - 7 where status = 'new'`) → it stays visible in Active. (Pre-DEC-045 it would have vanished.)
3. Mark an order picked up → it leaves Active, appears under Fulfilled with its status pill.
4. Export from each view → filename carries the view name; contents match what's on screen.
5. 375px: cards + chips wrap fine; expand a fulfilled card — Mark buttons disabled, detail intact.

CLI: `admin-orders`, `orders-flow`, `admin-orders-export` green desktop; `admin-orders`, `orders-flow` green mobile. New cross-week visibility test + reworked export/view tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
