### PR TITLE
Bundle B: per-unit SKU + Wave export repoint (#228); inventory hidden-state visual (#230)

### DIFF
--- a/src/actions/save-product-units.ts
+++ b/src/actions/save-product-units.ts
@@ -11,6 +11,9 @@ export type UnitInput = {
   unit_price_cents: number;
   is_active: boolean;
   sort_order: number | null;
+  // DEC-043: Wave Item Number for this unit's export lines; null → the
+  // generated slug covers the export.
+  sku: string | null;
 };
 
 export type SaveProductUnitsInput = {
@@ -49,7 +52,11 @@ export async function saveProductUnits(
     return { error: "A product must have at least one unit." };
   }
 
-  const trimmed = input.units.map((u) => ({ ...u, label: u.label.trim() }));
+  const trimmed = input.units.map((u) => ({
+    ...u,
+    label: u.label.trim(),
+    sku: u.sku?.trim() || null,
+  }));
 
   for (const u of trimmed) {
     if (!u.label) return { error: "Every unit needs a label." };
@@ -137,6 +144,7 @@ export async function saveProductUnits(
         unit_price_cents: u.unit_price_cents,
         is_active: u.is_active,
         sort_order: u.sort_order,
+        sku: u.sku,
         slug,
       });
       if (error) return { error: error.message };
@@ -149,6 +157,7 @@ export async function saveProductUnits(
           unit_price_cents: u.unit_price_cents,
           is_active: u.is_active,
           sort_order: u.sort_order,
+          sku: u.sku,
         })
         .eq("id", u.id);
       if (error) return { error: error.message };

--- a/src/app/(admin)/admin/inventory/page.tsx
+++ b/src/app/(admin)/admin/inventory/page.tsx
@@ -15,7 +15,7 @@ export default async function InventoryPage() {
       .order("name"),
     supabase
       .from("product_units")
-      .select("id, product_id, label, conversion_to_base, unit_price_cents, is_active, sort_order")
+      .select("id, product_id, label, conversion_to_base, unit_price_cents, is_active, sort_order, sku")
       .order("sort_order", { ascending: true, nullsFirst: false })
       .order("id"),
     supabase
@@ -89,6 +89,7 @@ export default async function InventoryPage() {
       unit_price_cents: u.unit_price_cents,
       is_active: u.is_active,
       sort_order: u.sort_order,
+      sku: u.sku,
     });
   }
 

--- a/src/components/admin/inventory-row.tsx
+++ b/src/components/admin/inventory-row.tsx
@@ -142,6 +142,9 @@ export function InventoryRow({
           </span>
         </td>
         <td>
+          {/* #230: explicit text, not texture alone — the hatch was nearly
+              indistinguishable from the plain-grey unavailable state. */}
+          {!row.is_active && <span className="pill pill-hidden">Hidden</span>}
           <input
             type="text"
             className="field-input"

--- a/src/components/admin/units-drawer.tsx
+++ b/src/components/admin/units-drawer.tsx
@@ -16,6 +16,10 @@ export type ProductUnitState = {
   unit_price_cents: number;
   is_active: boolean;
   sort_order: number | null;
+  // DEC-043: Wave "Item Number" for this unit's export lines. Null → the
+  // generated slug covers the export; editable so Annabel can match her
+  // existing Wave catalog.
+  sku: string | null;
 };
 
 type Props = {
@@ -85,7 +89,8 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
         orig.label !== u.label ||
         orig.conversion_to_base !== u.conversion_to_base ||
         orig.unit_price_cents !== u.unit_price_cents ||
-        orig.is_active !== u.is_active
+        orig.is_active !== u.is_active ||
+        (orig.sku ?? "") !== (u.sku ?? "")
       ) {
         return true;
       }
@@ -150,6 +155,7 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
         unit_price_cents: 0,
         is_active: true,
         sort_order: maxOrder + 10,
+        sku: null,
       },
     ]);
     setError(null);
@@ -190,6 +196,7 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
       unit_price_cents: u.unit_price_cents,
       is_active: u.is_active,
       sort_order: u.sort_order,
+      sku: u.sku?.trim() || null,
     }));
 
     setError(null);
@@ -278,6 +285,9 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
                 Conversion
               </span>
               <span className="units-col-price">Price</span>
+              <span className="units-col-sku" title="Wave Item Number for this unit's invoice lines. Blank uses the generated slug.">
+                SKU
+              </span>
               <span className="units-col-active">Active</span>
               <span className="units-col-trash" />
             </div>
@@ -445,6 +455,16 @@ function UnitRow({
             aria-label="Unit price"
           />
         </div>
+      </div>
+      <div className="units-col-sku">
+        <input
+          type="text"
+          className="field-input"
+          value={unit.sku ?? ""}
+          onChange={(e) => onUpdate({ sku: e.target.value })}
+          placeholder="Wave item #"
+          aria-label={`SKU: ${unit.label || "unit"}`}
+        />
       </div>
       <div className="units-col-active">
         <Switch

--- a/src/components/admin/units-drawer.tsx
+++ b/src/components/admin/units-drawer.tsx
@@ -285,9 +285,6 @@ export function UnitsDrawer({ productId, productName, initialUnits, onClose, onS
                 Conversion
               </span>
               <span className="units-col-price">Price</span>
-              <span className="units-col-sku" title="Wave Item Number for this unit's invoice lines. Blank uses the generated slug.">
-                SKU
-              </span>
               <span className="units-col-active">Active</span>
               <span className="units-col-trash" />
             </div>
@@ -457,6 +454,12 @@ function UnitRow({
         </div>
       </div>
       <div className="units-col-sku">
+        <span
+          className="units-sku-tag"
+          title="Wave Item Number for this unit's invoice lines. Blank uses the generated slug."
+        >
+          SKU
+        </span>
         <input
           type="text"
           className="field-input"

--- a/src/lib/admin/export-orders.ts
+++ b/src/lib/admin/export-orders.ts
@@ -59,7 +59,9 @@ export function ordersToRows(orders: OrderRow[]): ExportRow[] {
     for (const i of o.items) {
       rows.push({
         customerName: o.customerName,
-        itemNumber: i.sku ?? i.slug ?? "",
+        // `||` not `??`: the save action normalizes sku to trimmed-or-null,
+        // but no DB CHECK does — a stray "" must still fall back to the slug.
+        itemNumber: i.sku || i.slug || "",
         quantity: String(i.qty),
         unitPrice: money(i.unitPriceCents),
         description: i.name,

--- a/src/lib/admin/export-orders.ts
+++ b/src/lib/admin/export-orders.ts
@@ -14,11 +14,12 @@
 // "Customer Name." EXPORT_COLUMNS stays exported for documentation +
 // test assertions.
 //
-// One row per LINE ITEM. Per-product mapping:
-//   Wave "Item Number" ← products.description (used as a slug, e.g.
-//     "KALE-BUNCH" — Annabel populates this in the inventory editor).
-//     Empty cell when the slug isn't set; she fills it in Wave before
-//     posting.
+// One row per LINE ITEM. Per-line mapping (DEC-043):
+//   Wave "Item Number" ← the line's product_units.sku (Annabel-edited to
+//     match her Wave catalog, units drawer), falling back to the generated
+//     product_units.slug, then blank — she fills it in Wave before posting.
+//     products.description is OUT of the export entirely; it's the
+//     customer-facing long description and nothing else.
 //   Wave "Description" ← products.name (the human-readable product name).
 //   products.unit is no longer in the export; it lives in the customer-
 //     facing UI and the admin row detail, not the invoice.
@@ -58,7 +59,7 @@ export function ordersToRows(orders: OrderRow[]): ExportRow[] {
     for (const i of o.items) {
       rows.push({
         customerName: o.customerName,
-        itemNumber: i.description ?? "",
+        itemNumber: i.sku ?? i.slug ?? "",
         quantity: String(i.qty),
         unitPrice: money(i.unitPriceCents),
         description: i.name,

--- a/src/lib/admin/orders-queries.ts
+++ b/src/lib/admin/orders-queries.ts
@@ -69,10 +69,13 @@ export function isValidTransition(
 export type OrderItem = {
   productId: string;
   name: string;
-  // products.description doubles as the Wave-export "Item Number" slug per the
-  // 5.2 mapping (e.g. "KALE-BUNCH"). Null when unset — Wave just gets a blank
-  // Item Number cell, which Annabel fills before posting the invoice.
-  description: string | null;
+  // DEC-043: Wave "Item Number" inputs for this line's unit. sku is
+  // Annabel-edited (matches her Wave catalog); slug is the generated
+  // fallback. The export resolves sku → slug → blank. products.description
+  // left this shape entirely — it's the customer-facing long description,
+  // nothing more.
+  sku: string | null;
+  slug: string | null;
   // Product-level base unit label (the product_units row with
   // conversion_to_base = 1.0, per DEC-037). Used where a per-product unit is
   // needed (fulfillment report "total N <base>"); display surfaces should use
@@ -176,9 +179,9 @@ async function queryOrders(filter: {
        status, needs_reconciliation,
        customers(id, name, phone),
        order_items(product_id, qty, unit_price_cents,
-         products(name, description, qty_available,
+         products(name, qty_available,
            product_units(label, conversion_to_base)),
-         product_units(label, conversion_to_base))`,
+         product_units(label, conversion_to_base, sku, slug))`,
     )
     .order("created_at", { ascending: false });
   if (filter.weekOf) ordersQuery = ordersQuery.eq("week_of", filter.weekOf);
@@ -246,7 +249,6 @@ async function queryOrders(filter: {
         unit_price_cents: number;
         products: {
           name: string;
-          description: string | null;
           qty_available: number;
           // The product's full unit set (reverse join). Only the base row
           // (conversion_to_base = 1.0) is read here, for OrderItem.unit.
@@ -258,6 +260,8 @@ async function queryOrders(filter: {
         product_units: {
           label: string;
           conversion_to_base: number;
+          sku: string | null;
+          slug: string | null;
         } | null;
       }>)
         .filter((i) => i.products !== null)
@@ -274,7 +278,8 @@ async function queryOrders(filter: {
           return {
             productId: i.product_id,
             name: i.products!.name,
-            description: i.products!.description,
+            sku: i.product_units?.sku ?? null,
+            slug: i.product_units?.slug ?? null,
             unit: baseLabel ?? unitLabel,
             unitLabel,
             conversionToBase: Number(i.product_units?.conversion_to_base ?? 1),

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -314,6 +314,7 @@ export type Database = {
           is_active: boolean
           label: string
           product_id: string
+          sku: string | null
           slug: string
           sort_order: number | null
           unit_price_cents: number
@@ -326,6 +327,7 @@ export type Database = {
           is_active?: boolean
           label: string
           product_id: string
+          sku?: string | null
           slug: string
           sort_order?: number | null
           unit_price_cents: number
@@ -338,6 +340,7 @@ export type Database = {
           is_active?: boolean
           label?: string
           product_id?: string
+          sku?: string | null
           slug?: string
           sort_order?: number | null
           unit_price_cents?: number

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2954,6 +2954,11 @@
   }
   /* Hide drag handle on mobile — no useful interaction there yet. */
   .data-table tbody tr.data-row > td:nth-child(1) { display: none; }
+  /* #230: the desktop accent bar lives on that hidden first td — re-pin it
+     to the card edge so hidden ≠ unavailable reads on mobile too. */
+  .data-table tbody tr.data-row.is-hidden {
+    box-shadow: inset 3px 0 0 var(--rose-600);
+  }
   /* Switch + trash side-by-side at the bottom of the card. */
   .data-table tbody tr.data-row > td:nth-child(7) {
     display: inline-flex !important;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -344,14 +344,9 @@
   padding: 0 12px 8px !important;
   border-top: 0 !important;
 }
-.field-desc-input {
-  background: var(--leaf-50);
-  border-color: var(--leaf-100);
-  font-style: italic;
-  font-size: 0.9rem;
-  color: var(--ink-700);
-}
-.field-desc-input:focus { background: var(--paper); border-color: var(--leaf-600); }
+/* Deliberately no overrides — the open description editor reads exactly
+   like the name field above it (Eric: the green/italic treatment made it
+   look like a different kind of field; it isn't). */
 
 /* ── Switch ─────────────────────────────────────────────── */
 .switch {
@@ -633,13 +628,28 @@
 .units-list-head,
 .units-row {
   display: grid;
-  /* label · conversion · price · SKU (DEC-043) · active · trash */
-  grid-template-columns: minmax(0, 1.4fr) 80px 95px minmax(0, 0.9fr) 52px 32px;
+  grid-template-columns: minmax(0, 1.4fr) 90px 100px 56px 36px;
   align-items: center;
   gap: 10px;
   padding: 8px 12px;
 }
-.units-col-sku .field-input { width: 100%; min-width: 0; }
+/* SKU (DEC-043) rides a full-width second line — Wave item numbers run
+   long, and squeezing them into a sixth column crushed the label field.
+   `order` places it after active/trash in auto-placement. */
+.units-col-sku {
+  grid-column: 1 / -1;
+  order: 9;
+  display: flex; align-items: center; gap: 8px;
+}
+.units-col-sku .field-input { flex: 1; min-width: 0; }
+.units-sku-tag {
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-500);
+  flex-shrink: 0;
+}
 .units-list-head {
   background: var(--cream);
   border-bottom: 1px solid var(--ink-200);
@@ -701,15 +711,6 @@
    under the input instead of crushing it. */
 @media (max-width: 480px) {
   .units-col-label { flex-wrap: wrap; }
-  /* Six columns don't fit a 375px drawer — SKU wraps to its own full-width
-     second line (order pushes it after active/trash in auto-placement);
-     the placeholder labels the field since the header cell is hidden. */
-  .units-list-head,
-  .units-row {
-    grid-template-columns: minmax(0, 1.4fr) 80px 95px 52px 32px;
-  }
-  .units-col-sku { grid-column: 1 / -1; order: 7; }
-  .units-list-head .units-col-sku { display: none; }
 }
 
 .units-col-conv .field-input:disabled,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -168,15 +168,23 @@
    deactivated-customer treatment so "hidden" reads the same on both screens.
    Only visible when "Show hidden" is toggled on. */
 .data-table tbody tr.data-row.is-hidden td {
+  /* #230: one step darker than the old --ink-100 hatch so the texture
+     registers next to .is-disabled's plain grey. */
   background: repeating-linear-gradient(
     -45deg,
-    var(--ink-100) 0 6px,
+    var(--ink-200) 0 6px,
     transparent 6px 12px
   );
 }
 .data-table tbody tr.data-row.is-hidden .field-input,
 .data-table tbody tr.data-row.is-hidden .field-num,
 .data-table tbody tr.data-row.is-hidden .field-select { color: var(--ink-500); }
+/* #230: hidden ≠ unavailable at a glance — rose accent bar on the row edge
+   + an explicit pill (markup in inventory-row.tsx). .is-disabled stays the
+   quieter plain grey. */
+.data-table tbody tr.data-row.is-hidden td:first-child {
+  box-shadow: inset 3px 0 0 var(--rose-600);
+}
 
 /* Drag-to-reorder (#143) */
 .data-table tbody tr.data-row.is-dragging td { opacity: 0.4; }
@@ -625,11 +633,13 @@
 .units-list-head,
 .units-row {
   display: grid;
-  grid-template-columns: minmax(0, 1.4fr) 90px 100px 56px 36px;
+  /* label · conversion · price · SKU (DEC-043) · active · trash */
+  grid-template-columns: minmax(0, 1.4fr) 80px 95px minmax(0, 0.9fr) 52px 32px;
   align-items: center;
   gap: 10px;
   padding: 8px 12px;
 }
+.units-col-sku .field-input { width: 100%; min-width: 0; }
 .units-list-head {
   background: var(--cream);
   border-bottom: 1px solid var(--ink-200);
@@ -691,6 +701,15 @@
    under the input instead of crushing it. */
 @media (max-width: 480px) {
   .units-col-label { flex-wrap: wrap; }
+  /* Six columns don't fit a 375px drawer — SKU wraps to its own full-width
+     second line (order pushes it after active/trash in auto-placement);
+     the placeholder labels the field since the header cell is hidden. */
+  .units-list-head,
+  .units-row {
+    grid-template-columns: minmax(0, 1.4fr) 80px 95px 52px 32px;
+  }
+  .units-col-sku { grid-column: 1 / -1; order: 7; }
+  .units-list-head .units-col-sku { display: none; }
 }
 
 .units-col-conv .field-input:disabled,
@@ -2569,6 +2588,9 @@
 .pill-confirmed { background: var(--amber-50); color: #8A6210; border: 1px solid #EFD89A; }
 .pill-ready     { background: var(--leaf-50); color: var(--leaf-700); border: 1px solid var(--leaf-100); }
 .pill-done      { background: var(--ink-100); color: var(--ink-700); }
+/* #230: inventory hidden-state marker — pairs with the rose accent bar on
+   .is-hidden rows so hidden ≠ unavailable at a glance. */
+.pill-hidden    { background: rgba(178,59,46,0.1); color: var(--rose-600); margin-bottom: 4px; }
 
 .status-advance {
   display: inline-flex; align-items: center; gap: 6px;

--- a/supabase/migrations/20260702100000_product_units_sku.sql
+++ b/supabase/migrations/20260702100000_product_units_sku.sql
@@ -1,0 +1,19 @@
+-- #228 / DEC-043 — per-unit editable SKU.
+--
+-- Wave's "Item Number" is a PER-UNIT truth under multi-unit (one product →
+-- multiple orderable units, each its own Wave line item), and it must match
+-- Annabel's existing Wave item catalog — so it's editable, not the generated
+-- slug. The export resolves sku → slug → blank; products.description leaves
+-- the export entirely and reverts to its sole purpose, the customer-facing
+-- long description.
+--
+-- Nullable, no backfill: Annabel fills SKUs in as she reconciles her Wave
+-- catalog; slug keeps exports working meanwhile.
+
+alter table public.product_units
+  add column sku text;
+
+comment on column public.product_units.sku is
+  'DEC-043: Wave "Item Number" for this unit''s export lines. Editable so it '
+  'can match the existing Wave item catalog. Null falls back to slug in the '
+  'export.';

--- a/tests/admin-inventory-units.spec.ts
+++ b/tests/admin-inventory-units.spec.ts
@@ -62,6 +62,8 @@ test.describe("admin inventory · units drawer", () => {
     await newRow.getByRole("textbox", { name: "Unit label" }).fill("per lb");
     await newRow.getByRole("textbox", { name: "Conversion to base" }).fill("0.5");
     await newRow.getByRole("textbox", { name: "Unit price" }).fill("8.00");
+    // DEC-043: per-unit Wave Item Number, editable in the drawer.
+    await newRow.getByRole("textbox", { name: /^SKU/ }).fill("KALE-LB-WAVE");
 
     await drawerSave(page).click();
     await expect(drawer(page)).toBeHidden();
@@ -72,12 +74,13 @@ test.describe("admin inventory · units drawer", () => {
 
     // verify persisted via DB
     const sb = admin();
-    const { data } = await sb.from("product_units").select("label, unit_price_cents, conversion_to_base, is_active").eq("product_id", KALE.id);
+    const { data } = await sb.from("product_units").select("label, unit_price_cents, conversion_to_base, is_active, sku").eq("product_id", KALE.id);
     const extra = data?.find((u) => u.label === "per lb");
     expect(extra).toBeTruthy();
     expect(extra?.unit_price_cents).toBe(800);
     expect(Number(extra?.conversion_to_base)).toBe(0.5);
     expect(extra?.is_active).toBe(true);
+    expect(extra?.sku).toBe("KALE-LB-WAVE");
   });
 
   test("inactive unit is reflected in chip subtext", async ({ page }) => {

--- a/tests/admin-inventory.spec.ts
+++ b/tests/admin-inventory.spec.ts
@@ -229,6 +229,8 @@ test.describe("admin inventory", () => {
       const hidden = rowByName(page, "Test Carrots");
       await expect(hidden).toBeVisible();
       await expect(hidden).toHaveClass(/is-hidden/);
+      // #230: explicit Hidden pill, not texture alone.
+      await expect(hidden.locator(".pill-hidden")).toHaveText("Hidden");
 
       await hidden.getByRole("button", { name: /^Restore Test Carrots/ }).click();
       await expect(saveButton(page, 1)).toBeEnabled();

--- a/tests/admin-orders-export.spec.ts
+++ b/tests/admin-orders-export.spec.ts
@@ -39,7 +39,8 @@ function mockOrder(over: Partial<OrderRow> = {}): OrderRow {
       {
         productId: "p1",
         name: "Kale",
-        description: "KALE-BUNCH",
+        sku: "KALE-BUNCH",
+        slug: "kale-cccccccc",
         unit: "bunch",
         unitLabel: "bunch",
         conversionToBase: 1,
@@ -63,7 +64,8 @@ test("toCsv: no header row; line items only, RFC 4180 quoting", () => {
         {
           productId: "p1",
           name: "Heirloom\ntomatoes",
-          description: "HEIRLOOM-LB",
+          sku: "HEIRLOOM-LB",
+          slug: "heirloom-cccccccc",
           unit: "lb",
           unitLabel: "lb",
           conversionToBase: 1,
@@ -89,7 +91,7 @@ test("toCsv: no header row; line items only, RFC 4180 quoting", () => {
   expect(lines[0]).toContain(",HEIRLOOM-LB,3,5.50,");
 });
 
-test("toCsv: empty Item Number when product description (slug) is null", () => {
+test("toCsv: empty Item Number when both unit sku and slug are null", () => {
   const csv = toCsv([
     mockOrder({
       customerName: "Plum Café",
@@ -97,7 +99,8 @@ test("toCsv: empty Item Number when product description (slug) is null", () => {
         {
           productId: "p1",
           name: "Garlic scapes",
-          description: null,
+          sku: null,
+          slug: null,
           unit: "bunch",
           unitLabel: "bunch",
           conversionToBase: 1,
@@ -119,14 +122,14 @@ test("toCsv: one row per line item; multi-item order keeps per-line slugs", () =
     mockOrder({
       customerName: "A",
       items: [
-        { productId: "p1", name: "Kale", description: "KALE-BU", unit: "bunch", unitLabel: "bunch", conversionToBase: 1, qty: 1, unitPriceCents: 300, qtyAvailable: 5 },
-        { productId: "p2", name: "Eggs", description: "EGG-DZ", unit: "dozen", unitLabel: "dozen", conversionToBase: 1, qty: 2, unitPriceCents: 600, qtyAvailable: 5 },
+        { productId: "p1", name: "Kale", sku: "KALE-BU", slug: null, unit: "bunch", unitLabel: "bunch", conversionToBase: 1, qty: 1, unitPriceCents: 300, qtyAvailable: 5 },
+        { productId: "p2", name: "Eggs", sku: "EGG-DZ", slug: null, unit: "dozen", unitLabel: "dozen", conversionToBase: 1, qty: 2, unitPriceCents: 600, qtyAvailable: 5 },
       ],
     }),
     mockOrder({
       customerName: "B",
       items: [
-        { productId: "p3", name: "Honey", description: "HON-JAR", unit: "jar", unitLabel: "jar", conversionToBase: 1, qty: 1, unitPriceCents: 1200, qtyAvailable: 5 },
+        { productId: "p3", name: "Honey", sku: "HON-JAR", slug: null, unit: "jar", unitLabel: "jar", conversionToBase: 1, qty: 1, unitPriceCents: 1200, qtyAvailable: 5 },
       ],
     }),
   ]);
@@ -149,7 +152,8 @@ test("toTsv: tab-separated, strips embedded tabs/newlines from fields", () => {
         {
           productId: "p1",
           name: "Has\nnewline",
-          description: "SLUG-WITH\nNEWLINE",
+          sku: "SLUG-WITH\nNEWLINE",
+          slug: null,
           unit: "lb",
           unitLabel: "lb",
           conversionToBase: 1,
@@ -168,11 +172,11 @@ test("toTsv: tab-separated, strips embedded tabs/newlines from fields", () => {
   expect(lines[0]).toContain("SLUG-WITH NEWLINE");
 });
 
-test("ordersToRows: itemNumber = product description (slug); description = product name", () => {
+test("ordersToRows: itemNumber = unit sku → slug fallback; description = product name (DEC-043)", () => {
   const rows = ordersToRows([
     mockOrder({
       items: [
-        { productId: "p", name: "Honey", description: "HONEY-JAR", unit: "jar", unitLabel: "jar", conversionToBase: 1, qty: 7, unitPriceCents: 125, qtyAvailable: 10 },
+        { productId: "p", name: "Honey", sku: "HONEY-JAR", slug: "honey-jar-slug", unit: "jar", unitLabel: "jar", conversionToBase: 1, qty: 7, unitPriceCents: 125, qtyAvailable: 10 },
       ],
     }),
   ]);
@@ -199,21 +203,21 @@ test.describe("admin orders export — UI", () => {
     await clearOrdersForWeek(thisWeek);
   });
 
-  // Set a product slug for the download test so we exercise the non-empty
-  // Item Number path. Restored in afterEach.
-  async function setProductSlug(productId: string, slug: string | null): Promise<void> {
-    await admin().from("products").update({ description: slug }).eq("id", productId);
+  // DEC-043: Item Number comes from the line's unit sku (→ slug fallback).
+  // Set a sku for the download test's non-fallback path; restored in afterEach.
+  async function setUnitSku(productId: string, sku: string | null): Promise<void> {
+    await admin().from("product_units").update({ sku }).eq("product_id", productId);
   }
 
   test.afterEach(async () => {
-    // Restore seed shape — description is null for all TEST_PRODUCTS in seed.
-    await setProductSlug(TEST_PRODUCTS.kale.id, null);
-    await setProductSlug(TEST_PRODUCTS.honey.id, null);
+    // Restore seed shape — sku is null for all TEST_PRODUCTS units.
+    await setUnitSku(TEST_PRODUCTS.kale.id, null);
+    await setUnitSku(TEST_PRODUCTS.honey.id, null);
   });
 
   test("Download CSV produces a file with the expected header + body", async ({ page }) => {
     const ids = await customerIds();
-    await setProductSlug(TEST_PRODUCTS.kale.id, "KALE-BU");
+    await setUnitSku(TEST_PRODUCTS.kale.id, "KALE-BU");
     await seedOrder({
       customerId: ids.farmStand,
       weekOf: thisWeek,
@@ -239,10 +243,10 @@ test.describe("admin orders export — UI", () => {
     expect(line).toBe(`${TEST_CUSTOMERS.farmStand.name},KALE-BU,2,3.00,Kale,,`);
   });
 
-  test("Copy as TSV writes to clipboard; empty Item Number when slug is null", async ({ page, context }) => {
+  test("Copy as TSV writes to clipboard; Item Number falls back to the unit slug when sku is null", async ({ page, context }) => {
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
     const ids = await customerIds();
-    // Honey has no slug (seed default) — assert the Item Number cell is empty.
+    // Honey has no sku (seed default) — the generated unit slug fills in.
     await seedOrder({
       customerId: ids.restaurant,
       weekOf: thisWeek,
@@ -260,8 +264,8 @@ test.describe("admin orders export — UI", () => {
     const clip: string = await page.evaluate(() => navigator.clipboard.readText());
     const lines = clip.split("\n");
     const line = lines.find((l) => l.includes(TEST_CUSTOMERS.restaurant.name));
-    // Tab-separated: Customer, '', 1, 12.00, Honey, '', ''
-    expect(line).toBe(`${TEST_CUSTOMERS.restaurant.name}\t\t1\t12.00\tHoney\t\t`);
+    // Tab-separated: Customer, honey-cccccccc (slug fallback), 1, 12.00, Honey, '', ''
+    expect(line).toBe(`${TEST_CUSTOMERS.restaurant.name}\thoney-cccccccc\t1\t12.00\tHoney\t\t`);
   });
 
   test("Export button disabled when no orders for the week", async ({ page }) => {

--- a/tests/orders-flow.spec.ts
+++ b/tests/orders-flow.spec.ts
@@ -141,8 +141,9 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
         l.includes(TEST_PRODUCTS.kale.name),
     );
     expect(kaleLine).toBeTruthy();
-    // Seed product has description = null, so Item Number cell is empty.
-    expect(kaleLine).toBe(`${TEST_CUSTOMERS.farmStand.name},,2,3.00,${TEST_PRODUCTS.kale.name},,`);
+    // DEC-043: Item Number = unit sku → slug fallback. Seed units carry no
+    // sku, so the generated slug fills the cell.
+    expect(kaleLine).toBe(`${TEST_CUSTOMERS.farmStand.name},kale-cccccccc,2,3.00,${TEST_PRODUCTS.kale.name},,`);
 
     // Reference orderId so the unused-var lint stays happy + documents the
     // intent that this CSV line corresponds to the order we just created.


### PR DESCRIPTION
## Summary
Bundle B: per-unit editable SKU + Wave export repoint (9.4/#228, DEC-043) and the inventory hidden-state visual (9.6/#230).

Closes #228, closes #230. **Stacked on #243** — merge that first; this diff is the last two commits.

## What changes
**9.4** — `products.description` was a live landmine: the inventory editor treats it as the customer-facing long description while the Wave export emitted it as the invoice **Item Number**. Now:
- Migration adds nullable `product_units.sku` (no backfill — Annabel fills as she reconciles her Wave catalog).
- Units drawer gains an editable **SKU** column (wraps to its own line at ≤480px).
- Export Item Number resolves the line's unit `sku` → generated `slug` → blank; `description` is out of the export entirely.
- `OrderItem` drops `description`, gains `sku`/`slug`; Supabase types regenerated.

**9.6** — hidden inventory rows were nearly indistinguishable from unavailable ones. Now: explicit **Hidden** pill in the name cell, rose left-edge accent bar (re-pinned to the card edge on mobile, where the desktop td is display:none), hatch darkened one step. `.is-disabled` stays the quieter grey.

## Checklist
- Migration: yes — additive nullable column only (`supabase db push` to dev/preview before testing)
- RLS: no · 375px: yes (drawer SKU wrap + card accent bar verified on the mobile project)

## Code review
@code-review — verified the sku→slug→blank chain end-to-end including consolidated lines (unit uniqueness makes the first-row sku representative), no orphaned `description` readers, types diff exactly the three sku lines. Applied: mobile accent bar (desktop bar targeted a td the card layout hides) and `||` fallback so a stray empty-string sku still falls to the slug. Skipped: mobile-only SKU micro-label (aria-label covers AT; revisit if the bare input bothers Annabel).

## Test plan
Before testing: `source .envrc && supabase db push` (adds `product_units.sku` on dev/preview).

1. `/admin/inventory` → open a product's units drawer → new **SKU** column. Set one (e.g. `KALE-BU`), save, reopen — it stuck.
2. Place an order with that unit → `/admin/orders` → Export to Wave → Item Number = `KALE-BU`. Order a unit with no SKU → Item Number = its generated slug.
3. Confirm the customer page still shows the product's long description text (unchanged surface).
4. `/admin/inventory` → hide a product → toggle "Show hidden" → the row now carries a red **Hidden** pill + red left edge; an unavailable (grey) row looks clearly different. Check at 375px too — the card's left edge carries the bar.

CLI: `admin-orders-export`, `admin-inventory-units`, `admin-inventory`, `orders-flow` green desktop; inventory suites green mobile (one pre-existing mobile failure in `admin-inventory.spec.ts:156` "discard reverts pending edits" — fails identically on the clean tree, same mobile/webkit family as the known `admin-send` one; not from this PR). pgTAP green post-migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
