### PR TITLE
10.1: port db/migrate.ts runner + 0001_init.sql clean baseline — closes #254

### DIFF
--- a/db/migrate.ts
+++ b/db/migrate.ts
@@ -1,0 +1,79 @@
+/**
+ * Migration runner (DEC-046, ported from muster). Applies db/migrations/*.sql
+ * in filename order, each in a transaction, tracked in a `_migrations` table
+ * so re-runs are no-ops. Plain Postgres — no migration framework, so the DDL
+ * stays portable to any host.
+ *
+ * Used two ways: the `db:migrate` CLI (against DATABASE_URL or an explicit
+ * connection-string arg — prod migrations are ALWAYS the explicit-arg form,
+ * DEC-049) and test setup (which calls `migrate(TEST_DATABASE_URL)`).
+ */
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import pg from "pg";
+
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), "migrations");
+
+/** Default local-dev connection (the compose service). Overridden by env/arg. */
+export const DEFAULT_DATABASE_URL =
+  "postgres://bushel:bushel@localhost:5433/bushel_dev";
+
+/** Apply all pending migrations to `connectionString`. Returns the files applied. */
+export async function migrate(
+  connectionString: string = process.env.DATABASE_URL ?? DEFAULT_DATABASE_URL,
+): Promise<string[]> {
+  const client = new pg.Client({ connectionString });
+  await client.connect();
+  const applied: string[] = [];
+  try {
+    await client.query(
+      `create table if not exists _migrations (
+         filename text primary key,
+         applied_at timestamptz not null default now()
+       )`,
+    );
+    const files = (await readdir(MIGRATIONS_DIR))
+      .filter((f) => f.endsWith(".sql"))
+      .sort();
+    const done = new Set(
+      (
+        await client.query<{ filename: string }>(
+          "select filename from _migrations",
+        )
+      ).rows.map((r) => r.filename),
+    );
+    for (const file of files) {
+      if (done.has(file)) continue;
+      const sql = await readFile(join(MIGRATIONS_DIR, file), "utf8");
+      await client.query("begin");
+      try {
+        await client.query(sql);
+        await client.query("insert into _migrations(filename) values ($1)", [
+          file,
+        ]);
+        await client.query("commit");
+        applied.push(file);
+      } catch (e) {
+        await client.query("rollback");
+        throw e;
+      }
+    }
+  } finally {
+    await client.end();
+  }
+  return applied;
+}
+
+// CLI entry: `tsx db/migrate.ts [connectionString]`
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const url = process.argv[2] ?? process.env.DATABASE_URL ?? DEFAULT_DATABASE_URL;
+  migrate(url)
+    .then((a) =>
+      console.log(a.length ? `Applied: ${a.join(", ")}` : "Up to date."),
+    )
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    });
+}

--- a/db/migrations/0001_init.sql
+++ b/db/migrations/0001_init.sql
@@ -1,0 +1,520 @@
+-- 0001_init.sql — clean baseline (DEC-046). Replaces the 27 Supabase
+-- migrations as the source of truth for a fresh database. Authored from a
+-- schema-only dump of the final Supabase state, minus what DEC-048 deletes:
+-- every RLS policy, public.users + its auth.users FK (Supabase-auth mirror),
+-- and the auth.users FK on customer_sends.sent_by_user_id (column kept as a
+-- bare uuid; its repoint-or-drop lands with the admins table in 10.3/10.4).
+-- The service layer is the access boundary — this schema carries no policies.
+
+-- ── Functions ────────────────────────────────────────────────────────────────
+
+-- BEFORE-INSERT default: fill product_unit_id with the product's first active
+-- unit when the payload omits it (6.5a).
+CREATE FUNCTION public.order_items_default_unit() RETURNS trigger
+    LANGUAGE plpgsql
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+begin
+  if new.product_unit_id is null then
+    select id into new.product_unit_id
+      from public.product_units
+     where product_id = new.product_id and is_active = true
+     order by sort_order nulls last, created_at
+     limit 1;
+  end if;
+  return new;
+end;
+$$;
+
+-- place_order — additive open-order submit (DEC-039/041). Ported unchanged
+-- from Supabase; pure Postgres. See supabase/tests/place_order_additive.sql
+-- for the concurrency contract.
+CREATE FUNCTION public.place_order(p_customer_id uuid, p_week_of date, p_fulfillment_type text, p_delivery_address text, p_delivery_preference text, p_pickup_note text, p_notes text, p_items jsonb, p_submission_id uuid DEFAULT NULL::uuid) RETURNS TABLE(order_id uuid, appended boolean)
+    LANGUAGE plpgsql
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+declare
+  v_order_id     uuid;
+  v_status       text;
+  v_appended     boolean := false;
+  v_item         jsonb;
+  v_product_id   uuid;
+  v_unit_id      uuid;
+  v_qty          int;
+  v_unit_price   int;
+  v_conv         numeric(10,4);
+  v_negative     boolean;
+begin
+  -- NOTE: `order_id` and `appended` are in scope as OUT variables of the
+  -- RETURNS TABLE clause — every column reference below is table-qualified
+  -- to avoid ambiguity.
+
+  if jsonb_typeof(p_items) is distinct from 'array' or jsonb_array_length(p_items) = 0 then
+    raise exception 'place_order: p_items must be a non-empty json array';
+  end if;
+
+  -- Replay short-circuit (idempotency). If any order_items row already
+  -- carries this submission_id, the submission was applied — return the
+  -- order it landed on without inserting or decrementing anything.
+  if p_submission_id is not null then
+    -- Scoped to this customer: submission_id is a client-supplied UUID with
+    -- no unique constraint, so a replayed FOREIGN submission_id must not
+    -- resolve to someone else's order. A collision/forge finds nothing here
+    -- and falls through to create/append under the caller's own identity.
+    -- (DEC-041: week scope dropped — the customer scope alone is what keeps
+    -- a replay from resolving to the wrong order after a new open order
+    -- replaced a fulfilled one, because the replayed id's items still point
+    -- at the order they originally landed on.)
+    select oi.order_id into v_order_id
+      from public.order_items oi
+      join public.orders o on o.id = oi.order_id
+     where oi.submission_id = p_submission_id
+       and o.customer_id = p_customer_id
+     limit 1;
+    if v_order_id is not null then
+      -- Report `appended` consistently with the original call: the
+      -- submission was an append iff the order carries items from other
+      -- submissions (or pre-DEC-039 null-submission rows).
+      return query
+        select v_order_id,
+               exists (
+                 select 1 from public.order_items oi
+                  where oi.order_id = v_order_id
+                    and oi.submission_id is distinct from p_submission_id
+               );
+      return;
+    end if;
+  end if;
+
+  -- Resolve the customer's OPEN order — create-or-find loop (DEC-041).
+  -- The partial-index-inferring insert is the race-free arbiter of "who
+  -- creates the row"; losing the race falls through to a locked read of the
+  -- open row. If that row goes terminal between the two statements
+  -- (EvalPlanQual excludes it → zero rows), loop back and re-insert.
+  loop
+    insert into public.orders (
+      customer_id, week_of, fulfillment_type,
+      delivery_address, delivery_preference, pickup_note,
+      notes, status, needs_reconciliation
+    )
+    values (
+      p_customer_id, p_week_of, p_fulfillment_type,
+      p_delivery_address, p_delivery_preference, p_pickup_note,
+      p_notes, 'new', false
+    )
+    on conflict (customer_id) where status in ('new', 'confirmed', 'ready')
+    do nothing
+    returning id into v_order_id;
+
+    if v_order_id is not null then
+      exit;  -- created the open order
+    end if;
+
+    -- Lock the existing open order for this transaction so a concurrent
+    -- append/status change serializes behind us.
+    select o.id, o.status into v_order_id, v_status
+      from public.orders o
+     where o.customer_id = p_customer_id
+       and o.status in ('new', 'confirmed', 'ready')
+       for update;
+
+    if v_order_id is not null then
+      v_appended := true;
+      exit;  -- locked the open order — append path
+    end if;
+    -- Open order vanished (went terminal) between insert and lock; retry.
+  end loop;
+
+  if v_appended then
+    -- In-lock replay re-check — closes the create-vs-append race on a shared
+    -- submission_id. The outside-the-lock replay check above is not enough: two
+    -- concurrent requests with the same submission_id can both pass it (neither
+    -- has committed items yet), one wins the arbiter insert and the other
+    -- arrives here. A unique index on submission_id can't arbitrate (one
+    -- submission legitimately inserts many items sharing the id), so we lock the
+    -- order row, then re-check: the winner's items are now committed and visible
+    -- (READ COMMITTED), so we short-circuit instead of decrementing twice.
+    if p_submission_id is not null and exists (
+      select 1 from public.order_items oi
+       where oi.order_id = v_order_id
+         and oi.submission_id = p_submission_id
+    ) then
+      return query
+        select v_order_id,
+               exists (
+                 select 1 from public.order_items oi
+                  where oi.order_id = v_order_id
+                    and oi.submission_id is distinct from p_submission_id
+               );
+      return;
+    end if;
+
+    -- Notes on an append are additive — never clobber what the customer
+    -- already told Annabel.
+    if coalesce(trim(p_notes), '') <> '' then
+      update public.orders o
+         set notes = case
+                       when coalesce(trim(o.notes), '') = '' then p_notes
+                       else o.notes || ' — ' || p_notes
+                     end,
+             updated_at = now()
+       where o.id = v_order_id;
+    end if;
+  end if;
+
+  for v_item in select * from jsonb_array_elements(p_items)
+  loop
+    v_product_id := (v_item->>'product_id')::uuid;
+    v_qty        := (v_item->>'qty')::int;
+    -- product_unit_id is optional in the payload. When absent, the
+    -- order_items_default_unit BEFORE-INSERT trigger (from 6.5a) fills
+    -- in the first active unit for this product. We resolve the unit
+    -- here too so the price snapshot + decrement math match what the
+    -- row will end up with.
+    v_unit_id := nullif(v_item->>'product_unit_id', '')::uuid;
+    if v_unit_id is null then
+      select pu.id into v_unit_id
+        from public.product_units pu
+       where pu.product_id = v_product_id and pu.is_active = true
+       order by pu.sort_order nulls last, pu.created_at
+       limit 1;
+      -- Distinct error path from the cross-product-id case below so the
+      -- message points at the right remedy: re-activate (or seed) a unit
+      -- on this product, not "fix the unit_id in your payload."
+      if v_unit_id is null then
+        raise exception 'place_order: product % has no active units', v_product_id;
+      end if;
+    end if;
+
+    -- Snapshot from product_units, not from the client payload. If a unit
+    -- id was supplied but doesn't belong to this product (mismatched),
+    -- the lookup returns null and we raise — refusing to record a
+    -- cross-product unit reference rather than silently falling through.
+    select pu.unit_price_cents, pu.conversion_to_base
+      into v_unit_price, v_conv
+      from public.product_units pu
+     where pu.id = v_unit_id and pu.product_id = v_product_id;
+
+    if v_unit_price is null then
+      raise exception
+        'place_order: product_unit_id % does not belong to product %', v_unit_id, v_product_id;
+    end if;
+
+    insert into public.order_items (order_id, product_id, product_unit_id, qty, unit_price_cents, submission_id)
+    values (v_order_id, v_product_id, v_unit_id, v_qty, v_unit_price, p_submission_id);
+
+    -- DEC-036: optimistic oversell (DEC-012) applies only while there is
+    -- stock to draw down. The `qty_available > 0` guard makes this a no-op
+    -- on a sold-out product; FOUND is then false and we reject the whole
+    -- order. qty_available > 0 but insufficient still decrements into the
+    -- negative + flags reconciliation below — unchanged "last few" behavior.
+    update public.products p
+       set qty_available = p.qty_available - (v_qty::numeric * v_conv),
+           updated_at = now()
+     where p.id = v_product_id and p.qty_available > 0;
+
+    if not found then
+      raise exception 'place_order: product % is sold out', v_product_id
+        using errcode = 'P0001';
+    end if;
+  end loop;
+
+  -- An append re-enters Annabel's pipeline: a confirmed/ready order goes
+  -- back to 'new' (the stale confirmation SMS is covered by Re-send). A
+  -- 'new' order is untouched; a terminal order is unreachable here (the
+  -- lock predicate only finds open orders).
+  if v_appended then
+    update public.orders o
+       set status = 'new',
+           updated_at = now()
+     where o.id = v_order_id
+       and o.status in ('confirmed', 'ready');
+  end if;
+
+  -- Flip needs_reconciliation if any product touched by this order is now
+  -- negative. The join runs over ALL the order's items (original +
+  -- appended), so an append re-evaluates the whole order.
+  select exists (
+    select 1
+    from public.products p
+    join public.order_items oi on oi.product_id = p.id
+    where oi.order_id = v_order_id
+      and p.qty_available < 0
+  ) into v_negative;
+
+  if v_negative then
+    update public.orders o
+       set needs_reconciliation = true
+     where o.id = v_order_id;
+  end if;
+
+  return query select v_order_id, v_appended;
+end;
+$$;
+
+-- set_base_unit — rebase a product's unit conversions (6.5c/DEC-032).
+CREATE FUNCTION public.set_base_unit(p_product_id uuid, p_new_base_unit_id uuid) RETURNS void
+    LANGUAGE plpgsql
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+declare
+  v_old_conv   numeric(10,4);
+  v_is_active  boolean;
+begin
+  select conversion_to_base, is_active
+    into v_old_conv, v_is_active
+    from public.product_units
+   where id = p_new_base_unit_id
+     and product_id = p_product_id;
+
+  if v_old_conv is null then
+    raise exception 'set_base_unit: unit % does not belong to product %',
+      p_new_base_unit_id, p_product_id;
+  end if;
+
+  if not v_is_active then
+    raise exception 'set_base_unit: unit % is inactive — it cannot be the base unit',
+      p_new_base_unit_id;
+  end if;
+
+  -- Already the base — nothing to rescale, nothing to reorder.
+  if v_old_conv = 1.0 then
+    return;
+  end if;
+
+  -- Guard the conversion_to_base > 0 CHECK: a large rescale factor (a tiny
+  -- unit promoted onto a much bigger base) can round a small conversion down
+  -- to 0.0000 and abort the whole rebase with a raw constraint error. Catch
+  -- it up front with a remedy-shaped message instead.
+  if exists (
+    select 1 from public.product_units
+     where product_id = p_product_id
+       and round(conversion_to_base / v_old_conv, 4) <= 0
+  ) then
+    raise exception
+      'set_base_unit: units on product % are too far apart in scale to switch the base unit (a conversion would round to zero)',
+      p_product_id;
+  end if;
+
+  -- Rescale every unit's conversion by the same factor. The new base becomes
+  -- round(v_old_conv / v_old_conv, 4) = exactly 1.0000.
+  update public.product_units
+     set conversion_to_base = round(conversion_to_base / v_old_conv, 4),
+         updated_at = now()
+   where product_id = p_product_id;
+
+  -- qty_available is stored in base units, so it rescales by the same factor.
+  update public.products
+     set qty_available = round(qty_available / v_old_conv, 2),
+         updated_at = now()
+   where id = p_product_id;
+
+  -- Renumber sort_order deterministically: new base first (0), then the rest
+  -- in their current display order (sort_order nulls last, created_at) — the
+  -- same order the customer form and admin drawer sort by.
+  with ordered as (
+    select id,
+           row_number() over (
+             order by (id = p_new_base_unit_id) desc,
+                      sort_order nulls last,
+                      created_at
+           ) - 1 as new_order
+      from public.product_units
+     where product_id = p_product_id
+  )
+  update public.product_units pu
+     set sort_order = o.new_order
+    from ordered o
+   where pu.id = o.id;
+end;
+$$;
+
+-- ── Tables ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE public.codes (
+    type text NOT NULL,
+    code text NOT NULL,
+    label text NOT NULL,
+    sort_order integer,
+    CONSTRAINT codes_pkey PRIMARY KEY (type, code)
+);
+
+CREATE TABLE public.customers (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name text NOT NULL,
+    business_name text,
+    phone text,
+    email text,
+    token text NOT NULL,
+    delivery_address text,
+    is_active boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    send_weekly_link boolean DEFAULT true NOT NULL,
+    priority integer DEFAULT 100 NOT NULL,
+    CONSTRAINT customers_pkey PRIMARY KEY (id),
+    CONSTRAINT customers_token_key UNIQUE (token),
+    CONSTRAINT customers_priority_check CHECK ((priority >= 0))
+);
+
+COMMENT ON COLUMN public.customers.priority IS 'Send-queue ordering (DEC-026/027). Lower = earlier in the cycle. Default 100.';
+
+CREATE TABLE public.customer_sends (
+    customer_id uuid NOT NULL,
+    week_of date NOT NULL,
+    mode text NOT NULL,
+    sent_at timestamp with time zone DEFAULT now() NOT NULL,
+    sent_by_user_id uuid,
+    CONSTRAINT customer_sends_pkey PRIMARY KEY (customer_id, week_of, mode),
+    CONSTRAINT customer_sends_mode_check CHECK ((mode = ANY (ARRAY['weekly_update'::text, 'order_confirmation'::text, 'pickup_reminder'::text, 'delivery_reminder'::text]))),
+    CONSTRAINT customer_sends_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES public.customers(id) ON DELETE CASCADE
+);
+
+COMMENT ON COLUMN public.customer_sends.sent_by_user_id IS 'Legacy Supabase-auth attribution (was FK → auth.users). Bare uuid on Neon; repoint to admins or drop in 10.3/10.4 (DEC-048).';
+
+CREATE TABLE public.fulfillment_link (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    token uuid DEFAULT gen_random_uuid() NOT NULL,
+    is_singleton boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT fulfillment_link_pkey PRIMARY KEY (id),
+    CONSTRAINT fulfillment_link_token_key UNIQUE (token),
+    CONSTRAINT fulfillment_link_is_singleton_key UNIQUE (is_singleton),
+    CONSTRAINT fulfillment_link_singleton CHECK (is_singleton)
+);
+
+COMMENT ON TABLE public.fulfillment_link IS 'Singleton holding the secret token for the public /f/[token] harvest & pack sheet. The service layer resolves the token (DEC-048).';
+
+CREATE TABLE public.ordering_schedule (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    is_singleton boolean DEFAULT true NOT NULL,
+    is_open boolean DEFAULT true NOT NULL,
+    weekly_open_day smallint,
+    weekly_open_time time without time zone,
+    weekly_close_day smallint,
+    weekly_close_time time without time zone,
+    override_closes_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    intro_note text,
+    CONSTRAINT ordering_schedule_pkey PRIMARY KEY (id),
+    CONSTRAINT ordering_schedule_is_singleton_key UNIQUE (is_singleton),
+    CONSTRAINT ordering_schedule_is_singleton_check CHECK ((is_singleton = true)),
+    CONSTRAINT ordering_schedule_weekly_close_day_check CHECK (((weekly_close_day >= 0) AND (weekly_close_day <= 6))),
+    CONSTRAINT ordering_schedule_weekly_open_day_check CHECK (((weekly_open_day >= 0) AND (weekly_open_day <= 6)))
+);
+
+CREATE TABLE public.products (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name text NOT NULL,
+    description text,
+    qty_available numeric(10,2) DEFAULT 0 NOT NULL,
+    is_available boolean DEFAULT true NOT NULL,
+    sort_order integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    category text DEFAULT 'Other'::text NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
+    CONSTRAINT products_pkey PRIMARY KEY (id),
+    CONSTRAINT products_category_check CHECK ((category = ANY (ARRAY['Vegetables'::text, 'Fruit'::text, 'Herbs'::text, 'Flowers'::text, 'Other'::text])))
+);
+
+COMMENT ON COLUMN public.products.is_active IS 'Soft-delete flag. false = hidden/archived: excluded from the customer order form and the default admin inventory view, but order_items references remain valid. Distinct from is_available (per-week sold-out toggle).';
+
+CREATE TABLE public.product_units (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    product_id uuid NOT NULL,
+    label text NOT NULL,
+    conversion_to_base numeric(10,4) DEFAULT 1.0 NOT NULL,
+    unit_price_cents integer NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
+    slug text NOT NULL,
+    sort_order integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    sku text,
+    CONSTRAINT product_units_pkey PRIMARY KEY (id),
+    CONSTRAINT product_units_product_id_label_key UNIQUE (product_id, label),
+    CONSTRAINT product_units_slug_key UNIQUE (slug),
+    CONSTRAINT product_units_conversion_to_base_check CHECK ((conversion_to_base > (0)::numeric)),
+    CONSTRAINT product_units_unit_price_cents_check CHECK ((unit_price_cents > 0)),
+    CONSTRAINT product_units_product_id_fkey FOREIGN KEY (product_id) REFERENCES public.products(id) ON DELETE CASCADE
+);
+
+COMMENT ON COLUMN public.product_units.sku IS 'DEC-043: Wave "Item Number" for this unit''s export lines. Editable so it can match the existing Wave item catalog. Null falls back to slug in the export.';
+
+CREATE TABLE public.orders (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    customer_id uuid NOT NULL,
+    week_of date NOT NULL,
+    fulfillment_type text DEFAULT 'delivery'::text NOT NULL,
+    delivery_address text,
+    status text DEFAULT 'new'::text NOT NULL,
+    needs_reconciliation boolean DEFAULT false NOT NULL,
+    notes text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pickup_note text,
+    delivery_preference text,
+    CONSTRAINT orders_pkey PRIMARY KEY (id),
+    CONSTRAINT orders_customer_id_fkey FOREIGN KEY (customer_id) REFERENCES public.customers(id) ON DELETE RESTRICT
+);
+
+CREATE TABLE public.order_items (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    order_id uuid NOT NULL,
+    product_id uuid NOT NULL,
+    qty integer NOT NULL,
+    unit_price_cents integer NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    product_unit_id uuid NOT NULL,
+    submission_id uuid,
+    CONSTRAINT order_items_pkey PRIMARY KEY (id),
+    CONSTRAINT order_items_qty_check CHECK ((qty > 0)),
+    CONSTRAINT order_items_unit_price_cents_check CHECK ((unit_price_cents > 0)),
+    CONSTRAINT order_items_order_id_fkey FOREIGN KEY (order_id) REFERENCES public.orders(id) ON DELETE CASCADE,
+    CONSTRAINT order_items_product_id_fkey FOREIGN KEY (product_id) REFERENCES public.products(id) ON DELETE RESTRICT,
+    CONSTRAINT order_items_product_unit_id_fkey FOREIGN KEY (product_unit_id) REFERENCES public.product_units(id) ON DELETE RESTRICT
+);
+
+COMMENT ON COLUMN public.order_items.submission_id IS 'Client-generated per-submit-attempt UUID (DEC-039). Idempotency key for place_order — a replayed submission is a no-op returning the existing order — and per-submission audit (which submit attempt created this line). Null on rows that predate additive orders.';
+
+-- ── Indexes ──────────────────────────────────────────────────────────────────
+
+CREATE INDEX customer_sends_week_mode_idx ON public.customer_sends USING btree (week_of, mode);
+CREATE INDEX customers_token_idx ON public.customers USING btree (token);
+CREATE INDEX order_items_order_id_idx ON public.order_items USING btree (order_id);
+CREATE INDEX order_items_product_id_idx ON public.order_items USING btree (product_id);
+CREATE INDEX order_items_product_unit_id_idx ON public.order_items USING btree (product_unit_id);
+CREATE INDEX order_items_submission_id_idx ON public.order_items USING btree (submission_id);
+CREATE INDEX orders_customer_id_idx ON public.orders USING btree (customer_id);
+CREATE INDEX orders_needs_reconciliation_idx ON public.orders USING btree (needs_reconciliation) WHERE (needs_reconciliation = true);
+CREATE INDEX orders_week_of_idx ON public.orders USING btree (week_of);
+CREATE INDEX product_units_active_idx ON public.product_units USING btree (product_id) WHERE is_active;
+CREATE INDEX product_units_product_id_idx ON public.product_units USING btree (product_id);
+
+-- DEC-041: at most one non-terminal order per customer. Terminal statuses
+-- (picked_up/delivered) fall outside the predicate and free a new order.
+-- place_order's ON CONFLICT infers this index — it is load-bearing.
+CREATE UNIQUE INDEX orders_one_open_per_customer ON public.orders USING btree (customer_id) WHERE (status = ANY (ARRAY['new'::text, 'confirmed'::text, 'ready'::text]));
+
+-- ── Triggers ─────────────────────────────────────────────────────────────────
+
+CREATE TRIGGER order_items_default_unit_trigger BEFORE INSERT ON public.order_items FOR EACH ROW EXECUTE FUNCTION public.order_items_default_unit();
+
+-- ── Seed data ────────────────────────────────────────────────────────────────
+
+INSERT INTO public.codes (type, code, label, sort_order) VALUES
+  ('fulfillment_type', 'delivery', 'Delivery', 1),
+  ('fulfillment_type', 'pickup', 'Pickup', 2),
+  ('order_status', 'new', 'New', 1),
+  ('order_status', 'confirmed', 'Confirmed', 2),
+  ('order_status', 'ready', 'Ready', 3),
+  ('order_status', 'picked_up', 'Picked Up', 4),
+  ('order_status', 'delivered', 'Delivered', 5);
+
+-- Singletons. Ordering starts closed (matches original migration); the
+-- fulfillment link token mints fresh per database via the column default.
+INSERT INTO public.ordering_schedule (is_open) VALUES (false);
+INSERT INTO public.fulfillment_link (is_singleton) VALUES (true);

--- a/db/migrations/0001_init.sql
+++ b/db/migrations/0001_init.sql
@@ -499,6 +499,8 @@ CREATE INDEX product_units_product_id_idx ON public.product_units USING btree (p
 -- place_order's ON CONFLICT infers this index — it is load-bearing.
 CREATE UNIQUE INDEX orders_one_open_per_customer ON public.orders USING btree (customer_id) WHERE (status = ANY (ARRAY['new'::text, 'confirmed'::text, 'ready'::text]));
 
+COMMENT ON INDEX public.orders_one_open_per_customer IS 'DEC-041: at most one non-terminal order per customer. Terminal statuses (picked_up/delivered) fall outside the predicate and free a new order.';
+
 -- ── Triggers ─────────────────────────────────────────────────────────────────
 
 CREATE TRIGGER order_items_default_unit_trigger BEFORE INSERT ON public.order_items FOR EACH ROW EXECUTE FUNCTION public.order_items_default_unit();

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,11 +23,14 @@
         "@playwright/test": "1.59.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
+        "@types/pg": "^8.20.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
+        "pg": "^8.22.0",
         "tailwindcss": "^4",
+        "tsx": "^4.23.0",
         "typescript": "^5"
       }
     },
@@ -678,6 +681,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2389,6 +2834,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {
@@ -4380,6 +4837,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -7706,6 +8205,103 @@
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7814,6 +8410,49 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/powershell-utils": {
@@ -8676,6 +9315,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -9177,6 +9826,40 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",
@@ -9730,6 +10413,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "next": "16.2.4",
+        "pg": "^8.22.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "shadcn": "^4.7.0",
@@ -28,7 +29,6 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
-        "pg": "^8.22.0",
         "tailwindcss": "^4",
         "tsx": "^4.23.0",
         "typescript": "^5"
@@ -8209,7 +8209,6 @@
       "version": "8.22.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pg-connection-string": "^2.14.0",
@@ -8237,7 +8236,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
       "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -8245,14 +8243,12 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
       "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
@@ -8262,7 +8258,6 @@
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
       "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
@@ -8272,14 +8267,12 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
       "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pg-int8": "1.0.1",
@@ -8296,7 +8289,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
@@ -8416,7 +8408,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -8426,7 +8417,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8436,7 +8426,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8446,7 +8435,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
@@ -9319,7 +9307,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -10419,7 +10406,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "next": "16.2.4",
+    "pg": "^8.22.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.7.0",
@@ -32,7 +33,6 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
-    "pg": "^8.22.0",
     "tailwindcss": "^4",
     "tsx": "^4.23.0",
     "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev -p 3001 -H 0.0.0.0",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "db:up": "docker compose up -d --wait",
+    "db:down": "docker compose down",
+    "db:migrate": "tsx db/migrate.ts"
   },
   "dependencies": {
     "@supabase/ssr": "^0.10.2",
@@ -24,11 +27,14 @@
     "@playwright/test": "1.59.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/pg": "^8.20.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
+    "pg": "^8.22.0",
     "tailwindcss": "^4",
+    "tsx": "^4.23.0",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
Task 10.1 (DEC-046/048/049): muster's SQL migration runner ported, plus the clean `0001_init.sql` baseline that replaces the 27 Supabase migrations for fresh databases. Applied to docker test DB and the Neon `main` (dev/preview) branch; prod waits for 10.7's cutover.

## Files changed
- `db/migrate.ts` — muster's runner, byte-identical apart from bushel names, port 5433 default, and the DEC-049 explicit-arg prod form
- `db/migrations/0001_init.sql` — every table/column/constraint/index/FK/trigger/function/comment from the final Supabase schema, minus the DEC-048 deletions: all RLS policies + ENABLE ROW LEVEL SECURITY, `public.users` + its `auth.users` FK, and the `auth.users` FK on `customer_sends.sent_by_user_id` (column kept as bare uuid; disposition lands in 10.3/10.4). Seed data: 7 `codes` rows, `ordering_schedule` singleton (closed), `fulfillment_link` singleton
- `package.json` / `package-lock.json` — `db:up` / `db:down` / `db:migrate` scripts; `pg` in dependencies (10.2 runtime), `@types/pg` + `tsx` devDeps

## Code review
Baseline diffed against the schema dump programmatically — constraint/index/comment parity confirmed. Two findings, both fixed in 45bddea: restored the dropped `COMMENT ON INDEX orders_one_open_per_customer` (DEC-041 prose now lives in the catalog, not just the file), and moved `pg` from devDependencies to dependencies. One advisory for the 10.7 runbook: `pg`'s sslmode security warning prints to stderr on Neon connects — noise, not an error.

## Test plan
- [x] `npm run db:migrate -- <test-url>` on docker `bushel_test`: applies cleanly; second run → "Up to date."
- [x] `place_order` smoke on the baseline: create (appended=false) → append (true) → replay of same submission_id is a no-op (2 items, qty 10→5, default-unit trigger fired)
- [x] Applied to Neon `main` branch — 9 app tables + `_migrations`, index comment present
- [x] `npm run build`, `npx tsc --noEmit`, lint (1 pre-existing warning, untouched)
- [ ] CI green (typecheck/lint/build/Playwright — app code untouched, suite should be unaffected)
- No UI change; pgTAP suite still runs against Supabase local until 10.4/10.6 rewire it

🤖 Generated with [Claude Code](https://claude.com/claude-code)