### PR TITLE
Phase 10 + 11 setup: Supabase→Neon and Expo app — DEC-046–050, plan, issues

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -547,6 +547,72 @@ A customer has at most one **non-terminal** order; fulfilled orders (`picked_up`
 
 ---
 
+---
+
+## DEC-046 — Off Supabase to Neon; `pg` + hand-rolled SQL migration runner
+
+**Decision:** Bushel moves Postgres from Supabase Cloud to Neon (free tier). Data access is `pg` (node-postgres) `Pool` via `DATABASE_URL` — no ORM, no query builder. Migrations are plain SQL files `db/migrations/NNNN_name.sql` applied by a ~70-line runner ported from muster (`db/migrate.ts`: `_migrations` tracking table, each file in its own transaction). Local + CI test against docker Postgres; Neon hosts dev/preview + prod only.
+
+**Why:** Consolidates billing off Supabase; aligns bushel with muster (same stack, one maintenance surface for a solo dev); muster already runs this on Neon, so it's a proven path, not a spike. `pg` + plain SQL clears the dependency bar where Drizzle/Prisma do not — the queries are hand-written already and "migrations are source of truth" stays literally true.
+
+**Rejected:** Drizzle/Prisma (new paradigm + tooling for no gain at this scale); drizzle-kit (the SQL runner is portable and understood); replaying the 27 Supabase migrations (a third are RLS/mirror churn that gets deleted — author a clean `0001_init.sql` baseline instead, validated by the surviving pgTAP function tests). Also consciously rejected: staying on Supabase with just code-auth + one project — satisfies OAuth/billing goals without a DB move, but leaves bushel and muster on divergent stacks forever; the muster-alignment dividend is the tie-breaker.
+
+**Migration:** fresh baseline schema on Neon; `place_order` plpgsql + `order_items` trigger port unchanged (pure Postgres). Data crosses via targeted `pg_dump -t products -t product_units -t customers` (orders/order_items/customer_sends are wiped by DEC-041's cutover, so they don't move).
+
+**Sequencing:** the Neon data move happens in the SAME quiet-minute as the pending DEC-041 production cutover — one outage on the live tool, not two.
+
+---
+
+## DEC-047 — Admin auth: shared access code + self-rolled HMAC session (drops Google OAuth / Supabase Auth)
+
+**Decision:** Admin login is a short access code (the sailbook/muster pattern), verified against an env-configured value (or a 2-row `admin_codes` table), minting a stateless HMAC-SHA256 session token stored in an httpOnly cookie. Session code is ported verbatim from muster's `src/auth/session.ts` (pure node:crypto, zero dependencies). Google OAuth and `@supabase/ssr` are removed. The session token is **dual-consumable** — cookie for the browser, bearer header for the Phase 11 native client — so Phase 11 needs no re-auth work.
+
+**Why:** Two known operators (Annabel, Emma) and no email service (DEC-033 chose Telegram precisely to avoid onboarding a mail provider) make muster's full email→code→login_codes machinery unnecessary. A shared code that isn't emailed to anyone needs no TTL table and no attempt cap at this scale. Removing OAuth also unblocks headless admin Playwright auth (long a sore point — Phase 1's authenticated admin tests were deferred to #27 over exactly this).
+
+**Supersedes:** DEC-003 (single admin via Google OAuth / Supabase Auth). **Unaffected:** DEC-004 customer token auth — customers never used Supabase Auth; the `bbf_customer_token` cookie → `customers.token` path is untouched.
+
+**Trade-off accepted:** a shared code has no per-user attribution. If Annabel vs Emma attribution ever matters (it doesn't today — `send_queue.sent_by_user_id` is the only current consumer and can go nullable/dropped), issue per-user codes against the 2-row table then.
+
+---
+
+## DEC-048 — RLS deleted; the service layer IS the access boundary (formalizes existing reality; untangles auth.users)
+
+**Decision:** All RLS policies are dropped, not translated. The auth boundary is already the service layer — customer reads resolve `bbf_customer_token` → `customers.token` then query with full DB privilege (documented in `src/lib/customer/queries.ts`); admin reads sit behind the DEC-047 session. RLS was belt-and-suspenders, tested by pgTAP, never the app's access path.
+
+**Schema untangle** (Supabase-auth tendrils that can't exist on Neon): drop `public.users` + its `auth.users` mirror trigger; `send_queue.sent_by_user_id` (FK → auth.users) drops the FK, column goes nullable or is removed (DEC-047 trade-off); all `auth.uid()` policies removed with RLS.
+
+**pgTAP disposition:** the RLS-only files (`customers_rls`, `fulfillment_link_rls`, `rls_tables`) are deleted; the FUNCTION/DATA tests (`place_order_additive`, `place_order_units`, `product_units`, `set_base_unit`, `order_status_codes`, `customer_sends_modes`) stay and keep running against docker Postgres — they're the regression net for the concurrency-sensitive `place_order` path.
+
+**Why now:** with the DB moving anyway, keeping RLS would mean re-authoring every policy against a role model Neon doesn't share, to protect a path the app never uses. Deleting is both simpler and honest about how access actually works.
+
+---
+
+## DEC-049 — Environment model: Neon branches replace the two-project split; prod-write protection via connection-string discipline
+
+**Decision:** One Neon project, two branches — `main` (dev/preview) and `production`. Vercel Production → Neon `production` branch URL; Vercel Preview/Development + `.env.local` → Neon `main` branch URL. CI/local tests run docker Postgres (unchanged). No per-PR ephemeral-branch automation.
+
+**Production-write protection** (replaces DEC-S009's Supabase relink dance): production `DATABASE_URL` lives ONLY in Vercel and a separate, deliberately-sourced `.envrc.production` — never the shell default. `db/migrate.ts` takes the connection string as an arg, so a prod migration is an explicit `tsx db/migrate.ts "$PROD_DATABASE_URL"`, not a lingering link state. Strictly safer than the "link to prod for a few seconds, always relink back" ritual — there is no default-prod state to forget out of.
+
+**Supersedes:** DEC-S009 mechanics (the two-Supabase-project split + link discipline) and the Supabase↔Vercel env-sync section — replaced by two Neon branch URLs and the same "both Vercel scopes must stay coherent" diff-check.
+
+---
+
+## DEC-050 — Expo native app: muster rehearsal, push-first, thin scope
+
+**Decision:** A separate-repo Expo (React Native) app, `bushel-mobile`, whose v1 scope is exactly: (a) receive Expo push notifications, (b) a read-only active-orders list, (c) one mutation — mark-fulfilled. It authenticates to bushel's Next.js `/api/*` routes with the DEC-047 HMAC session as a bearer token — never direct DB access from the phone. Not an admin port.
+
+**Why:** bushel is the rehearsal for muster, where native + background-sync are real requirements — and long-term, in-app push is the path off SMS/carrier costs for users who don't want texts. Bushel's only alert channel today is Telegram (DEC-033; the PWA push idea #170 was closed *parked*, never built), so the app also replaces that hack for Annabel — but the scope stays thin because the rehearsal is the point.
+
+**Net-new API surface:** bushel mutations are Server Actions (uncallable from native), so Phase 11 builds the first real `/api/*` routes — list orders, mark-fulfilled, register push token, order-arrival push fan-out. The DEC-047 session is bearer-consumable specifically to serve these.
+
+**iOS scope reset:** remote push to iOS requires an APNs key, which requires paid Apple Developer Program membership ($99/yr, deferred). Free 7-day personal-team signing installs and runs on Emma's iPhone but does NOT grant remote push. So **v1 push is ANDROID-ONLY (Annabel)**; iPhone push is explicitly gated behind the $99 enrollment. Android proves the Expo push loop for the muster rehearsal.
+
+**Repo shape:** separate repo, not in-repo `apps/mobile` — a monorepo root collides with the seeds-template sync (root-file-oriented, single-app-root assumption). Muster decides its own shape independently.
+
+**Build/signing:** Android via EAS free tier → sideloaded APK ($0). iOS via free-signed 7-day EAS builds for install/run only (no push) until $99 lands. No Mac in the loop for Android.
+
+---
+
 ## Open / Pending Product Owner Discussion
 
 - **Minimum delivery amount (in dollars).** Threshold below which delivery is unavailable, or above which delivery is free. Phase 7+ candidate.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -563,15 +563,15 @@ A customer has at most one **non-terminal** order; fulfilled orders (`picked_up`
 
 ---
 
-## DEC-047 — Admin auth: shared access code + self-rolled HMAC session (drops Google OAuth / Supabase Auth)
+## DEC-047 — Admin auth: email → login code + self-rolled HMAC session via Resend (drops Google OAuth / Supabase Auth)
 
-**Decision:** Admin login is a short access code (the sailbook/muster pattern), verified against an env-configured value (or a 2-row `admin_codes` table), minting a stateless HMAC-SHA256 session token stored in an httpOnly cookie. Session code is ported verbatim from muster's `src/auth/session.ts` (pure node:crypto, zero dependencies). Google OAuth and `@supabase/ssr` are removed. The session token is **dual-consumable** — cookie for the browser, bearer header for the Phase 11 native client — so Phase 11 needs no re-auth work.
+**Decision:** Admin login is muster's full flow, ported verbatim: admin enters their email, a short-lived one-time code lands in their inbox via **Resend**, and verifying it mints a stateless HMAC-SHA256 session token stored in an httpOnly cookie. The port covers muster's `src/auth/session.ts` (pure node:crypto, zero dependencies) plus its `login_codes` table (TTL + attempt cap) and code-email sending. Admin identities live in a 2-row `admins` table (Annabel, Emma) — only listed emails can request a code. Google OAuth and `@supabase/ssr` are removed. The session token is **dual-consumable** — cookie for the browser, bearer header for the Phase 11 native client — so Phase 11 needs no re-auth work.
 
-**Why:** Two known operators (Annabel, Emma) and no email service (DEC-033 chose Telegram precisely to avoid onboarding a mail provider) make muster's full email→code→login_codes machinery unnecessary. A shared code that isn't emailed to anyone needs no TTL table and no attempt cap at this scale. Removing OAuth also unblocks headless admin Playwright auth (long a sore point — Phase 1's authenticated admin tests were deferred to #27 over exactly this).
+**Why:** The first draft of this DEC used a shared access code in an env var, reasoning that DEC-033's "no mail provider" stance made muster's email machinery not worth it. Rejected as hacky: a shared static secret has no per-user attribution, rotates only via redeploy, and saves very little — the Resend wire-up is trivial and the rest of the flow ports from muster unchanged. Per-user attribution now comes free. Removing OAuth still unblocks headless admin Playwright auth (long a sore point — Phase 1's authenticated admin tests were deferred to #27 over exactly this): global-setup requests a code and reads it straight from `login_codes` in the test DB, no inbox in the loop.
+
+**Resend scope:** auth-only. It amends DEC-033's rationale (a mail provider now exists) but not its outcome — alerting does not move to email. Telegram remains today's alert channel only until DEC-050's push replaces it; Eric wants off Telegram, and push is that path, not email.
 
 **Supersedes:** DEC-003 (single admin via Google OAuth / Supabase Auth). **Unaffected:** DEC-004 customer token auth — customers never used Supabase Auth; the `bbf_customer_token` cookie → `customers.token` path is untouched.
-
-**Trade-off accepted:** a shared code has no per-user attribution. If Annabel vs Emma attribution ever matters (it doesn't today — `send_queue.sent_by_user_id` is the only current consumer and can go nullable/dropped), issue per-user codes against the 2-row table then.
 
 ---
 
@@ -579,7 +579,7 @@ A customer has at most one **non-terminal** order; fulfilled orders (`picked_up`
 
 **Decision:** All RLS policies are dropped, not translated. The auth boundary is already the service layer — customer reads resolve `bbf_customer_token` → `customers.token` then query with full DB privilege (documented in `src/lib/customer/queries.ts`); admin reads sit behind the DEC-047 session. RLS was belt-and-suspenders, tested by pgTAP, never the app's access path.
 
-**Schema untangle** (Supabase-auth tendrils that can't exist on Neon): drop `public.users` + its `auth.users` mirror trigger; `send_queue.sent_by_user_id` (FK → auth.users) drops the FK, column goes nullable or is removed (DEC-047 trade-off); all `auth.uid()` policies removed with RLS.
+**Schema untangle** (Supabase-auth tendrils that can't exist on Neon): drop `public.users` + its `auth.users` mirror trigger; `send_queue.sent_by_user_id` (FK → auth.users) drops the FK and either repoints to the DEC-047 `admins` table or is removed; all `auth.uid()` policies removed with RLS.
 
 **pgTAP disposition:** the RLS-only files (`customers_rls`, `fulfillment_link_rls`, `rls_tables`) are deleted; the FUNCTION/DATA tests (`place_order_additive`, `place_order_units`, `product_units`, `set_base_unit`, `order_status_codes`, `customer_sends_modes`) stay and keep running against docker Postgres — they're the regression net for the concurrency-sensitive `place_order` path.
 
@@ -607,7 +607,9 @@ A customer has at most one **non-terminal** order; fulfilled orders (`picked_up`
 
 **iOS scope reset:** remote push to iOS requires an APNs key, which requires paid Apple Developer Program membership ($99/yr, deferred). Free 7-day personal-team signing installs and runs on Emma's iPhone but does NOT grant remote push. So **v1 push is ANDROID-ONLY (Annabel)**; iPhone push is explicitly gated behind the $99 enrollment. Android proves the Expo push loop for the muster rehearsal.
 
-**Repo shape:** separate repo, not in-repo `apps/mobile` — a monorepo root collides with the seeds-template sync (root-file-oriented, single-app-root assumption). Muster decides its own shape independently.
+**Repo shape:** separate repo, not in-repo `apps/mobile` — a monorepo root collides with the seeds-template sync (root-file-oriented, single-app-root assumption). This sets no precedent for muster's repo layout — muster makes its own monorepo-vs-separate call when it builds its app.
+
+**Web↔app parity:** the two surfaces need to stay close, not 1:1. Two mechanisms: (1) admin mutations are implemented as service-layer functions first, with the Server Action (web) and `/api/*` route (app) as thin wrappers over the same function — parity is then a wrapper, not a reimplementation; (2) each phase retro includes a parity pass — which admin capabilities added that phase should the app pick up, and which diverge deliberately. Divergence is fine when named; drift is not.
 
 **Build/signing:** Android via EAS free tier → sideloaded APK ($0). iOS via free-signed 7-day EAS builds for install/run only (no push) until $99 lands. No Mac in the loop for Android.
 

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -254,6 +254,41 @@ Re-keys order identity from the week to the open order, kills the scheduled-clos
 
 **Closed 2026-07-02 (retro):** 25 pts, 10 issues, span 9.2d — throughput 19.1 pts/calendar-wk (single active ISO week). 13 PRs merged in-window. Hard cutover applied to dev/preview; **production cutover pending** (Eric's quiet-minute call: prod `db push` → `/promote-production`, DB before code).
 
+---
+
+## Phase 10 — Supabase → Neon + service layer + code-auth (32 pts)
+
+**HIGH PRIORITY (Eric, 2026-07-02).** Off Supabase entirely: Neon free tier (`pg` Pool, no ORM), muster's SQL migration runner + clean `0001_init.sql` baseline, shared-access-code auth replacing Google OAuth, RLS deleted (the service layer already IS the boundary), docker Postgres for local/CI. DEC-046–049; @architect pass 2026-07-02 (Opus). Muster is the reference implementation — this aligns both projects on one stack.
+
+**Sequencing:** 10.7 is the blast-radius step — one quiet-minute outage covers BOTH the pending DEC-041 prod cutover and the Neon move (only `products`/`product_units`/`customers` migrate; the rest is wiped by DEC-041 anyway). Gate it behind everything green on dev/preview. Phase 11 must not start until 10.2 + 10.3 merge.
+
+| # | Task | Pts | Status |
+|---|---|---|---|
+| 10.0 | Neon project + branches + docker CI Postgres | 3 | [#253](https://github.com/mobiustripper42/bushel/issues/253) |
+| 10.1 | Port `db/migrate.ts` runner + `0001_init.sql` clean baseline | 5 | [#254](https://github.com/mobiustripper42/bushel/issues/254) |
+| 10.2 | `pg` data layer — swap the ~15 supabase-js call sites | 8 | [#255](https://github.com/mobiustripper42/bushel/issues/255) |
+| 10.3 | Code-auth: muster `session.ts` + access-code login (DEC-047) | 5 | [#256](https://github.com/mobiustripper42/bushel/issues/256) |
+| 10.4 | Delete RLS + untangle auth.users; prune pgTAP (DEC-048) | 3 | [#257](https://github.com/mobiustripper42/bushel/issues/257) |
+| 10.5 | Remove `@supabase/*` deps + env/branch config (DEC-049) | 3 | [#258](https://github.com/mobiustripper42/bushel/issues/258) |
+| 10.6 | Playwright: headless code-auth helper + full suite green | 3 | [#259](https://github.com/mobiustripper42/bushel/issues/259) |
+| 10.7 | Prod cutover: Neon move co-timed with DEC-041 cutover | 2 | [#260](https://github.com/mobiustripper42/bushel/issues/260) |
+
+---
+
+## Phase 11 — Expo mobile app: muster rehearsal, push-first (20 pts)
+
+Separate repo `bushel-mobile` (DEC-050): Expo/React Native, push notifications as the point (long-term path off SMS/Twilio for non-SMS users), read-only orders list + one mutation. Annabel = Android sideload APK ($0, full push). Emma = iPhone free-signed 7-day builds, install-only — **iOS remote push is gated on the deferred $99 Apple Developer enrollment** (APNs key requires paid membership). Bushel's first real `/api/*` routes (Server Actions are uncallable from native), authenticated by DEC-047's bearer-consumable session.
+
+**Gated on Phase 10** (10.2 data layer + 10.3 auth merged) — building API routes against the Supabase layer would be throwaway work.
+
+| # | Task | Pts | Status |
+|---|---|---|---|
+| 11.1 | `/api/*` routes on bushel + bearer-token auth guard | 5 | [#261](https://github.com/mobiustripper42/bushel/issues/261) |
+| 11.2 | Expo app scaffold + code-auth login + orders list | 5 | [#262](https://github.com/mobiustripper42/bushel/issues/262) |
+| 11.3 | Expo push: token registration + Android push end-to-end | 5 | [#263](https://github.com/mobiustripper42/bushel/issues/263) |
+| 11.4 | Mark-fulfilled mutation from the app | 2 | [#264](https://github.com/mobiustripper42/bushel/issues/264) |
+| 11.5 | Android EAS build → sideloaded APK; iOS free-sign install | 3 | [#265](https://github.com/mobiustripper42/bushel/issues/265) |
+
 DEC-039 (#218's additive-orders decision) lands in `DECISIONS.md` when 9.1 merges; DEC-040–045 are already written. Customer-facing order history (#136) stays in the backlog.
 
 ---

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -256,9 +256,9 @@ Re-keys order identity from the week to the open order, kills the scheduled-clos
 
 ---
 
-## Phase 10 — Supabase → Neon + service layer + code-auth (32 pts)
+## Phase 10 — Supabase → Neon + service layer + email-code auth (35 pts)
 
-**HIGH PRIORITY (Eric, 2026-07-02).** Off Supabase entirely: Neon free tier (`pg` Pool, no ORM), muster's SQL migration runner + clean `0001_init.sql` baseline, shared-access-code auth replacing Google OAuth, RLS deleted (the service layer already IS the boundary), docker Postgres for local/CI. DEC-046–049; @architect pass 2026-07-02 (Opus). Muster is the reference implementation — this aligns both projects on one stack.
+**HIGH PRIORITY (Eric, 2026-07-02).** Off Supabase entirely: Neon free tier (`pg` Pool, no ORM), muster's SQL migration runner + clean `0001_init.sql` baseline, muster's email→login-code auth via Resend replacing Google OAuth, RLS deleted (the service layer already IS the boundary), docker Postgres for local/CI. DEC-046–049; @architect pass 2026-07-02 (Opus). Muster is the reference implementation — this aligns both projects on one stack.
 
 **Sequencing:** 10.7 is the blast-radius step — one quiet-minute outage covers BOTH the pending DEC-041 prod cutover and the Neon move (only `products`/`product_units`/`customers` migrate; the rest is wiped by DEC-041 anyway). Gate it behind everything green on dev/preview. Phase 11 must not start until 10.2 + 10.3 merge.
 
@@ -267,10 +267,10 @@ Re-keys order identity from the week to the open order, kills the scheduled-clos
 | 10.0 | Neon project + branches + docker CI Postgres | 3 | [#253](https://github.com/mobiustripper42/bushel/issues/253) |
 | 10.1 | Port `db/migrate.ts` runner + `0001_init.sql` clean baseline | 5 | [#254](https://github.com/mobiustripper42/bushel/issues/254) |
 | 10.2 | `pg` data layer — swap the ~15 supabase-js call sites | 8 | [#255](https://github.com/mobiustripper42/bushel/issues/255) |
-| 10.3 | Code-auth: muster `session.ts` + access-code login (DEC-047) | 5 | [#256](https://github.com/mobiustripper42/bushel/issues/256) |
+| 10.3 | Email-code auth: muster `session.ts` + `login_codes` + Resend (DEC-047) | 8 | [#256](https://github.com/mobiustripper42/bushel/issues/256) |
 | 10.4 | Delete RLS + untangle auth.users; prune pgTAP (DEC-048) | 3 | [#257](https://github.com/mobiustripper42/bushel/issues/257) |
 | 10.5 | Remove `@supabase/*` deps + env/branch config (DEC-049) | 3 | [#258](https://github.com/mobiustripper42/bushel/issues/258) |
-| 10.6 | Playwright: headless code-auth helper + full suite green | 3 | [#259](https://github.com/mobiustripper42/bushel/issues/259) |
+| 10.6 | Playwright: headless login-code helper (code read from test DB) + full suite green | 3 | [#259](https://github.com/mobiustripper42/bushel/issues/259) |
 | 10.7 | Prod cutover: Neon move co-timed with DEC-041 cutover | 2 | [#260](https://github.com/mobiustripper42/bushel/issues/260) |
 
 ---
@@ -284,7 +284,7 @@ Separate repo `bushel-mobile` (DEC-050): Expo/React Native, push notifications a
 | # | Task | Pts | Status |
 |---|---|---|---|
 | 11.1 | `/api/*` routes on bushel + bearer-token auth guard | 5 | [#261](https://github.com/mobiustripper42/bushel/issues/261) |
-| 11.2 | Expo app scaffold + code-auth login + orders list | 5 | [#262](https://github.com/mobiustripper42/bushel/issues/262) |
+| 11.2 | Expo app scaffold + email-code login + orders list | 5 | [#262](https://github.com/mobiustripper42/bushel/issues/262) |
 | 11.3 | Expo push: token registration + Android push end-to-end | 5 | [#263](https://github.com/mobiustripper42/bushel/issues/263) |
 | 11.4 | Mark-fulfilled mutation from the app | 2 | [#264](https://github.com/mobiustripper42/bushel/issues/264) |
 | 11.5 | Android EAS build → sideloaded APK; iOS free-sign install | 3 | [#265](https://github.com/mobiustripper42/bushel/issues/265) |


### PR DESCRIPTION
## Summary
Materializes the @architect pass (Opus, 2026-07-02) into DEC-046–050, PROJECT_PLAN Phase 10 (32 pts, #253–#260) + Phase 11 (20 pts, #261–#265) sections, and 13 pointed issues.

**Phase 10 — Supabase → Neon (HIGH PRIORITY):** `pg` no-ORM, muster's SQL migration runner, clean `0001_init.sql` baseline (RLS + users-table + auth.users tendrils deleted, not translated), shared-access-code auth (dual cookie/bearer session), Neon branches replace the two-project split, docker Postgres for CI. **10.7 co-times the Neon move with the pending DEC-041 prod cutover — one outage, three tables.**

**Phase 11 — Expo app:** separate repo, push-first thin scope; **v1 push is Android-only** (iOS remote push requires the deferred $99 APNs entitlement); bushel's first `/api/*` routes ride the DEC-047 bearer token.

Correction applied to the architect draft: #170 (PWA push) was closed *parked*, never shipped — bushel's only alert channel today is Telegram; DEC-050 reflects that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)