### PR TITLE
CI: typecheck + lint gates (#238 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Typecheck + lint gate (#238 follow-up): neither was a CI gate, so both
+      # silently drifted to 50 accumulated errors before anyone noticed. They
+      # run in seconds — fail fast, before the build/Playwright spend.
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npm run lint
+
       - name: Set Supabase env vars
         run: |
           eval $(supabase status --output env)


### PR DESCRIPTION
## Summary
Adds `tsc --noEmit` and `npm run lint` steps to ci.yml, after `npm ci` and before the build — the follow-up left open when #238 dug out the silently-accumulated 50-error backlog. Both finish in seconds; a type or lint error now fails the PR before any Playwright spend.

Verified green locally against this branch (the one standing warning — aria-sort on a button role — is a warning, not an error, so it doesn't gate).

## Test plan
This PR's own CI run is the test: the two new steps should appear and pass in the checks list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)