### PR TITLE
10.0: Neon project + branches + docker CI Postgres — closes #253

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    # Plain Postgres for the migration runner + tests (DEC-046, task 10.0).
+    # Port 5433 matches the local docker-compose mapping so one DATABASE_URL
+    # convention works in both places. Supabase steps below coexist until
+    # 10.5/10.6 remove them.
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: bushel
+          POSTGRES_PASSWORD: bushel
+          POSTGRES_DB: bushel_test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U bushel -d bushel_test"
+          --health-interval 3s
+          --health-timeout 3s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v4
+
+      - name: Postgres service sanity
+        run: psql "postgresql://bushel:bushel@localhost:5433/bushel_test" -c "SELECT 1"
 
       - uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .envrc
+# Prod DATABASE_URL lives here, deliberately sourced only (DEC-049) — never committed
+.envrc.production
 .sessions-worktree/

--- a/db/init/01-create-test-db.sql
+++ b/db/init/01-create-test-db.sql
@@ -1,0 +1,4 @@
+-- Runs once on first container init (docker-entrypoint-initdb.d). Creates the
+-- test database next to bushel_dev so tests have their own DB to wipe without
+-- touching dev data. Migrations run separately via db/migrate.ts (10.1).
+CREATE DATABASE bushel_test OWNER bushel;

--- a/db/roles/mcp_readonly.sql
+++ b/db/roles/mcp_readonly.sql
@@ -1,0 +1,15 @@
+-- Read-only role for MCP inspection of the Neon *production* branch (task 10.0).
+-- Run once against the production branch with an admin connection:
+--   psql "$PROD_DATABASE_URL_UNPOOLED" -f db/roles/mcp_readonly.sql
+-- Then set the password out-of-band (never commit it):
+--   ALTER ROLE mcp_readonly WITH PASSWORD '<generate one>';
+-- The MCP server connects with this role's URL — SELECT-only, no writes possible.
+
+CREATE ROLE mcp_readonly WITH LOGIN;
+
+GRANT CONNECT ON DATABASE neondb TO mcp_readonly;
+GRANT USAGE ON SCHEMA public TO mcp_readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO mcp_readonly;
+
+-- Tables created by future migrations are readable too, without re-running this.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO mcp_readonly;

--- a/db/roles/mcp_readonly.sql
+++ b/db/roles/mcp_readonly.sql
@@ -4,6 +4,13 @@
 -- Then set the password out-of-band (never commit it):
 --   ALTER ROLE mcp_readonly WITH PASSWORD '<generate one>';
 -- The MCP server connects with this role's URL — SELECT-only, no writes possible.
+--
+-- Two assumptions this file bakes in:
+-- 1. The database is named `neondb` (Neon's default; matches bushel's project).
+-- 2. The DEFAULT PRIVILEGES grant below binds to the role EXECUTING this script.
+--    It must be the same role that runs prod migrations (neondb_owner via
+--    PROD_DATABASE_URL_UNPOOLED), or tables created by future migrations are
+--    silently invisible to mcp_readonly.
 
 CREATE ROLE mcp_readonly WITH LOGIN;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+# Local Postgres for dev + tests (DEC-046). Mirrors muster's docker-compose:
+# one server, two logical DBs — bushel_dev (the app, once 10.2 lands) and
+# bushel_test (Playwright/pgTAP target from 10.6, freely wiped). Hosted
+# dev/preview + prod live on Neon (DEC-049); this container is local/CI only.
+# Host port 5433, not 5432 — muster's container owns 5432 on this machine.
+services:
+  postgres:
+    image: postgres:17
+    container_name: bushel-postgres
+    environment:
+      POSTGRES_USER: bushel
+      POSTGRES_PASSWORD: bushel
+      POSTGRES_DB: bushel_dev
+    ports:
+      - "5433:5432"
+    volumes:
+      - bushel-pgdata:/var/lib/postgresql/data
+      # Runs once on first init: creates the test database alongside bushel_dev.
+      - ./db/init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U bushel -d bushel_dev"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  bushel-pgdata:


### PR DESCRIPTION
## Summary
Task 10.0 (DEC-046/049): local + CI docker Postgres, Neon two-branch environment plumbing, and the read-only MCP prod role. Repo side of the Neon foundation — the app still runs supabase-js until 10.2.

## Files changed
- `docker-compose.yml` — postgres:17, `bushel_dev` + `bushel_test`, host port 5433 (muster owns 5432), healthcheck, init-script mount
- `db/init/01-create-test-db.sql` — creates `bushel_test` on first container init
- `db/roles/mcp_readonly.sql` — SELECT-only role for MCP prod inspection (already applied to the Neon `production` branch; login verified, CREATE denied)
- `.github/workflows/ci.yml` — postgres:17 service on 5433 + sanity step; Supabase steps coexist until 10.5/10.6
- `.gitignore` — `.envrc.production` (prod URLs only ever deliberately sourced, DEC-049)

## Done outside the repo (not in this diff)
- Neon project (Vercel Storage integration), branches `main` (dev/preview) + `production`
- Vercel env split: Production scope → `production` branch URLs; Preview → `main` branch URLs
- `.envrc` / `.envrc.production` filled; `mcp_readonly` created + password set

## Code review
One real finding, addressed in 7bf06e9: documented the `ALTER DEFAULT PRIVILEGES` role-binding assumption (script must run as the same role that runs prod migrations — `neondb_owner`). Advisory notes on the hardcoded `neondb` name (documented) and CI healthcheck cadence drift vs muster (intentional, faster feedback).

## Test plan
- [x] `docker compose up -d` → container healthy; `SELECT 1` on `bushel_dev`; `bushel_test` exists (init script ran)
- [x] Neon `main` + `production` branches both answer `SELECT 1` (distinct endpoints verified)
- [x] `mcp_readonly` on prod: login ok, `CREATE TABLE` → permission denied
- [x] `npm run build` green
- [ ] CI on this PR: "Postgres service sanity" step passes (the new service's proof)
- No migration, no RLS change, no UI — nothing to click at 375px

🤖 Generated with [Claude Code](https://claude.com/claude-code)