### PR TITLE
auto-sync downstream — 2026-07-02

### DIFF
--- a/.claude/agents/code-review.md
+++ b/.claude/agents/code-review.md
@@ -1,6 +1,7 @@
 ---
 name: code-review
 description: Post-commit code reviewer for [Project]. Reviews recent changes for pattern consistency, RLS gaps, missing error/loading states, and convention violations. Advisory only — flags issues, doesn't block.
+model: sonnet
 ---
 
 You are @code-review — a lightweight post-commit reviewer.

--- a/.claude/skills/kill-this/SKILL.md
+++ b/.claude/skills/kill-this/SKILL.md
@@ -38,7 +38,7 @@ Stage all uncommitted code changes on the **task branch** (the current `$BRANCH`
 git add -A
 git commit -m "<phase/task summary>
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
 ```
 
 If there is nothing to commit, surface that and stop here — no PR for no code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Default to the cheapest model that does the job. **Opus 4.8 is the standing mode
 
 | Tier | Model | Use for |
 |------|-------|---------|
-| Cheap | `claude-sonnet-4-6` | Trivial/scoped agents and reviews — fast, low-cost. |
+| Cheap | `claude-sonnet-5` | Trivial/scoped agents and reviews — fast, low-cost. |
 | Default | `claude-opus-4-8` | The standing model for development and architecture. Most work runs here. |
 
 - **Reach for `effort` before reaching for a bigger model.** `effort` (`low`/`medium`/`high`/`xhigh`/`max`, via `output_config`) buys quality more cheaply than a model jump on a task the current model can already do. `xhigh` is the floor for coding/agentic work, `high` for intelligence-sensitive work, `max` only when correctness must beat cost.
@@ -184,6 +184,15 @@ Doing PR reviews from your phone is tolerable if you structure for it:
 - **Bug reports:** create a GitHub issue, label `bug`, add to current or next phase.
 
 Project-specific debugging gotchas (dev-server checks, stale-process traps, auth-redirect quirks) live in `.claude/CLAUDE-context.md` under `## Workflow Notes (project)`.
+
+## Memory
+
+Two actions, both automatic — never wait for the user to ask, and never defer to session end:
+
+1. **Save on the spot.** The moment the user states a durable fact (a preference, a correction, a project constraint), do two things in that same turn: (a) write the memory file, (b) add its one-line pointer to `MEMORY.md`. Saying "noted" or "I'll remember" is not saving — if no file was written, nothing was remembered.
+2. **Reconcile at session start.** When you load memory, list the memory directory and diff it against `MEMORY.md`. For any file missing a pointer line, add one. Only `MEMORY.md` loads at startup, so an unindexed file never recalls — this self-check catches drift without the user ever having to notice it broke.
+
+A memory is "working" only when both its file exists **and** it has a line in `MEMORY.md`. One without the other is invisible.
 
 ## Approval Before Action (all tasks)
 


### PR DESCRIPTION
Base: `main`

Nightly downstream sync (seeds → bushel) via @sync-config `direction: pull, mode: auto`. Three template files evolved in seeds since the last converged sync (2026-07-01); this PR forward-ports them.

## Action rows

| File | Hunk | Provenance | Classification | Action |
|------|------|------------|----------------|--------|
| `CLAUDE.md` | line 96 tier label `` `claude-sonnet-4-6` `` → `` `claude-sonnet-5` `` | Template-only | Forward-port | Applied — hybrid shell tier label bumped (seeds PR #135, Sonnet 5 pin) |
| `CLAUDE.md` | new `## Memory` section (write-on-the-spot discipline) | Template-only | Forward-port | Applied — inserted before `## Approval Before Action` (seeds PR #134) |
| `.claude/agents/code-review.md` | new `model: sonnet` frontmatter line | Template-only | Forward-port | Applied — inserted after `description:` (seeds PR #135) |
| `.claude/skills/kill-this/SKILL.md` | hash mismatch | Class: logic | Forward-port | logic-drift — full-file overwrite from seeds (co-author string bumped to Sonnet 5) |

## Files updated

- `CLAUDE.md` — 2 hunks forward-ported
- `.claude/agents/code-review.md` — 1 hunk forward-ported
- `.claude/skills/kill-this/SKILL.md` — full-file overwrite from seeds

## Skip summary

- Skipped (class:context, 1 file): `.claude/CLAUDE-context.md`
- Skipped (logic, hash-equal, 15 files) — all 13 skill `SKILL.md` files + `agents/sync-config.md` + `agents/tape-reader.md` byte-identical with seeds
- Skipped (hybrid Project-only / Both-modified, PULL direction, 1 file): `.claude/agents/ui-reviewer.md` (project-specific customizations preserved)

## Operational notes

- Bushel project type: `webapp` — no type-gating this run.
- No open PRs on bushel at scoping time; `Step 1.5` duplicate-PR check inert.
- Fleet-wide first non-empty sync run since 2026-06-30 (helm #89, since closed).

_Generated by the nightly bi-directional sync Routine (DEC-S010, DEC-S028)._

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDqckysjudwVaEpTaTKhfB)_