### PR TITLE
10.2: pg data layer — swap supabase-js call sites to pg (DEC-046/048) — closes #255

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    # The app + tests read/write this DB (task 10.2); Supabase below is
+    # auth-only until 10.3.
+    env:
+      DATABASE_URL: postgres://bushel:bushel@localhost:5433/bushel_test
+
     # Plain Postgres for the migration runner + tests (DEC-046, task 10.0).
     # Port 5433 matches the local docker-compose mapping so one DATABASE_URL
     # convention works in both places. Supabase steps below coexist until
@@ -51,6 +56,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Run migrations (pg data DB)
+        run: npx tsx db/migrate.ts "$DATABASE_URL"
 
       # Typecheck + lint gate (#238 follow-up): neither was a CI gate, so both
       # silently drifted to 50 accumulated errors before anyone noticed. They
@@ -101,6 +109,7 @@ jobs:
             -e NEXT_PUBLIC_SUPABASE_URL \
             -e NEXT_PUBLIC_SUPABASE_ANON_KEY \
             -e SUPABASE_SERVICE_ROLE_KEY \
+            -e DATABASE_URL \
             mcr.microsoft.com/playwright:v1.59.1-noble \
             npx playwright test
 

--- a/src/actions/advance-order-status.ts
+++ b/src/actions/advance-order-status.ts
@@ -2,46 +2,45 @@
 
 import { revalidatePath } from "next/cache";
 
-import { createClient } from "@/lib/supabase/server";
-import { isValidTransition, type OrderStatus } from "@/lib/admin/orders-queries";
+import { getAdminUser } from "@/lib/admin/auth";
+import { isValidTransition, type OrderStatus } from "@/lib/admin/order-status";
+import { query } from "@/lib/db";
+import { pgMessage } from "@/lib/pg-errors";
 
-// Uses cookie-bound client (not admin) — the admin_all_orders RLS policy
-// (migration 20260508014838) is the gate on writes here. Matches the
-// recordSend pattern.
+// Admin gate first, then full-privilege pg writes (DEC-048 — the service
+// layer is the boundary; RLS is gone).
 export async function advanceOrderStatus(
   orderId: string,
   nextStatus: OrderStatus,
 ): Promise<{ error: string | null }> {
-  const supabase = await createClient();
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getAdminUser();
   if (!user) return { error: "Unauthorized" };
 
-  const { data: order, error: readError } = await supabase
-    .from("orders")
-    .select("status, fulfillment_type")
-    .eq("id", orderId)
-    .single();
-  if (readError) return { error: readError.message };
-  if (!order) return { error: "Order not found" };
+  try {
+    const rows = await query<{ status: string; fulfillment_type: string }>(
+      `select status, fulfillment_type from orders where id = $1`,
+      [orderId],
+    );
+    const order = rows[0];
+    if (!order) return { error: "Order not found" };
 
-  const from = order.status as OrderStatus;
-  const fulfillmentType =
-    order.fulfillment_type === "delivery" ? "delivery" : "pickup";
+    const from = order.status as OrderStatus;
+    const fulfillmentType =
+      order.fulfillment_type === "delivery" ? "delivery" : "pickup";
 
-  if (!isValidTransition(from, nextStatus, fulfillmentType)) {
-    return {
-      error: `Cannot move ${from} → ${nextStatus} (${fulfillmentType})`,
-    };
+    if (!isValidTransition(from, nextStatus, fulfillmentType)) {
+      return {
+        error: `Cannot move ${from} → ${nextStatus} (${fulfillmentType})`,
+      };
+    }
+
+    await query(
+      `update orders set status = $1, updated_at = now() where id = $2`,
+      [nextStatus, orderId],
+    );
+  } catch (e) {
+    return { error: pgMessage(e) };
   }
-
-  const { error: updateError } = await supabase
-    .from("orders")
-    .update({ status: nextStatus, updated_at: new Date().toISOString() })
-    .eq("id", orderId);
-  if (updateError) return { error: updateError.message };
 
   revalidatePath("/admin/orders");
   return { error: null };

--- a/src/actions/deactivate-customer.ts
+++ b/src/actions/deactivate-customer.ts
@@ -1,15 +1,22 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { createClient } from "@/lib/supabase/server";
+
+import { getAdminUser } from "@/lib/admin/auth";
+import { query } from "@/lib/db";
+import { pgMessage } from "@/lib/pg-errors";
 
 export async function deactivateCustomer(id: string): Promise<{ error: string | null }> {
-  const supabase = await createClient();
-  const { error } = await supabase
-    .from("customers")
-    .update({ is_active: false, updated_at: new Date().toISOString() })
-    .eq("id", id);
-  if (error) return { error: error.message };
+  const user = await getAdminUser();
+  if (!user) return { error: "Unauthorized" };
+  try {
+    await query(
+      `update customers set is_active = false, updated_at = now() where id = $1`,
+      [id],
+    );
+  } catch (e) {
+    return { error: pgMessage(e) };
+  }
   revalidatePath("/admin/customers");
   revalidatePath("/admin/inventory");
   return { error: null };

--- a/src/actions/place-order.ts
+++ b/src/actions/place-order.ts
@@ -2,14 +2,14 @@
 
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { createAdminClient } from "@/lib/supabase/admin";
 import {
   CUSTOMER_TOKEN_COOKIE,
   lookupCustomerByToken,
 } from "@/lib/customer/session";
+import { query } from "@/lib/db";
 import { sendAdminOrderAlert } from "@/lib/notifications/admin-telegram";
 import { totalItemCount } from "@/lib/order-items";
-import type { Json } from "@/lib/supabase/types";
+import { pgMessage } from "@/lib/pg-errors";
 import { weekOfMondayNY } from "@/lib/week";
 
 export type PlaceOrderItem = {
@@ -60,33 +60,32 @@ export async function placeOrder(
     return { error: "Add at least one item before submitting." };
   }
 
-  const supabase = createAdminClient();
   // DEC-039: place_order returns table(order_id, appended) — `appended`
   // tells us whether this submission created the week's order or topped up
-  // an existing one, which picks the alert copy below. .single() collapses
-  // the one-row set.
-  const { data, error } = await supabase
-    .rpc("place_order", {
-      p_customer_id: customer.id,
-      p_week_of: weekOfMondayNY(),
-      p_fulfillment_type: payload.mode,
-      p_delivery_address:
+  // an existing one, which picks the alert copy below.
+  let appended = false;
+  try {
+    const rows = await query<{ order_id: string; appended: boolean }>(
+      `select * from place_order($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+      [
+        customer.id,
+        weekOfMondayNY(),
+        payload.mode,
         payload.mode === "delivery" ? (customer.delivery_address ?? "") : "",
-      p_delivery_preference:
         payload.mode === "delivery" ? payload.delivery_preference.trim() : "",
-      p_pickup_note: payload.mode === "pickup" ? payload.pickup_note.trim() : "",
-      p_notes: payload.notes.trim(),
-      p_items: payload.items as unknown as Json,
-      p_submission_id: payload.submission_id,
-    })
-    .single();
-
-  if (error) {
+        payload.mode === "pickup" ? payload.pickup_note.trim() : "",
+        payload.notes.trim(),
+        JSON.stringify(payload.items),
+        payload.submission_id,
+      ],
+    );
+    appended = rows[0]?.appended ?? false;
+  } catch (e) {
     // #132 / DEC-036: place_order rejects items whose product is sold out
     // (qty_available = 0) at submit time — the stale-tab race. Surface a
-    // friendly, actionable message instead of the raw RPC text; reloading
+    // friendly, actionable message instead of the raw error text; reloading
     // re-fetches inventory and greys the sold-out rows.
-    if (error.message.includes("is sold out")) {
+    if (pgMessage(e).includes("is sold out")) {
       return {
         error:
           "Some items sold out while you were ordering. Reload to see what's still available.",
@@ -95,9 +94,8 @@ export async function placeOrder(
     // DEC-041: the old "already fulfilled" refusal is gone — a submission
     // arriving after the open order went terminal simply creates a fresh
     // open order (fulfilled orders drop out of the identity).
-    return { error: error.message };
+    return { error: pgMessage(e) };
   }
-  const appended = data?.appended ?? false;
 
   // Best-effort admin alert (DEC-033). Failure is swallowed inside the
   // wrapper — order placement never blocks on a notification miss. We

--- a/src/actions/reactivate-customer.ts
+++ b/src/actions/reactivate-customer.ts
@@ -1,18 +1,25 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { createClient } from "@/lib/supabase/server";
+
+import { getAdminUser } from "@/lib/admin/auth";
+import { query } from "@/lib/db";
+import { pgMessage } from "@/lib/pg-errors";
 
 // #61 — counterpart to deactivateCustomer. Flips is_active back to true.
 // Revalidates /admin/customers (the row jumps back into the default view)
 // and /admin/inventory (subscribed pill is a consumer of the count).
 export async function reactivateCustomer(id: string): Promise<{ error: string | null }> {
-  const supabase = await createClient();
-  const { error } = await supabase
-    .from("customers")
-    .update({ is_active: true, updated_at: new Date().toISOString() })
-    .eq("id", id);
-  if (error) return { error: error.message };
+  const user = await getAdminUser();
+  if (!user) return { error: "Unauthorized" };
+  try {
+    await query(
+      `update customers set is_active = true, updated_at = now() where id = $1`,
+      [id],
+    );
+  } catch (e) {
+    return { error: pgMessage(e) };
+  }
   revalidatePath("/admin/customers");
   revalidatePath("/admin/inventory");
   return { error: null };

--- a/src/actions/record-send.ts
+++ b/src/actions/record-send.ts
@@ -2,12 +2,13 @@
 
 import { revalidatePath } from "next/cache";
 
-import { createClient } from "@/lib/supabase/server";
+import { getAdminUser } from "@/lib/admin/auth";
 import type { SendMode } from "@/lib/admin/send-queue-queries";
+import { query } from "@/lib/db";
+import { pgMessage } from "@/lib/pg-errors";
 
 // Marks a customer as sent for (week, mode). Idempotent — upsert collapses
-// repeat taps to a single row. Uses RLS-gated server client (admin-all policy
-// on customer_sends from migration 20260515133545).
+// repeat taps to a single row. Admin-gated; full-privilege pg write.
 export async function recordSend(
   customerId: string,
   weekOf: string,
@@ -17,27 +18,20 @@ export async function recordSend(
   // the original 3-arg call sites stay unchanged (#191).
   revalidate: string = "/admin/send",
 ): Promise<{ error: string | null }> {
-  const supabase = await createClient();
-
-  // Belt-and-suspenders: RLS admin-all is the gate today, but a future
-  // policy loosening shouldn't accidentally allow anonymous writes here.
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getAdminUser();
   if (!user) return { error: "Unauthorized" };
 
-  const { error } = await supabase.from("customer_sends").upsert(
-    {
-      customer_id: customerId,
-      week_of: weekOf,
-      mode,
-      sent_at: new Date().toISOString(),
-      sent_by_user_id: user.id,
-    },
-    { onConflict: "customer_id,week_of,mode" },
-  );
-
-  if (error) return { error: error.message };
+  try {
+    await query(
+      `insert into customer_sends (customer_id, week_of, mode, sent_at, sent_by_user_id)
+       values ($1, $2, $3, now(), $4)
+       on conflict (customer_id, week_of, mode)
+       do update set sent_at = excluded.sent_at, sent_by_user_id = excluded.sent_by_user_id`,
+      [customerId, weekOf, mode, user.id],
+    );
+  } catch (e) {
+    return { error: pgMessage(e) };
+  }
 
   revalidatePath(revalidate);
   return { error: null };

--- a/src/actions/regenerate-token.ts
+++ b/src/actions/regenerate-token.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { createClient } from "@/lib/supabase/server";
+
+import { getAdminUser } from "@/lib/admin/auth";
+import { query } from "@/lib/db";
+import { pgCode, pgMessage, UNIQUE_VIOLATION } from "@/lib/pg-errors";
 import { generateToken } from "@/lib/tokens";
 
 const TOKEN_UPDATE_RETRIES = 5;
@@ -12,22 +15,24 @@ export type RegenerateTokenResult = {
 };
 
 export async function regenerateToken(id: string): Promise<RegenerateTokenResult> {
-  const supabase = await createClient();
-  const now = new Date().toISOString();
+  const user = await getAdminUser();
+  if (!user) return { error: "Unauthorized" };
 
   for (let attempt = 0; attempt < TOKEN_UPDATE_RETRIES; attempt++) {
     const token = generateToken();
-    const { data, error } = await supabase
-      .from("customers")
-      .update({ token, updated_at: now })
-      .eq("id", id)
-      .select("token")
-      .single();
-    if (!error) {
+    try {
+      const rows = await query<{ token: string }>(
+        `update customers set token = $1, updated_at = now()
+          where id = $2
+          returning token`,
+        [token, id],
+      );
+      if (rows.length === 0) return { error: "Customer not found." };
       revalidatePath("/admin/customers");
-      return { error: null, token: data.token };
+      return { error: null, token: rows[0].token };
+    } catch (e) {
+      if (pgCode(e) !== UNIQUE_VIOLATION) return { error: pgMessage(e) };
     }
-    if (error.code !== "23505") return { error: error.message };
   }
   return { error: "Could not generate a unique token. Try again." };
 }

--- a/src/actions/save-customer.ts
+++ b/src/actions/save-customer.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { createClient } from "@/lib/supabase/server";
+
+import { getAdminUser } from "@/lib/admin/auth";
+import { query } from "@/lib/db";
+import { pgCode, pgMessage, UNIQUE_VIOLATION } from "@/lib/pg-errors";
 import { generateToken } from "@/lib/tokens";
 
 const TOKEN_INSERT_RETRIES = 5;
@@ -40,8 +43,10 @@ export async function saveCustomer(input: CustomerInput): Promise<SaveCustomerRe
   const err = validate(input);
   if (err) return { error: err };
 
-  const supabase = await createClient();
-  const now = new Date().toISOString();
+  // RLS is gone (DEC-048) — the explicit gate replaces the old cookie-client
+  // + admin_all policy pair.
+  const user = await getAdminUser();
+  if (!user) return { error: "Unauthorized" };
 
   const trimmed = {
     name: input.name.trim(),
@@ -51,33 +56,61 @@ export async function saveCustomer(input: CustomerInput): Promise<SaveCustomerRe
     delivery_address: input.delivery_address?.trim() || null,
     priority: input.priority,
     send_weekly_link: input.send_weekly_link,
-    updated_at: now,
   };
 
   if (input.id) {
-    const { error } = await supabase
-      .from("customers")
-      .update(trimmed)
-      .eq("id", input.id);
-    if (error) return { error: error.message };
+    try {
+      await query(
+        `update customers
+            set name = $1, business_name = $2, email = $3, phone = $4,
+                delivery_address = $5, priority = $6, send_weekly_link = $7,
+                updated_at = now()
+          where id = $8`,
+        [
+          trimmed.name,
+          trimmed.business_name,
+          trimmed.email,
+          trimmed.phone,
+          trimmed.delivery_address,
+          trimmed.priority,
+          trimmed.send_weekly_link,
+          input.id,
+        ],
+      );
+    } catch (e) {
+      return { error: pgMessage(e) };
+    }
     revalidatePath("/admin/customers");
     revalidatePath("/admin/inventory");
     return { error: null, customerId: input.id };
   }
 
   for (let attempt = 0; attempt < TOKEN_INSERT_RETRIES; attempt++) {
-    const { data, error } = await supabase
-      .from("customers")
-      .insert({ ...trimmed, token: generateToken(), is_active: true })
-      .select("id")
-      .single();
-    if (!error) {
+    try {
+      const rows = await query<{ id: string }>(
+        `insert into customers
+           (name, business_name, email, phone, delivery_address, priority,
+            send_weekly_link, token, is_active)
+         values ($1, $2, $3, $4, $5, $6, $7, $8, true)
+         returning id`,
+        [
+          trimmed.name,
+          trimmed.business_name,
+          trimmed.email,
+          trimmed.phone,
+          trimmed.delivery_address,
+          trimmed.priority,
+          trimmed.send_weekly_link,
+          generateToken(),
+        ],
+      );
       revalidatePath("/admin/customers");
       revalidatePath("/admin/inventory");
-      return { error: null, customerId: data.id };
+      return { error: null, customerId: rows[0].id };
+    } catch (e) {
+      // Token collision → retry with a fresh token; anything else surfaces.
+      if (pgCode(e) !== UNIQUE_VIOLATION) return { error: pgMessage(e) };
     }
-    // 23505 = unique_violation in Postgres
-    if (error.code !== "23505") return { error: error.message };
   }
   return { error: "Could not generate a unique token. Try again." };
 }

--- a/src/actions/save-intro-note.ts
+++ b/src/actions/save-intro-note.ts
@@ -2,24 +2,31 @@
 
 import { revalidatePath } from "next/cache";
 
-import { createClient } from "@/lib/supabase/server";
+import { getAdminUser } from "@/lib/admin/auth";
+import { query } from "@/lib/db";
+import { pgMessage } from "@/lib/pg-errors";
 
 // Updates the per-cycle intro note on the ordering_schedule singleton. Empty
 // string clears it (template treats null and "" the same).
 export async function saveIntroNote(text: string): Promise<{ error: string | null }> {
-  const supabase = await createClient();
+  const user = await getAdminUser();
+  if (!user) return { error: "Unauthorized" };
 
-  // .select().single() surfaces "no row matched" as an error — without it,
-  // a missing singleton (migration drift, wrong env) would return success
-  // while nothing changed.
-  const { error } = await supabase
-    .from("ordering_schedule")
-    .update({ intro_note: text, updated_at: new Date().toISOString() })
-    .eq("is_singleton", true)
-    .select("id")
-    .single();
-
-  if (error) return { error: error.message };
+  try {
+    // RETURNING surfaces "no row matched" — without it, a missing singleton
+    // (migration drift, wrong env) would return success while nothing changed.
+    const rows = await query<{ id: string }>(
+      `update ordering_schedule set intro_note = $1, updated_at = now()
+        where is_singleton = true
+        returning id`,
+      [text],
+    );
+    if (rows.length === 0) {
+      return { error: "saveIntroNote: ordering_schedule singleton missing" };
+    }
+  } catch (e) {
+    return { error: pgMessage(e) };
+  }
 
   revalidatePath("/admin/send");
   return { error: null };

--- a/src/actions/save-inventory.ts
+++ b/src/actions/save-inventory.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { createClient } from "@/lib/supabase/server";
+
+import { getAdminUser } from "@/lib/admin/auth";
+import { query } from "@/lib/db";
+import { pgCode, pgMessage, UNIQUE_VIOLATION } from "@/lib/pg-errors";
 
 const ALLOWED_CATEGORIES = ["Vegetables", "Fruit", "Herbs", "Flowers", "Other"] as const;
 type Category = (typeof ALLOWED_CATEGORIES)[number];
@@ -62,20 +65,15 @@ function baseUnitSlug(name: string, productId: string): string {
   return `${nameSlug}-${productId.slice(0, 8)}`;
 }
 
-// unique (product_id, label) — the dropped mirror trigger used to silently
-// skip on this collision; DEC-037 surfaces it as a row error instead.
-function isUniqueViolation(code: string | undefined): boolean {
-  return code === "23505";
-}
-
 export async function saveInventory(input: SaveInventoryInput): Promise<SaveInventoryResult> {
   for (let i = 0; i < input.rows.length; i++) {
     const err = validateRow(input.rows[i], i);
     if (err) return { error: err };
   }
 
-  const supabase = await createClient();
-  const now = new Date().toISOString();
+  // RLS is gone (DEC-048) — explicit gate replaces the cookie-client policy pair.
+  const user = await getAdminUser();
+  if (!user) return { error: "Unauthorized" };
 
   const newIdMap: Record<string, string> = {};
 
@@ -86,71 +84,93 @@ export async function saveInventory(input: SaveInventoryInput): Promise<SaveInve
     const row = input.rows[i];
     const rowLabel = `Row ${i + 1}`;
     const unitLabel = row.unit.trim();
-    const payload = {
-      name: row.name.trim(),
-      category: row.category,
-      description: row.description?.trim() || null,
-      qty_available: Math.round(row.qty_available * 100) / 100,
-      is_available: row.is_available,
-      is_active: row.is_active,
-      sort_order: row.sort_order,
-      updated_at: now,
-    };
+    const payload = [
+      row.name.trim(),
+      row.category,
+      row.description?.trim() || null,
+      Math.round(row.qty_available * 100) / 100,
+      row.is_available,
+      row.is_active,
+      row.sort_order,
+    ];
 
     if (row.isNew) {
-      const { data, error } = await supabase
-        .from("products")
-        .insert(payload)
-        .select("id")
-        .single();
-      if (error) return { error: error.message, newIdMap };
-      if (!data) return { error: `${rowLabel}: insert returned no id.`, newIdMap };
+      let productId: string;
+      try {
+        const rows = await query<{ id: string }>(
+          `insert into products
+             (name, category, description, qty_available, is_available,
+              is_active, sort_order)
+           values ($1, $2, $3, $4, $5, $6, $7)
+           returning id`,
+          payload,
+        );
+        productId = rows[0].id;
+      } catch (e) {
+        return { error: pgMessage(e), newIdMap };
+      }
 
       // DEC-037: the spawn trigger is gone — saveInventory owns the base
       // product_units row. Insert it right after the product; on failure,
       // compensating-delete the product so the "every product has a base
       // unit" invariant holds (same row-by-row non-atomic style as the rest
       // of this action).
-      const { error: unitError } = await supabase.from("product_units").insert({
-        product_id: data.id,
-        label: unitLabel,
-        conversion_to_base: 1.0,
-        unit_price_cents: row.price_cents,
-        is_active: true,
-        sort_order: 0,
-        slug: baseUnitSlug(row.name.trim(), data.id),
-      });
-      if (unitError) {
+      try {
+        await query(
+          `insert into product_units
+             (product_id, label, conversion_to_base, unit_price_cents,
+              is_active, sort_order, slug)
+           values ($1, $2, 1.0, $3, true, 0, $4)`,
+          [productId, unitLabel, row.price_cents, baseUnitSlug(row.name.trim(), productId)],
+        );
+      } catch (e) {
         // Best-effort compensating delete — if it fails we leak a base-unit-less
         // product, but the original error is the one worth surfacing.
-        await supabase.from("products").delete().eq("id", data.id);
-        return { error: `${rowLabel}: ${unitError.message}`, newIdMap };
+        await query(`delete from products where id = $1`, [productId]).catch(
+          () => {},
+        );
+        return { error: `${rowLabel}: ${pgMessage(e)}`, newIdMap };
       }
-      newIdMap[row.id] = data.id;
+      newIdMap[row.id] = productId;
     } else {
-      const { error } = await supabase.from("products").update(payload).eq("id", row.id);
-      if (error) return { error: error.message, newIdMap };
+      try {
+        await query(
+          `update products
+              set name = $1, category = $2, description = $3,
+                  qty_available = $4, is_available = $5, is_active = $6,
+                  sort_order = $7, updated_at = now()
+            where id = $8`,
+          [...payload, row.id],
+        );
+      } catch (e) {
+        return { error: pgMessage(e), newIdMap };
+      }
 
       // Existing product: the inline unit/price fields edit the base unit row.
       // Capture the affected id — a zero-row update means the product has no
       // conversion_to_base = 1.0 row (a violated invariant, normally prevented
       // by saveProductUnits). Fail loud rather than silently dropping the edit.
-      const { data: updated, error: unitError } = await supabase
-        .from("product_units")
-        .update({ label: unitLabel, unit_price_cents: row.price_cents })
-        .eq("product_id", row.id)
-        .eq("conversion_to_base", 1.0)
-        .select("id");
-      if (unitError) {
-        if (isUniqueViolation(unitError.code)) {
+      let updated: Array<{ id: string }>;
+      try {
+        updated = await query<{ id: string }>(
+          `update product_units
+              set label = $1, unit_price_cents = $2, updated_at = now()
+            where product_id = $3 and conversion_to_base = 1.0
+            returning id`,
+          [unitLabel, row.price_cents, row.id],
+        );
+      } catch (e) {
+        // unique (product_id, label) — the dropped mirror trigger used to
+        // silently skip on this collision; DEC-037 surfaces it as a row error.
+        if (pgCode(e) === UNIQUE_VIOLATION) {
           return {
             error: `${rowLabel}: the unit label "${unitLabel}" is already used by another unit on this product.`,
             newIdMap,
           };
         }
-        return { error: `${rowLabel}: ${unitError.message}`, newIdMap };
+        return { error: `${rowLabel}: ${pgMessage(e)}`, newIdMap };
       }
-      if (!updated || updated.length === 0) {
+      if (updated.length === 0) {
         return {
           error: `${rowLabel}: no base unit found for "${row.name.trim()}". Open its units and set one unit's conversion to 1.`,
           newIdMap,

--- a/src/actions/save-product-units.ts
+++ b/src/actions/save-product-units.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { createClient } from "@/lib/supabase/server";
+
+import { getAdminUser } from "@/lib/admin/auth";
+import { query } from "@/lib/db";
+import { pgCode, pgMessage, FOREIGN_KEY_VIOLATION } from "@/lib/pg-errors";
 
 export type UnitInput = {
   // null = new unit (insert); non-null = existing (update)
@@ -101,66 +104,79 @@ export async function saveProductUnits(
     };
   }
 
-  const supabase = await createClient();
+  // RLS is gone (DEC-048) — explicit gate replaces the cookie-client policy pair.
+  const user = await getAdminUser();
+  if (!user) return { error: "Unauthorized" };
 
-  const { data: product, error: prodErr } = await supabase
-    .from("products")
-    .select("id, name")
-    .eq("id", input.productId)
-    .single();
-  if (prodErr || !product) {
-    return { error: prodErr?.message ?? "Product not found." };
+  const productRows = await query<{ id: string; name: string }>(
+    `select id, name from products where id = $1`,
+    [input.productId],
+  );
+  const product = productRows[0];
+  if (!product) {
+    return { error: "Product not found." };
   }
 
   // Delete first so existing labels can be reassigned within the same save
   // without colliding on the unique (product_id, label) index.
   if (input.deletedUnitIds.length > 0) {
-    const { error } = await supabase
-      .from("product_units")
-      .delete()
-      .in("id", input.deletedUnitIds);
-    if (error) {
-      // 23503 = foreign_key_violation — order_items.product_unit_id is ON
-      // DELETE RESTRICT. Surface a friendly message so Annabel knows the
-      // remedy (deactivate instead of delete) without seeing the raw FK
-      // constraint name.
-      if (error.code === "23503") {
+    try {
+      await query(`delete from product_units where id = any($1)`, [
+        input.deletedUnitIds,
+      ]);
+    } catch (e) {
+      // order_items.product_unit_id is ON DELETE RESTRICT. Surface a friendly
+      // message so Annabel knows the remedy (deactivate instead of delete)
+      // without seeing the raw FK constraint name.
+      if (pgCode(e) === FOREIGN_KEY_VIOLATION) {
         return {
           error:
             "Can't delete a unit that's already on an existing order. Turn the Active switch off instead — customers won't see it next week.",
         };
       }
-      return { error: error.message };
+      return { error: pgMessage(e) };
     }
   }
 
   for (const u of trimmed) {
-    if (u.id === null) {
-      const slug = unitSlug(product.name, product.id, u.label);
-      const { error } = await supabase.from("product_units").insert({
-        product_id: input.productId,
-        label: u.label,
-        conversion_to_base: u.conversion_to_base,
-        unit_price_cents: u.unit_price_cents,
-        is_active: u.is_active,
-        sort_order: u.sort_order,
-        sku: u.sku,
-        slug,
-      });
-      if (error) return { error: error.message };
-    } else {
-      const { error } = await supabase
-        .from("product_units")
-        .update({
-          label: u.label,
-          conversion_to_base: u.conversion_to_base,
-          unit_price_cents: u.unit_price_cents,
-          is_active: u.is_active,
-          sort_order: u.sort_order,
-          sku: u.sku,
-        })
-        .eq("id", u.id);
-      if (error) return { error: error.message };
+    try {
+      if (u.id === null) {
+        const slug = unitSlug(product.name, product.id, u.label);
+        await query(
+          `insert into product_units
+             (product_id, label, conversion_to_base, unit_price_cents,
+              is_active, sort_order, sku, slug)
+           values ($1, $2, $3, $4, $5, $6, $7, $8)`,
+          [
+            input.productId,
+            u.label,
+            u.conversion_to_base,
+            u.unit_price_cents,
+            u.is_active,
+            u.sort_order,
+            u.sku,
+            slug,
+          ],
+        );
+      } else {
+        await query(
+          `update product_units
+              set label = $1, conversion_to_base = $2, unit_price_cents = $3,
+                  is_active = $4, sort_order = $5, sku = $6, updated_at = now()
+            where id = $7`,
+          [
+            u.label,
+            u.conversion_to_base,
+            u.unit_price_cents,
+            u.is_active,
+            u.sort_order,
+            u.sku,
+            u.id,
+          ],
+        );
+      }
+    } catch (e) {
+      return { error: pgMessage(e) };
     }
   }
 

--- a/src/actions/save-schedule.ts
+++ b/src/actions/save-schedule.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { createClient } from "@/lib/supabase/server";
+
+import { getAdminUser } from "@/lib/admin/auth";
+import { query } from "@/lib/db";
+import { pgMessage } from "@/lib/pg-errors";
 
 export type SaveScheduleInput = {
   useSchedule: boolean;
@@ -12,28 +15,25 @@ export type SaveScheduleInput = {
 };
 
 export async function saveSchedule(input: SaveScheduleInput): Promise<string | null> {
-  const supabase = await createClient();
+  const user = await getAdminUser();
+  if (!user) return "Unauthorized";
 
-  const patch = input.useSchedule
-    ? {
-        weekly_open_day: input.openDay,
-        weekly_open_time: input.openTime,
-        weekly_close_day: input.closeDay,
-        weekly_close_time: input.closeTime,
-      }
-    : {
-        weekly_open_day: null,
-        weekly_open_time: null,
-        weekly_close_day: null,
-        weekly_close_time: null,
-      };
+  const values = input.useSchedule
+    ? [input.openDay, input.openTime, input.closeDay, input.closeTime]
+    : [null, null, null, null];
 
-  const { error } = await supabase
-    .from("ordering_schedule")
-    .update({ ...patch, updated_at: new Date().toISOString() })
-    .eq("is_singleton", true);
-
-  if (error) return error.message;
+  try {
+    await query(
+      `update ordering_schedule
+          set weekly_open_day = $1, weekly_open_time = $2,
+              weekly_close_day = $3, weekly_close_time = $4,
+              updated_at = now()
+        where is_singleton = true`,
+      values,
+    );
+  } catch (e) {
+    return pgMessage(e);
+  }
 
   revalidatePath("/admin/settings");
   return null;

--- a/src/actions/set-base-unit.ts
+++ b/src/actions/set-base-unit.ts
@@ -1,15 +1,18 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { createClient } from "@/lib/supabase/server";
+
+import { getAdminUser } from "@/lib/admin/auth";
+import { query } from "@/lib/db";
+import { pgMessage } from "@/lib/pg-errors";
 
 export type SetBaseUnitResult = {
   error: string | null;
 };
 
 // #208 (DEC-038) — promote a product_units row to base. Thin wrapper over the
-// set_base_unit RPC, which atomically rescales every unit's conversion + the
-// product's qty_available and renumbers sort_order so the new base sorts
+// set_base_unit function, which atomically rescales every unit's conversion +
+// the product's qty_available and renumbers sort_order so the new base sorts
 // first (becoming the customer default). Deliberately NOT folded into
 // saveProductUnits' staged save — re-basing touches live stock and must run
 // as one server-side transaction, not as a diff of row updates.
@@ -17,34 +20,33 @@ export async function setBaseUnit(
   productId: string,
   unitId: string,
 ): Promise<SetBaseUnitResult> {
-  const supabase = await createClient();
+  const user = await getAdminUser();
+  if (!user) return { error: "Unauthorized" };
 
-  const { error } = await supabase.rpc("set_base_unit", {
-    p_product_id: productId,
-    p_new_base_unit_id: unitId,
-  });
-
-  if (error) {
-    // Map the RPC's raise texts to remedies Annabel can act on; anything
+  try {
+    await query(`select set_base_unit($1, $2)`, [productId, unitId]);
+  } catch (e) {
+    const message = pgMessage(e);
+    // Map the function's raise texts to remedies Annabel can act on; anything
     // else surfaces raw (same contract as saveProductUnits).
-    if (error.message.includes("is inactive")) {
+    if (message.includes("is inactive")) {
       return {
         error:
           "An inactive unit can't be the base. Turn its Active switch on and save first.",
       };
     }
-    if (error.message.includes("does not belong")) {
+    if (message.includes("does not belong")) {
       return {
         error: "That unit doesn't belong to this product. Reload and try again.",
       };
     }
-    if (error.message.includes("too far apart in scale")) {
+    if (message.includes("too far apart in scale")) {
       return {
         error:
           "These units are too far apart in size to switch the base unit. Adjust the conversions closer first.",
       };
     }
-    return { error: error.message };
+    return { error: message };
   }
 
   revalidatePath("/admin/inventory");

--- a/src/actions/toggle-ordering.ts
+++ b/src/actions/toggle-ordering.ts
@@ -1,33 +1,35 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { createClient } from "@/lib/supabase/server";
-import type { Database } from "@/lib/supabase/types";
 
-type ScheduleUpdate = Database["public"]["Tables"]["ordering_schedule"]["Update"];
+import { getAdminUser } from "@/lib/admin/auth";
+import { query } from "@/lib/db";
+import { pgMessage } from "@/lib/pg-errors";
 
 export type ToggleOrderingAction = "open" | "close" | "resume";
 
 export async function toggleOrdering(action: ToggleOrderingAction): Promise<string | null> {
-  const supabase = await createClient();
+  const user = await getAdminUser();
+  if (!user) return "Unauthorized";
 
-  const now = new Date().toISOString();
-  let patch: ScheduleUpdate;
+  // open: flip on. close: flip off + clear any override. resume: clear the
+  // override only (the weekly schedule takes back over).
+  const sql =
+    action === "open"
+      ? `update ordering_schedule set is_open = true, updated_at = now()
+          where is_singleton = true`
+      : action === "close"
+        ? `update ordering_schedule set is_open = false, override_closes_at = null,
+                  updated_at = now()
+            where is_singleton = true`
+        : `update ordering_schedule set override_closes_at = null, updated_at = now()
+            where is_singleton = true`;
 
-  if (action === "open") {
-    patch = { is_open: true, updated_at: now };
-  } else if (action === "close") {
-    patch = { is_open: false, override_closes_at: null, updated_at: now };
-  } else {
-    patch = { override_closes_at: null, updated_at: now };
+  try {
+    await query(sql);
+  } catch (e) {
+    return pgMessage(e);
   }
-
-  const { error } = await supabase
-    .from("ordering_schedule")
-    .update(patch)
-    .eq("is_singleton", true);
-
-  if (error) return error.message;
 
   revalidatePath("/admin/settings");
   return null;

--- a/src/actions/toggle-subscribed.ts
+++ b/src/actions/toggle-subscribed.ts
@@ -1,18 +1,25 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { createClient } from "@/lib/supabase/server";
+
+import { getAdminUser } from "@/lib/admin/auth";
+import { query } from "@/lib/db";
+import { pgMessage } from "@/lib/pg-errors";
 
 export async function toggleSubscribed(
   id: string,
   send_weekly_link: boolean,
 ): Promise<{ error: string | null }> {
-  const supabase = await createClient();
-  const { error } = await supabase
-    .from("customers")
-    .update({ send_weekly_link, updated_at: new Date().toISOString() })
-    .eq("id", id);
-  if (error) return { error: error.message };
+  const user = await getAdminUser();
+  if (!user) return { error: "Unauthorized" };
+  try {
+    await query(
+      `update customers set send_weekly_link = $1, updated_at = now() where id = $2`,
+      [send_weekly_link, id],
+    );
+  } catch (e) {
+    return { error: pgMessage(e) };
+  }
   revalidatePath("/admin/customers");
   revalidatePath("/admin/inventory");
   return { error: null };

--- a/src/app/(admin)/admin/customers/page.tsx
+++ b/src/app/(admin)/admin/customers/page.tsx
@@ -1,26 +1,28 @@
-import { createClient } from "@/lib/supabase/server";
+import { query } from "@/lib/db";
 import { CustomersPage, type CustomerRow } from "@/components/admin/customers-page";
 
 export default async function AdminCustomersPage() {
-  const supabase = await createClient();
   // #61: fetch all customers (active + deactivated). Default view filters
   // to active client-side; the page-header toggle reveals the rest.
-  const { data, error } = await supabase
-    .from("customers")
-    .select("id, name, business_name, email, phone, delivery_address, priority, send_weekly_link, token, is_active")
-    .order("is_active", { ascending: false })
-    .order("priority", { ascending: true })
-    .order("name", { ascending: true });
-
-  if (error) {
+  // (Admin auth is enforced by the (admin) layout; data reads are
+  // full-privilege pg per DEC-048.)
+  let customers: CustomerRow[];
+  try {
+    customers = await query<CustomerRow>(
+      `select id, name, business_name, email, phone, delivery_address,
+              priority, send_weekly_link, token, is_active
+         from customers
+        order by is_active desc, priority asc, name asc`,
+    );
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
     return (
       <main style={{ padding: "28px 32px", maxWidth: 1200 }}>
         <h1 className="page-title">Customers</h1>
-        <p style={{ color: "var(--rose-600)", marginTop: 16 }}>{error.message}</p>
+        <p style={{ color: "var(--rose-600)", marginTop: 16 }}>{message}</p>
       </main>
     );
   }
 
-  const customers: CustomerRow[] = data ?? [];
   return <CustomersPage customers={customers} />;
 }

--- a/src/app/(admin)/admin/inventory/page.tsx
+++ b/src/app/(admin)/admin/inventory/page.tsx
@@ -1,72 +1,97 @@
-import { createClient } from "@/lib/supabase/server";
+import { query } from "@/lib/db";
+import type { ProductRow } from "@/lib/db-types";
 import { InventoryEditor, type ScheduleSummary, type CustomerStats } from "@/components/admin/inventory-editor";
 import type { InventoryRowState } from "@/components/admin/inventory-row";
 import type { ProductUnitState } from "@/components/admin/units-drawer";
 import { weekOfLabel, weekOfMondayNY } from "@/lib/week";
 
+type UnitRow = {
+  id: string;
+  product_id: string;
+  label: string;
+  conversion_to_base: number;
+  unit_price_cents: number;
+  is_active: boolean;
+  sort_order: number | null;
+  sku: string | null;
+};
+
+type ScheduleRow = {
+  is_open: boolean;
+  weekly_open_day: number | null;
+  weekly_open_time: string | null;
+  weekly_close_day: number | null;
+  weekly_close_time: string | null;
+};
+
 export default async function InventoryPage() {
-  const supabase = await createClient();
   const weekOf = weekOfMondayNY();
-  const [productsRes, unitsRes, scheduleRes, subscribedCustomersRes, weekOrdersRes, weekItemsRes] = await Promise.all([
-    supabase
-      .from("products")
-      .select("*")
-      .order("sort_order", { ascending: true, nullsFirst: false })
-      .order("name"),
-    supabase
-      .from("product_units")
-      .select("id, product_id, label, conversion_to_base, unit_price_cents, is_active, sort_order, sku")
-      .order("sort_order", { ascending: true, nullsFirst: false })
-      .order("id"),
-    supabase
-      .from("ordering_schedule")
-      .select("is_open, weekly_open_day, weekly_open_time, weekly_close_day, weekly_close_time")
-      .eq("is_singleton", true)
-      .single(),
-    supabase
-      .from("customers")
-      .select("id", { count: "exact", head: true })
-      .eq("is_active", true)
-      .eq("send_weekly_link", true),
-    supabase
-      .from("orders")
-      .select("customer_id", { count: "exact", head: true })
-      .eq("week_of", weekOf),
-    // Sold-this-week per product (base units). Aggregated client-side rather
-    // than via PostgREST RPC because the multi-unit join (qty * conversion)
-    // pushes us past what `.select(..., count: "exact")` can express. Volume
-    // is small — single-digit customers × handful of items per order.
-    // No `orders.status` filter today — there's no cancellation flow in V1.
-    // If one lands (DEC-012 reconciliation could grow one), add the filter
-    // here so cancelled items don't count as sold.
-    supabase
-      .from("order_items")
-      .select("product_id, qty, product_units(conversion_to_base), orders!inner(week_of)")
-      .eq("orders.week_of", weekOf),
-  ]);
 
   // Every query is load-bearing for the pills / table — failing silently on
   // schedule or counts would render a plausible-but-wrong "Closed · 0 active"
-  // state. Short-circuit on any error so Annabel sees a loud failure instead.
-  const firstError =
-    productsRes.error ??
-    unitsRes.error ??
-    scheduleRes.error ??
-    subscribedCustomersRes.error ??
-    weekOrdersRes.error ??
-    weekItemsRes.error;
-  if (firstError || !scheduleRes.data) {
+  // state. The try/catch surfaces any failure loudly instead.
+  let products: ProductRow[];
+  let units: UnitRow[];
+  let scheduleRows: ScheduleRow[];
+  let subscribedCount: number;
+  let weekOrdersCount: number;
+  let weekItems: Array<{ product_id: string; qty: number; conversion_to_base: number | null }>;
+  try {
+    [products, units, scheduleRows, subscribedCount, weekOrdersCount, weekItems] =
+      await Promise.all([
+        query<ProductRow>(
+          `select * from products order by sort_order asc nulls last, name asc`,
+        ),
+        query<UnitRow>(
+          `select id, product_id, label, conversion_to_base, unit_price_cents,
+                  is_active, sort_order, sku
+             from product_units
+            order by sort_order asc nulls last, id asc`,
+        ),
+        query<ScheduleRow>(
+          `select is_open, weekly_open_day, weekly_open_time, weekly_close_day,
+                  weekly_close_time
+             from ordering_schedule
+            where is_singleton = true`,
+        ),
+        query<{ count: number }>(
+          `select count(*)::int as count from customers
+            where is_active and send_weekly_link`,
+        ).then((r) => r[0].count),
+        query<{ count: number }>(
+          `select count(*)::int as count from orders where week_of = $1`,
+          [weekOf],
+        ).then((r) => r[0].count),
+        // Sold-this-week per product (base units), aggregated below. Falls
+        // back to conv=1 when the unit row is absent — pre-6.5a data had no
+        // unit attached; the safety-net trigger now fills it on insert, but
+        // historical rows remain. No `orders.status` filter today — there's
+        // no cancellation flow in V1. If one lands (DEC-012 reconciliation
+        // could grow one), add the filter here so cancelled items don't
+        // count as sold.
+        query<{ product_id: string; qty: number; conversion_to_base: number | null }>(
+          `select oi.product_id, oi.qty, pu.conversion_to_base
+             from order_items oi
+             join orders o on o.id = oi.order_id
+             left join product_units pu on pu.id = oi.product_unit_id
+            where o.week_of = $1`,
+          [weekOf],
+        ),
+      ]);
+    if (scheduleRows.length !== 1) {
+      throw new Error("ordering_schedule singleton row missing");
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
     return (
       <main style={{ padding: "28px 32px", maxWidth: 1200 }}>
         <h1 className="page-title">Inventory</h1>
-        <p style={{ color: "var(--rose-600)", marginTop: 16 }}>
-          {firstError?.message ?? "ordering_schedule singleton row missing"}
-        </p>
+        <p style={{ color: "var(--rose-600)", marginTop: 16 }}>{message}</p>
       </main>
     );
   }
 
-  const scheduleRow = scheduleRes.data;
+  const scheduleRow = scheduleRows[0];
   const schedule: ScheduleSummary = {
     isOpen: scheduleRow.is_open,
     openDay: scheduleRow.weekly_open_day,
@@ -76,12 +101,12 @@ export default async function InventoryPage() {
   };
 
   const customerStats: CustomerStats = {
-    subscribed: subscribedCustomersRes.count ?? 0,
-    orderedThisWeek: weekOrdersRes.count ?? 0,
+    subscribed: subscribedCount,
+    orderedThisWeek: weekOrdersCount,
   };
 
   const unitsByProductId: Record<string, ProductUnitState[]> = {};
-  for (const u of unitsRes.data ?? []) {
+  for (const u of units) {
     (unitsByProductId[u.product_id] ??= []).push({
       id: u.id,
       label: u.label,
@@ -94,16 +119,9 @@ export default async function InventoryPage() {
   }
 
   // Sold this week per product, in base units (qty * conversion_to_base).
-  // Falls back to conv=1 when product_units join is absent — pre-6.5a data
-  // had no unit row attached; the 6.5a safety-net trigger now fills it on
-  // insert, but historical rows remain.
   const soldByProductId: Record<string, number> = {};
-  for (const row of (weekItemsRes.data ?? []) as Array<{
-    product_id: string;
-    qty: number;
-    product_units: { conversion_to_base: number } | null;
-  }>) {
-    const conv = Number(row.product_units?.conversion_to_base ?? 1);
+  for (const row of weekItems) {
+    const conv = Number(row.conversion_to_base ?? 1);
     soldByProductId[row.product_id] = (soldByProductId[row.product_id] ?? 0) + row.qty * conv;
   }
 
@@ -112,7 +130,7 @@ export default async function InventoryPage() {
   // picked from the units already loaded above. A missing base row violates the
   // saveInventory invariant; fall back to empty/0 so the broken row is loudly
   // uneditable (save rejects blank unit / zero price) instead of silently wrong.
-  const initialRows: InventoryRowState[] = (productsRes.data ?? []).map((p) => {
+  const initialRows: InventoryRowState[] = products.map((p) => {
     const base = (unitsByProductId[p.id] ?? []).find(
       (u) => u.conversion_to_base === 1,
     );

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -1,27 +1,40 @@
-import { createClient } from "@/lib/supabase/server";
+import { query } from "@/lib/db";
 import { SettingsScheduleCard } from "@/components/admin/SettingsScheduleCard";
 
 export const metadata = { title: "Settings — Bay Branch Farm" };
 
-export default async function SettingsPage() {
-  const supabase = await createClient();
-  const { data, error } = await supabase
-    .from("ordering_schedule")
-    .select("is_open, weekly_open_day, weekly_open_time, weekly_close_day, weekly_close_time")
-    .eq("is_singleton", true)
-    .single();
+type ScheduleRow = {
+  is_open: boolean;
+  weekly_open_day: number | null;
+  weekly_open_time: string | null;
+  weekly_close_day: number | null;
+  weekly_close_time: string | null;
+};
 
-  if (error || !data) {
+export default async function SettingsPage() {
+  let schedule: ScheduleRow | undefined;
+  let loadError: string | null = null;
+  try {
+    const rows = await query<ScheduleRow>(
+      `select is_open, weekly_open_day, weekly_open_time, weekly_close_day,
+              weekly_close_time
+         from ordering_schedule
+        where is_singleton = true`,
+    );
+    schedule = rows[0];
+  } catch (e) {
+    loadError = e instanceof Error ? e.message : String(e);
+  }
+
+  if (loadError || !schedule) {
     return (
       <div style={{ padding: "32px" }}>
         <p style={{ color: "var(--rose-600)" }}>
-          Could not load settings: {error?.message ?? "no schedule row found"}
+          Could not load settings: {loadError ?? "no schedule row found"}
         </p>
       </div>
     );
   }
-
-  const schedule = data;
 
   return (
     <div style={{ padding: "32px", maxWidth: 860, margin: "0 auto" }}>

--- a/src/app/api/cron/check-schedule/route.ts
+++ b/src/app/api/cron/check-schedule/route.ts
@@ -1,8 +1,5 @@
 import { NextResponse } from "next/server";
-import { createAdminClient } from "@/lib/supabase/admin";
-import type { Database } from "@/lib/supabase/types";
-
-type ScheduleUpdate = Database["public"]["Tables"]["ordering_schedule"]["Update"];
+import { query } from "@/lib/db";
 
 // DORMANT (DEC-040): the vercel.json crons entry was removed — nothing calls
 // this route anymore. The store is always-open; is_open changes only via the
@@ -16,6 +13,15 @@ type ScheduleUpdate = Database["public"]["Tables"]["ordering_schedule"]["Update"
 // Vercel passes it automatically as Authorization: Bearer <secret> for
 // cron jobs; for manual testing use the same header.
 
+type ScheduleRow = {
+  is_open: boolean;
+  weekly_open_day: number | null;
+  weekly_open_time: string | null;
+  weekly_close_day: number | null;
+  weekly_close_time: string | null;
+  override_closes_at: string | null;
+};
+
 export async function GET(request: Request) {
   const secret = process.env.CRON_SECRET;
   if (!secret) {
@@ -27,24 +33,24 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const supabase = createAdminClient();
-  const { data: row, error } = await supabase
-    .from("ordering_schedule")
-    .select("is_open, weekly_open_day, weekly_open_time, weekly_close_day, weekly_close_time, override_closes_at")
-    .eq("is_singleton", true)
-    .single();
-
-  if (error || !row) {
+  const rows = await query<ScheduleRow>(
+    `select is_open, weekly_open_day, weekly_open_time, weekly_close_day,
+            weekly_close_time, override_closes_at
+       from ordering_schedule
+      where is_singleton = true`,
+  );
+  const row = rows[0];
+  if (!row) {
     return NextResponse.json({ error: "No schedule row" }, { status: 500 });
   }
 
   const now = new Date();
-  let patch: ScheduleUpdate | null = null;
+  let patch: { is_open?: boolean; override_closes_at?: null } | null = null;
   let action: string | null = null;
 
   // 1. override_closes_at — highest priority
   if (row.override_closes_at && new Date(row.override_closes_at) <= now) {
-    patch = { is_open: false, override_closes_at: null, updated_at: now.toISOString() };
+    patch = { is_open: false, override_closes_at: null };
     action = "override-expired → closed";
   }
 
@@ -66,10 +72,10 @@ export async function GET(request: Request) {
     const isCloseDay = dayNow === row.weekly_close_day;
 
     if (isCloseDay && minutesNow >= closeMinutes && row.is_open) {
-      patch = { is_open: false, updated_at: now.toISOString() };
+      patch = { is_open: false };
       action = "schedule → closed";
     } else if (isOpenDay && minutesNow >= openMinutes && !row.is_open) {
-      patch = { is_open: true, updated_at: now.toISOString() };
+      patch = { is_open: true };
       action = "schedule → open";
     }
   }
@@ -78,13 +84,18 @@ export async function GET(request: Request) {
     return NextResponse.json({ ok: true, action: "no-op" });
   }
 
-  const { error: updateError } = await supabase
-    .from("ordering_schedule")
-    .update(patch)
-    .eq("is_singleton", true);
-
-  if (updateError) {
-    return NextResponse.json({ error: updateError.message }, { status: 500 });
+  try {
+    await query(
+      `update ordering_schedule
+          set is_open = coalesce($1, is_open),
+              override_closes_at = case when $2 then null else override_closes_at end,
+              updated_at = now()
+        where is_singleton = true`,
+      [patch.is_open ?? null, "override_closes_at" in patch],
+    );
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 
   return NextResponse.json({ ok: true, action });

--- a/src/app/c/[token]/confirmed/page.tsx
+++ b/src/app/c/[token]/confirmed/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { PausedShell } from "@/components/customer/PausedShell";
 import { StatusShell } from "@/components/customer/StatusShell";
-import { isTerminalStatus } from "@/lib/admin/orders-queries";
+import { isTerminalStatus } from "@/lib/admin/order-status";
 import {
   anyOrderable,
   getAvailableProducts,

--- a/src/components/admin/export-orders-button.tsx
+++ b/src/components/admin/export-orders-button.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import { csvFilename, toCsv, toTsv } from "@/lib/admin/export-orders";
-import type { OrderRow } from "@/lib/admin/orders-queries";
+import type { OrderRow } from "@/lib/admin/order-status";
 
 type Props = {
   orders: OrderRow[];

--- a/src/components/admin/order-actions.tsx
+++ b/src/components/admin/order-actions.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { SendAction } from "@/components/admin/send-action";
-import type { OrderRow as OrderRowData, OrderStatus } from "@/lib/admin/orders-queries";
-import { statusAfterConfirmSend } from "@/lib/admin/orders-queries";
+import type { OrderRow as OrderRowData, OrderStatus } from "@/lib/admin/order-status";
+import { statusAfterConfirmSend } from "@/lib/admin/order-status";
 import {
   deliveryReminderBody,
   orderConfirmationBody,

--- a/src/components/admin/order-detail.tsx
+++ b/src/components/admin/order-detail.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import type { OrderRow as OrderRowData } from "@/lib/admin/orders-queries";
+import type { OrderRow as OrderRowData } from "@/lib/admin/order-status";
 
 function formatMoney(cents: number): string {
   return `$${(cents / 100).toFixed(2)}`;

--- a/src/components/admin/order-row.tsx
+++ b/src/components/admin/order-row.tsx
@@ -5,7 +5,7 @@ import { useState, useTransition, Fragment } from "react";
 import { advanceOrderStatus } from "@/actions/advance-order-status";
 import { OrderDetail } from "@/components/admin/order-detail";
 import { OrderActions } from "@/components/admin/order-actions";
-import type { OrderRow as OrderRowData, OrderStatus } from "@/lib/admin/orders-queries";
+import type { OrderRow as OrderRowData, OrderStatus } from "@/lib/admin/order-status";
 import { totalItemCount } from "@/lib/order-items";
 
 type Props = {

--- a/src/components/admin/orders-page.tsx
+++ b/src/components/admin/orders-page.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 
 import { OrderRow } from "@/components/admin/order-row";
 import { ExportOrdersButton } from "@/components/admin/export-orders-button";
-import type { OrderRow as OrderRowData } from "@/lib/admin/orders-queries";
+import type { OrderRow as OrderRowData } from "@/lib/admin/order-status";
 
 type SortKey = "placed" | "customer" | "total";
 type SortDir = "asc" | "desc";

--- a/src/lib/admin/auth.ts
+++ b/src/lib/admin/auth.ts
@@ -1,0 +1,14 @@
+// Transitional admin auth gate. Until DEC-047's email-code session lands
+// (task 10.3), admin identity still comes from Supabase Auth cookies — but
+// data access moved to pg (task 10.2), so this is the ONLY thing the
+// supabase server client is still used for in actions. 10.3 swaps this
+// body for the HMAC-session check; call sites stay put.
+import { createClient } from "@/lib/supabase/server";
+
+export async function getAdminUser(): Promise<{ id: string } | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return user ? { id: user.id } : null;
+}

--- a/src/lib/admin/order-status.ts
+++ b/src/lib/admin/order-status.ts
@@ -1,0 +1,116 @@
+// Pure order-status domain: types, status sets, and transition rules. No DB
+// import — safe for client components (the pg-backed queries live in
+// orders-queries.ts, which re-exports everything here for server callers).
+
+// DEC-035 (amends DEC-010): new → [confirmed] → ready → (picked_up | delivered).
+// Confirmed is optional. Ordering matches codes.sort_order.
+// DEC-044: snake_case picked_up is canonical — matches the codes table row.
+export type OrderStatus =
+  | "new"
+  | "confirmed"
+  | "ready"
+  | "picked_up"
+  | "delivered";
+
+export const ORDER_STATUSES: OrderStatus[] = [
+  "new",
+  "confirmed",
+  "ready",
+  "picked_up",
+  "delivered",
+];
+
+// DEC-041: the open-order identity set. A customer has at most one order in
+// these statuses (partial unique index orders_one_open_per_customer); a
+// terminal order drops out and frees a new one. Keep this list identical to
+// the index predicate in the DEC-041 migration.
+export const OPEN_ORDER_STATUSES: OrderStatus[] = ["new", "confirmed", "ready"];
+
+// The complement — every status is in exactly one of these two sets, so an
+// order can never fall out of both admin views (DEC-045). isTerminalStatus
+// and the Fulfilled-view filter both derive from this single list.
+export const TERMINAL_ORDER_STATUSES: OrderStatus[] = ["picked_up", "delivered"];
+
+// The no-regress auto-advance rule for confirm-sends (DEC-035): sending the
+// confirmation text moves a new order to confirmed, but must never regress a
+// ready/terminal order. Wired to the confirm-send action in the Orders-page
+// action stack (#192); lives here as a pure, testable helper.
+export function statusAfterConfirmSend(current: OrderStatus): OrderStatus {
+  return current === "new" ? "confirmed" : current;
+}
+
+// DEC-041: terminal = the box has been handed over. A terminal order drops
+// out of the open-order identity — /confirmed renders it read-only and the
+// next submission creates a fresh order. Takes raw text because orders.status
+// is app-enforced text in the DB (DEC-010) — customer-side reads arrive untyped.
+export function isTerminalStatus(status: string): boolean {
+  return (TERMINAL_ORDER_STATUSES as string[]).includes(status);
+}
+
+// DEC-035 (amends DEC-010): new → [confirmed] → ready → (picked_up | delivered).
+// Confirmed is optional — new → ready stays valid (Annabel may pack before
+// texting). Fulfillment type pins which terminal state is valid. Pure +
+// exported so advance-order-status.ts (a "use server" module, which can only
+// export async actions) can import it and tests can exercise the table.
+export function isValidTransition(
+  from: OrderStatus,
+  to: OrderStatus,
+  fulfillmentType: "pickup" | "delivery",
+): boolean {
+  if (from === "new" && to === "confirmed") return true;
+  if (from === "new" && to === "ready") return true;
+  if (from === "confirmed" && to === "ready") return true;
+  if (from === "ready" && to === "picked_up") return fulfillmentType === "pickup";
+  if (from === "ready" && to === "delivered") return fulfillmentType === "delivery";
+  return false;
+}
+
+export type OrderItem = {
+  productId: string;
+  name: string;
+  // DEC-043: Wave "Item Number" inputs for this line's unit. sku is
+  // Annabel-edited (matches her Wave catalog); slug is the generated
+  // fallback. The export resolves sku → slug → blank. products.description
+  // left this shape entirely — it's the customer-facing long description,
+  // nothing more.
+  sku: string | null;
+  slug: string | null;
+  // Product-level base unit label (the product_units row with
+  // conversion_to_base = 1.0, per DEC-037). Used where a per-product unit is
+  // needed (fulfillment report "total N <base>"); display surfaces should use
+  // unitLabel for per-line accuracy under multi-unit.
+  unit: string;
+  // 6.5f: per-line unit label resolved from product_units.label via
+  // order_items.product_unit_id. For single-unit products this matches `unit`;
+  // for multi-unit lines this is the unit the customer actually selected.
+  unitLabel: string;
+  // 6.5f: conversion factor for the line's unit. Used for unit-aware oversold
+  // math (qty * conversionToBase vs base qty_available).
+  conversionToBase: number;
+  qty: number;
+  unitPriceCents: number;
+  qtyAvailable: number;
+};
+
+export type OrderRow = {
+  id: string;
+  customerId: string;
+  customerName: string;
+  // Drives the per-order Send actions (#192). Null → "No phone" disabled state.
+  phone: string | null;
+  placedAt: string;
+  weekOf: string;
+  fulfillmentType: "pickup" | "delivery";
+  deliveryAddress: string | null;
+  deliveryPreference: string | null;
+  pickupNote: string | null;
+  notes: string | null;
+  status: OrderStatus;
+  needsReconciliation: boolean;
+  items: OrderItem[];
+  totalCents: number;
+  // Per-mode sent timestamps for this customer's current-week sends (#192).
+  // Null = not yet sent. Drives the Send/Re-send state in the action stack.
+  confirmSentAt: string | null;
+  reminderSentAt: string | null;
+};

--- a/src/lib/admin/orders-queries.ts
+++ b/src/lib/admin/orders-queries.ts
@@ -1,120 +1,20 @@
-// Admin order-list reads (Phase 5.1). Service-role client — admin only.
+// Admin order-list reads (Phase 5.1). Full-privilege pg reads — admin only.
+// The pure order-status domain (types, status sets, transition rules) lives
+// in order-status.ts so client components can import it without dragging pg
+// into the browser bundle; re-exported here for server-side callers.
 import { consolidateItems, consolidationKey } from "@/lib/order-items";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { query } from "@/lib/db";
+import {
+  OPEN_ORDER_STATUSES,
+  ORDER_STATUSES,
+  TERMINAL_ORDER_STATUSES,
+  type OrderItem,
+  type OrderRow,
+  type OrderStatus,
+} from "@/lib/admin/order-status";
 import { weekOfMondayNY } from "@/lib/week";
 
-// DEC-035 (amends DEC-010): new → [confirmed] → ready → (picked_up | delivered).
-// Confirmed is optional. Ordering matches codes.sort_order.
-// DEC-044: snake_case picked_up is canonical — matches the codes table row.
-export type OrderStatus =
-  | "new"
-  | "confirmed"
-  | "ready"
-  | "picked_up"
-  | "delivered";
-
-export const ORDER_STATUSES: OrderStatus[] = [
-  "new",
-  "confirmed",
-  "ready",
-  "picked_up",
-  "delivered",
-];
-
-// DEC-041: the open-order identity set. A customer has at most one order in
-// these statuses (partial unique index orders_one_open_per_customer); a
-// terminal order drops out and frees a new one. Keep this list identical to
-// the index predicate in the DEC-041 migration.
-export const OPEN_ORDER_STATUSES: OrderStatus[] = ["new", "confirmed", "ready"];
-
-// The complement — every status is in exactly one of these two sets, so an
-// order can never fall out of both admin views (DEC-045). isTerminalStatus
-// and the Fulfilled-view filter both derive from this single list.
-export const TERMINAL_ORDER_STATUSES: OrderStatus[] = ["picked_up", "delivered"];
-
-// The no-regress auto-advance rule for confirm-sends (DEC-035): sending the
-// confirmation text moves a new order to confirmed, but must never regress a
-// ready/terminal order. Wired to the confirm-send action in the Orders-page
-// action stack (#192); lives here as a pure, testable helper.
-export function statusAfterConfirmSend(current: OrderStatus): OrderStatus {
-  return current === "new" ? "confirmed" : current;
-}
-
-// DEC-041: terminal = the box has been handed over. A terminal order drops
-// out of the open-order identity — /confirmed renders it read-only and the
-// next submission creates a fresh order. Takes raw text because orders.status
-// is app-enforced text in the DB (DEC-010) — customer-side reads arrive untyped.
-export function isTerminalStatus(status: string): boolean {
-  return (TERMINAL_ORDER_STATUSES as string[]).includes(status);
-}
-
-// DEC-035 (amends DEC-010): new → [confirmed] → ready → (picked_up | delivered).
-// Confirmed is optional — new → ready stays valid (Annabel may pack before
-// texting). Fulfillment type pins which terminal state is valid. Pure +
-// exported so advance-order-status.ts (a "use server" module, which can only
-// export async actions) can import it and tests can exercise the table.
-export function isValidTransition(
-  from: OrderStatus,
-  to: OrderStatus,
-  fulfillmentType: "pickup" | "delivery",
-): boolean {
-  if (from === "new" && to === "confirmed") return true;
-  if (from === "new" && to === "ready") return true;
-  if (from === "confirmed" && to === "ready") return true;
-  if (from === "ready" && to === "picked_up") return fulfillmentType === "pickup";
-  if (from === "ready" && to === "delivered") return fulfillmentType === "delivery";
-  return false;
-}
-
-export type OrderItem = {
-  productId: string;
-  name: string;
-  // DEC-043: Wave "Item Number" inputs for this line's unit. sku is
-  // Annabel-edited (matches her Wave catalog); slug is the generated
-  // fallback. The export resolves sku → slug → blank. products.description
-  // left this shape entirely — it's the customer-facing long description,
-  // nothing more.
-  sku: string | null;
-  slug: string | null;
-  // Product-level base unit label (the product_units row with
-  // conversion_to_base = 1.0, per DEC-037). Used where a per-product unit is
-  // needed (fulfillment report "total N <base>"); display surfaces should use
-  // unitLabel for per-line accuracy under multi-unit.
-  unit: string;
-  // 6.5f: per-line unit label resolved from product_units.label via
-  // order_items.product_unit_id. For single-unit products this matches `unit`;
-  // for multi-unit lines this is the unit the customer actually selected.
-  unitLabel: string;
-  // 6.5f: conversion factor for the line's unit. Used for unit-aware oversold
-  // math (qty * conversionToBase vs base qty_available).
-  conversionToBase: number;
-  qty: number;
-  unitPriceCents: number;
-  qtyAvailable: number;
-};
-
-export type OrderRow = {
-  id: string;
-  customerId: string;
-  customerName: string;
-  // Drives the per-order Send actions (#192). Null → "No phone" disabled state.
-  phone: string | null;
-  placedAt: string;
-  weekOf: string;
-  fulfillmentType: "pickup" | "delivery";
-  deliveryAddress: string | null;
-  deliveryPreference: string | null;
-  pickupNote: string | null;
-  notes: string | null;
-  status: OrderStatus;
-  needsReconciliation: boolean;
-  items: OrderItem[];
-  totalCents: number;
-  // Per-mode sent timestamps for this customer's current-week sends (#192).
-  // Null = not yet sent. Drives the Send/Re-send state in the action stack.
-  confirmSentAt: string | null;
-  reminderSentAt: string | null;
-};
+export * from "@/lib/admin/order-status";
 
 function narrowStatus(s: string): OrderStatus {
   return (ORDER_STATUSES as string[]).includes(s) ? (s as OrderStatus) : "new";
@@ -155,58 +55,127 @@ export async function listFulfilledOrders(): Promise<OrderRow[]> {
 export async function countOrdersByStatus(
   statuses: OrderStatus[],
 ): Promise<number> {
-  const supabase = createAdminClient();
-  const { count, error } = await supabase
-    .from("orders")
-    .select("id", { count: "exact", head: true })
-    .in("status", statuses);
-  if (error) throw new Error(`countOrdersByStatus: ${error.message}`);
-  return count ?? 0;
+  const rows = await query<{ count: number }>(
+    `select count(*)::int as count from orders where status = any($1)`,
+    [statuses],
+  );
+  return rows[0].count;
 }
+
+// Row shape the SQL below builds — mirrors the old PostgREST embed so the
+// mapping code beneath is unchanged.
+type QueryOrdersRow = {
+  id: string;
+  customer_id: string;
+  created_at: string;
+  week_of: string;
+  fulfillment_type: string;
+  delivery_address: string | null;
+  delivery_preference: string | null;
+  pickup_note: string | null;
+  notes: string | null;
+  status: string;
+  needs_reconciliation: boolean;
+  customers: { id: string; name: string; phone: string | null } | null;
+  order_items: Array<{
+    product_id: string;
+    qty: number;
+    unit_price_cents: number;
+    products: {
+      name: string;
+      qty_available: number;
+      product_units: Array<{ label: string; conversion_to_base: number }>;
+    } | null;
+    product_units: {
+      label: string;
+      conversion_to_base: number;
+      sku: string | null;
+      slug: string | null;
+    } | null;
+  }>;
+};
 
 async function queryOrders(filter: {
   weekOf?: string;
   activeOnly?: boolean;
   terminalOnly?: boolean;
 }): Promise<OrderRow[]> {
-  const supabase = createAdminClient();
+  const where: string[] = [];
+  const params: unknown[] = [];
+  if (filter.weekOf) {
+    params.push(filter.weekOf);
+    where.push(`o.week_of = $${params.length}`);
+  }
+  if (filter.activeOnly) {
+    params.push(OPEN_ORDER_STATUSES);
+    where.push(`o.status = any($${params.length})`);
+  }
+  if (filter.terminalOnly) {
+    params.push(TERMINAL_ORDER_STATUSES);
+    where.push(`o.status = any($${params.length})`);
+  }
 
-  let ordersQuery = supabase
-    .from("orders")
-    .select(
-      `id, customer_id, created_at, week_of, fulfillment_type,
-       delivery_address, delivery_preference, pickup_note, notes,
-       status, needs_reconciliation,
-       customers(id, name, phone),
-       order_items(product_id, qty, unit_price_cents,
-         products(name, qty_available,
-           product_units(label, conversion_to_base)),
-         product_units(label, conversion_to_base, sku, slug))`,
-    )
-    .order("created_at", { ascending: false });
-  if (filter.weekOf) ordersQuery = ordersQuery.eq("week_of", filter.weekOf);
-  if (filter.activeOnly)
-    ordersQuery = ordersQuery.in("status", OPEN_ORDER_STATUSES);
-  if (filter.terminalOnly)
-    ordersQuery = ordersQuery.in("status", TERMINAL_ORDER_STATUSES);
-
-  const { data, error } = await ordersQuery;
-  if (error) throw new Error(`queryOrders: ${error.message}`);
+  const data = await query<QueryOrdersRow>(
+    `select o.id, o.customer_id, o.created_at, o.week_of, o.fulfillment_type,
+            o.delivery_address, o.delivery_preference, o.pickup_note, o.notes,
+            o.status, o.needs_reconciliation,
+            json_build_object('id', c.id, 'name', c.name, 'phone', c.phone) as customers,
+            coalesce(
+              json_agg(
+                json_build_object(
+                  'product_id', oi.product_id,
+                  'qty', oi.qty,
+                  'unit_price_cents', oi.unit_price_cents,
+                  'products', case when pr.id is null then null else json_build_object(
+                    'name', pr.name,
+                    'qty_available', pr.qty_available,
+                    'product_units', coalesce(
+                      (select json_agg(json_build_object(
+                                'label', u.label,
+                                'conversion_to_base', u.conversion_to_base))
+                         from product_units u where u.product_id = pr.id),
+                      '[]')
+                  ) end,
+                  'product_units', case when pu.id is null then null else json_build_object(
+                    'label', pu.label,
+                    'conversion_to_base', pu.conversion_to_base,
+                    'sku', pu.sku,
+                    'slug', pu.slug
+                  ) end
+                )
+                order by oi.created_at
+              ) filter (where oi.id is not null),
+              '[]'
+            ) as order_items
+       from orders o
+       join customers c on c.id = o.customer_id
+       left join order_items oi on oi.order_id = o.id
+       left join products pr on pr.id = oi.product_id
+       left join product_units pu on pu.id = oi.product_unit_id
+      ${where.length ? `where ${where.join(" and ")}` : ""}
+      group by o.id, c.id
+      order by o.created_at desc`,
+    params,
+  );
 
   // customer_sends stays week-keyed (DEC-042), so the Send state for each
   // order is the send row of the order's OWN week_of stamp. Fetched after the
   // orders because the active view can span weeks — the sends lookup needs
   // the set of weeks actually present.
-  const weeks = [...new Set((data ?? []).map((o) => o.week_of))];
-  const sendsResult =
+  const weeks = [...new Set(data.map((o) => o.week_of))];
+  const sendsRows =
     weeks.length === 0
-      ? { data: [], error: null }
-      : await supabase
-          .from("customer_sends")
-          .select("customer_id, week_of, mode, sent_at")
-          .in("week_of", weeks);
-  if (sendsResult.error)
-    throw new Error(`queryOrders(sends): ${sendsResult.error.message}`);
+      ? []
+      : await query<{
+          customer_id: string;
+          week_of: string;
+          mode: string;
+          sent_at: string;
+        }>(
+          `select customer_id, week_of, mode, sent_at
+             from customer_sends where week_of = any($1)`,
+          [weeks],
+        );
 
   // Reminder mode is per-fulfillment (#193): pickup orders use pickup_reminder,
   // delivery orders use delivery_reminder — tracked separately, resolved per
@@ -220,7 +189,7 @@ async function queryOrders(filter: {
   // customer can appear with sends in more than one week — the old per-
   // customer key silently merged them.
   const sentByCustomerWeek = new Map<string, SentEntry>();
-  for (const s of sendsResult.data ?? []) {
+  for (const s of sendsRows) {
     const key = `${s.customer_id}:${s.week_of}`;
     const entry = sentByCustomerWeek.get(key) ?? {
       confirm: null,
@@ -233,37 +202,17 @@ async function queryOrders(filter: {
     sentByCustomerWeek.set(key, entry);
   }
 
-  return (data ?? [])
+  return data
     .filter((o) => o.customers !== null)
     .map((o) => {
-      const c = o.customers as { id: string; name: string; phone: string | null };
+      const c = o.customers!;
       const sent = sentByCustomerWeek.get(`${c.id}:${o.week_of}`) ?? {
         confirm: null,
         pickupReminder: null,
         deliveryReminder: null,
       };
       const fulfillmentType = narrowFulfillment(o.fulfillment_type);
-      const items: OrderItem[] = ((o.order_items ?? []) as Array<{
-        product_id: string;
-        qty: number;
-        unit_price_cents: number;
-        products: {
-          name: string;
-          qty_available: number;
-          // The product's full unit set (reverse join). Only the base row
-          // (conversion_to_base = 1.0) is read here, for OrderItem.unit.
-          product_units: Array<{
-            label: string;
-            conversion_to_base: number;
-          }>;
-        } | null;
-        product_units: {
-          label: string;
-          conversion_to_base: number;
-          sku: string | null;
-          slug: string | null;
-        } | null;
-      }>)
+      const items: OrderItem[] = o.order_items
         .filter((i) => i.products !== null)
         .map((i) => {
           // DEC-037: the product-level unit is the base product_units row.

--- a/src/lib/admin/queries.ts
+++ b/src/lib/admin/queries.ts
@@ -1,41 +1,34 @@
 // Admin-side reads used to populate the shell chrome (nav badges, footer
-// status). Service-role client — these reads cross every tenant boundary
-// the shell shows. Never expose any of these to the client.
-import { createAdminClient } from "@/lib/supabase/admin";
+// status). Full-privilege pg reads — these cross every boundary the shell
+// shows. Server-only.
+import { query, queryOne } from "@/lib/db";
 import { weekOfMondayNY } from "@/lib/week";
 
 export async function getInventoryCount(): Promise<number> {
-  const supabase = createAdminClient();
-  const { count, error } = await supabase
-    .from("products")
-    .select("id", { count: "exact", head: true })
-    .eq("is_active", true)
-    .eq("is_available", true);
-  if (error) throw new Error(`getInventoryCount: ${error.message}`);
-  return count ?? 0;
+  const rows = await query<{ count: number }>(
+    `select count(*)::int as count from products
+      where is_active and is_available`,
+  );
+  return rows[0].count;
 }
 
 export async function getNewOrdersCount(): Promise<number> {
-  const supabase = createAdminClient();
-  const { count, error } = await supabase
-    .from("orders")
-    .select("id", { count: "exact", head: true })
-    .eq("status", "new")
-    .eq("week_of", weekOfMondayNY());
-  if (error) throw new Error(`getNewOrdersCount: ${error.message}`);
-  return count ?? 0;
+  const rows = await query<{ count: number }>(
+    `select count(*)::int as count from orders
+      where status = 'new' and week_of = $1`,
+    [weekOfMondayNY()],
+  );
+  return rows[0].count;
 }
 
 // ordering_schedule is a singleton (DEC-030 seeds one row; an is_singleton
-// unique-check constraint enforces it). .single() is intentional — if the
+// unique-check constraint enforces it). queryOne is intentional — if the
 // row ever goes missing, the admin shell 500s loudly, which is the right
 // signal vs silently defaulting to "open."
 export async function getOrderingOpen(): Promise<boolean> {
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("ordering_schedule")
-    .select("is_open")
-    .single();
-  if (error) throw new Error(`getOrderingOpen: ${error.message}`);
-  return data.is_open;
+  const row = await queryOne<{ is_open: boolean }>(
+    "getOrderingOpen",
+    `select is_open from ordering_schedule`,
+  );
+  return row.is_open;
 }

--- a/src/lib/admin/send-queue-queries.ts
+++ b/src/lib/admin/send-queue-queries.ts
@@ -1,8 +1,6 @@
-// Send-queue reads (Phase 4.2). Service-role admin reads — these enumerate
-// every customer in the system. RLS would also allow it (authenticated all-
-// access), but we use service role for consistency with the rest of the
-// admin queries.
-import { createAdminClient } from "@/lib/supabase/admin";
+// Send-queue reads (Phase 4.2). Full-privilege admin reads — these enumerate
+// every customer in the system. Server-only.
+import { query, queryOne } from "@/lib/db";
 import { weekOfMondayNY } from "@/lib/week";
 
 export type SendMode =
@@ -53,37 +51,35 @@ async function loadSendStateMap(
   weekOf: string,
   mode: SendMode,
 ): Promise<Map<string, string>> {
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("customer_sends")
-    .select("customer_id, sent_at")
-    .eq("week_of", weekOf)
-    .eq("mode", mode);
-  if (error) throw new Error(`loadSendStateMap: ${error.message}`);
-  return new Map((data ?? []).map((r) => [r.customer_id, r.sent_at]));
+  const rows = await query<{ customer_id: string; sent_at: string }>(
+    `select customer_id, sent_at from customer_sends
+      where week_of = $1 and mode = $2`,
+    [weekOf, mode],
+  );
+  return new Map(rows.map((r) => [r.customer_id, r.sent_at]));
 }
 
 // weekly_update queue: every active customer with send_weekly_link=true,
 // priority desc.
 export async function getWeeklyUpdateQueue(): Promise<SendQueueRow[]> {
-  const supabase = createAdminClient();
   const weekOf = weekOfMondayNY();
 
-  const [customersResult, sendMap] = await Promise.all([
-    supabase
-      .from("customers")
-      .select("id, name, phone, token, priority")
-      .eq("is_active", true)
-      .eq("send_weekly_link", true)
-      .order("priority", { ascending: false })
-      .order("name", { ascending: true }),
+  const [customers, sendMap] = await Promise.all([
+    query<{
+      id: string;
+      name: string;
+      phone: string | null;
+      token: string;
+      priority: number;
+    }>(
+      `select id, name, phone, token, priority from customers
+        where is_active and send_weekly_link
+        order by priority desc, name asc`,
+    ),
     loadSendStateMap(weekOf, "weekly_update"),
   ]);
 
-  if (customersResult.error)
-    throw new Error(`getWeeklyUpdateQueue: ${customersResult.error.message}`);
-
-  return (customersResult.data ?? []).map((c) => ({
+  return customers.map((c) => ({
     customerId: c.id,
     customerName: c.name,
     phone: c.phone,
@@ -96,16 +92,14 @@ export async function getWeeklyUpdateQueue(): Promise<SendQueueRow[]> {
   }));
 }
 
-// ordering_schedule is a singleton (DEC-030). Same .single() discipline as
+// ordering_schedule is a singleton (DEC-030). Same queryOne discipline as
 // getOrderingOpen — loud failure if the row goes missing.
 export async function getIntroNote(): Promise<string> {
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("ordering_schedule")
-    .select("intro_note")
-    .single();
-  if (error) throw new Error(`getIntroNote: ${error.message}`);
-  return data.intro_note ?? "";
+  const row = await queryOne<{ intro_note: string | null }>(
+    "getIntroNote",
+    `select intro_note from ordering_schedule`,
+  );
+  return row.intro_note ?? "";
 }
 
 // Count of weekly_update unsent for the current week — used by the admin
@@ -114,26 +108,19 @@ export async function getIntroNote(): Promise<string> {
 // handles. Runs on every admin page render via the layout, so we avoid the
 // full queue load: count subscribers, subtract sent rows for the week.
 export async function getWeeklyUpdateUnsentCount(): Promise<number> {
-  const supabase = createAdminClient();
   const weekOf = weekOfMondayNY();
 
   const [subscribers, sent] = await Promise.all([
-    supabase
-      .from("customers")
-      .select("id", { count: "exact", head: true })
-      .eq("is_active", true)
-      .eq("send_weekly_link", true),
-    supabase
-      .from("customer_sends")
-      .select("customer_id", { count: "exact", head: true })
-      .eq("week_of", weekOf)
-      .eq("mode", "weekly_update"),
+    query<{ count: number }>(
+      `select count(*)::int as count from customers
+        where is_active and send_weekly_link`,
+    ),
+    query<{ count: number }>(
+      `select count(*)::int as count from customer_sends
+        where week_of = $1 and mode = 'weekly_update'`,
+      [weekOf],
+    ),
   ]);
 
-  if (subscribers.error)
-    throw new Error(`getWeeklyUpdateUnsentCount(subscribers): ${subscribers.error.message}`);
-  if (sent.error)
-    throw new Error(`getWeeklyUpdateUnsentCount(sent): ${sent.error.message}`);
-
-  return Math.max(0, (subscribers.count ?? 0) - (sent.count ?? 0));
+  return Math.max(0, subscribers[0].count - sent[0].count);
 }

--- a/src/lib/customer/queries.ts
+++ b/src/lib/customer/queries.ts
@@ -132,6 +132,14 @@ export async function getOpenOrder(
      group by o.id`,
     [customerId, OPEN_ORDER_STATUSES],
   );
+  // The partial unique index guarantees at most one open order; 2+ rows means
+  // the invariant is broken — fail loud (same discipline .maybeSingle() had)
+  // rather than silently picking one.
+  if (rows.length > 1) {
+    throw new Error(
+      `getOpenOrder: ${rows.length} open orders for customer ${customerId} — orders_one_open_per_customer invariant violated`,
+    );
+  }
   return rows[0] ?? null;
 }
 

--- a/src/lib/customer/queries.ts
+++ b/src/lib/customer/queries.ts
@@ -1,15 +1,14 @@
-// Customer-side reads use the service-role admin client intentionally. The
-// token in the bbf_customer_token cookie is the authentication boundary;
-// once it resolves to a customer row, the rest of the customer-facing
-// queries bypass RLS by design. Don't "fix" these to the anon client —
-// the customer-side RLS policies key off `current_setting('app.customer_id')`
-// which we don't set, so anon reads return empty.
-import { OPEN_ORDER_STATUSES } from "@/lib/admin/orders-queries";
-import { createAdminClient } from "@/lib/supabase/admin";
-import type { Database } from "@/lib/supabase/types";
+// Customer-side reads. The token in the bbf_customer_token cookie is the
+// authentication boundary; once it resolves to a customer row, these queries
+// run with full DB privilege by design (DEC-048 — the service layer IS the
+// access boundary).
+import { OPEN_ORDER_STATUSES } from "@/lib/admin/order-status";
+import { query, queryOne } from "@/lib/db";
+import type { ProductUnitRow } from "@/lib/db-types";
+import type { ProductRow as BaseProductRow } from "@/lib/db-types";
 
-export type ProductUnitRow = Database["public"]["Tables"]["product_units"]["Row"];
-export type ProductRow = Database["public"]["Tables"]["products"]["Row"] & {
+export type { ProductUnitRow };
+export type ProductRow = BaseProductRow & {
   // Active units only, sorted by (sort_order nulls last, created_at). The base
   // unit (conversion_to_base = 1) is the implicit default for the customer
   // picker. 6.5a guarantees every product has at least one active unit.
@@ -17,34 +16,20 @@ export type ProductRow = Database["public"]["Tables"]["products"]["Row"] & {
 };
 
 export async function getAvailableProducts(): Promise<ProductRow[]> {
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("products")
-    .select("*, product_units(*)")
-    .eq("is_active", true)
-    .eq("is_available", true)
-    .order("sort_order", { ascending: true });
-  if (error) throw new Error(`getAvailableProducts: ${error.message}`);
-  if (!data) return [];
-  return data.map((row) => {
-    const allUnits = (row.product_units ?? []) as ProductUnitRow[];
-    const units = allUnits
-      .filter((u) => u.is_active)
-      .sort((a, b) => {
-        const ao = a.sort_order;
-        const bo = b.sort_order;
-        if (ao === null && bo === null) return a.created_at.localeCompare(b.created_at);
-        if (ao === null) return 1;
-        if (bo === null) return -1;
-        return ao - bo;
-      });
-    // Strip the raw join field so the returned row matches ProductRow exactly.
-    const { product_units: _product_units, ...rest } = row as typeof row & {
-      product_units: ProductUnitRow[];
-    };
-    void _product_units;
-    return { ...rest, units };
-  });
+  // Units are aggregated (active only, picker order) in SQL — the JSON path
+  // delivers numerics as numbers and timestamps as ISO strings already.
+  return query<ProductRow>(
+    `select p.*,
+            coalesce(
+              (select json_agg(to_json(pu) order by pu.sort_order nulls last, pu.created_at)
+                 from product_units pu
+                where pu.product_id = p.id and pu.is_active),
+              '[]'
+            ) as units
+       from products p
+      where p.is_active and p.is_available
+      order by p.sort_order asc`,
+  );
 }
 
 // 6.5d: orderable means at least one active unit fits in current base
@@ -60,72 +45,94 @@ export function anyOrderable(products: ProductRow[]): boolean {
 
 // Reads the ordering_schedule singleton. Customer page uses this to decide
 // between the open form, the manual-closed shell, and the all-sold-out shell
-// (DEC-031). DEC-030 guarantees a single row exists — .single() lets a
+// (DEC-031). DEC-030 guarantees a single row exists — queryOne lets a
 // missing row surface as a real error rather than silently defaulting.
 export async function getOrderingScheduleStatus(): Promise<{ is_open: boolean }> {
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("ordering_schedule")
-    .select("is_open")
-    .single();
-  if (error) throw new Error(`getOrderingScheduleStatus: ${error.message}`);
-  return { is_open: data.is_open };
+  return queryOne<{ is_open: boolean }>(
+    "getOrderingScheduleStatus",
+    `select is_open from ordering_schedule`,
+  );
 }
 
 export async function getLatestDeliveryPreference(
   customerId: string,
 ): Promise<string | null> {
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("orders")
-    .select("delivery_preference")
-    .eq("customer_id", customerId)
-    .eq("fulfillment_type", "delivery")
-    .not("delivery_preference", "is", null)
-    .order("created_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
-  if (error) throw new Error(`getLatestDeliveryPreference: ${error.message}`);
-  return data?.delivery_preference ?? null;
+  const rows = await query<{ delivery_preference: string }>(
+    `select delivery_preference
+       from orders
+      where customer_id = $1
+        and fulfillment_type = 'delivery'
+        and delivery_preference is not null
+      order by created_at desc
+      limit 1`,
+    [customerId],
+  );
+  return rows[0]?.delivery_preference ?? null;
 }
 
-// Shared join for the customer-facing order reads: line items + product
-// names + per-line unit labels (product_units, DEC-037).
+// Shared shape for the customer-facing order reads: line items + product
+// names + per-line unit labels (product_units, DEC-037). Field names mirror
+// the old PostgREST embed so consumers are unchanged.
+export type CustomerOrder = {
+  id: string;
+  week_of: string;
+  fulfillment_type: string;
+  delivery_address: string | null;
+  delivery_preference: string | null;
+  pickup_note: string | null;
+  notes: string | null;
+  status: string;
+  created_at: string;
+  order_items: Array<{
+    id: string;
+    product_id: string;
+    qty: number;
+    unit_price_cents: number;
+    products: { name: string } | null;
+    product_units: { label: string } | null;
+  }>;
+};
+
 const CUSTOMER_ORDER_SELECT = `
-  id,
-  week_of,
-  fulfillment_type,
-  delivery_address,
-  delivery_preference,
-  pickup_note,
-  notes,
-  status,
-  created_at,
-  order_items (
-    id,
-    product_id,
-    qty,
-    unit_price_cents,
-    products ( name ),
-    product_units ( label )
-  )
-` as const;
+  select o.id, o.week_of, o.fulfillment_type, o.delivery_address,
+         o.delivery_preference, o.pickup_note, o.notes, o.status, o.created_at,
+         coalesce(
+           json_agg(
+             json_build_object(
+               'id', oi.id,
+               'product_id', oi.product_id,
+               'qty', oi.qty,
+               'unit_price_cents', oi.unit_price_cents,
+               'products', case when pr.id is null then null
+                                else json_build_object('name', pr.name) end,
+               'product_units', case when pu.id is null then null
+                                     else json_build_object('label', pu.label) end
+             )
+             order by oi.created_at
+           ) filter (where oi.id is not null),
+           '[]'
+         ) as order_items
+    from orders o
+    left join order_items oi on oi.order_id = o.id
+    left join products pr on pr.id = oi.product_id
+    left join product_units pu on pu.id = oi.product_unit_id
+`;
 
 // DEC-041 (#227): the customer's OPEN order — the one non-terminal order the
 // partial unique index guarantees (at most one of new/confirmed/ready).
 // Replaces the week-keyed getCurrentWeekOrder: identity is the open order,
 // week_of is just a stamp. /c/[token] renders this order editable
 // (pre-populated add mode); null means the customer is free to start fresh.
-export async function getOpenOrder(customerId: string) {
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("orders")
-    .select(CUSTOMER_ORDER_SELECT)
-    .eq("customer_id", customerId)
-    .in("status", OPEN_ORDER_STATUSES)
-    .maybeSingle();
-  if (error) throw new Error(`getOpenOrder: ${error.message}`);
-  return data ?? null;
+export async function getOpenOrder(
+  customerId: string,
+): Promise<CustomerOrder | null> {
+  const rows = await query<CustomerOrder>(
+    `${CUSTOMER_ORDER_SELECT}
+     where o.customer_id = $1 and o.status = any($2)
+     group by o.id`,
+    [customerId, OPEN_ORDER_STATUSES],
+  );
+  return rows[0] ?? null;
 }
 
 // The customer's most recent order in ANY status. /confirmed renders this as
@@ -133,15 +140,16 @@ export async function getOpenOrder(customerId: string) {
 // read-only with a "place a new order" path (DEC-042 — orders are only ever
 // created open and move forward, so the newest row is the open order
 // whenever one exists).
-export async function getLatestOrder(customerId: string) {
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("orders")
-    .select(CUSTOMER_ORDER_SELECT)
-    .eq("customer_id", customerId)
-    .order("created_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
-  if (error) throw new Error(`getLatestOrder: ${error.message}`);
-  return data ?? null;
+export async function getLatestOrder(
+  customerId: string,
+): Promise<CustomerOrder | null> {
+  const rows = await query<CustomerOrder>(
+    `${CUSTOMER_ORDER_SELECT}
+     where o.customer_id = $1
+     group by o.id
+     order by o.created_at desc
+     limit 1`,
+    [customerId],
+  );
+  return rows[0] ?? null;
 }

--- a/src/lib/customer/session.ts
+++ b/src/lib/customer/session.ts
@@ -1,12 +1,12 @@
-import { createAdminClient } from "@/lib/supabase/admin";
-import type { Database } from "@/lib/supabase/types";
+import { query } from "@/lib/db";
+import type { CustomerRow } from "@/lib/db-types";
 
 export const CUSTOMER_TOKEN_COOKIE = "bbf_customer_token";
 
 // 1 year. Token rotation (admin Regenerate) invalidates server-side on next lookup.
 export const CUSTOMER_TOKEN_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
 
-export type Customer = Database["public"]["Tables"]["customers"]["Row"];
+export type Customer = CustomerRow;
 
 // Returns the matching customer row regardless of is_active or
 // send_weekly_link state. Callers branch on those flags themselves —
@@ -20,11 +20,9 @@ export async function lookupCustomerByToken(
   token: string | undefined,
 ): Promise<Customer | null> {
   if (!token) return null;
-  const supabase = createAdminClient();
-  const { data } = await supabase
-    .from("customers")
-    .select("*")
-    .eq("token", token)
-    .maybeSingle();
-  return data ?? null;
+  const rows = await query<Customer>(
+    `select * from customers where token = $1`,
+    [token],
+  );
+  return rows[0] ?? null;
 }

--- a/src/lib/db-types.ts
+++ b/src/lib/db-types.ts
@@ -1,0 +1,61 @@
+// Plain row types for the pg data layer (DEC-046). These replace the
+// generated supabase Database["public"]["Tables"][...]["Row"] types —
+// hand-maintained against db/migrations/0001_init.sql (+ later migrations).
+// Timestamps arrive as ISO strings, dates as 'YYYY-MM-DD', numerics as
+// numbers (see the type parsers in src/lib/db.ts).
+
+export type CustomerRow = {
+  id: string;
+  name: string;
+  business_name: string | null;
+  phone: string | null;
+  email: string | null;
+  token: string;
+  delivery_address: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+  send_weekly_link: boolean;
+  priority: number;
+};
+
+export type ProductRow = {
+  id: string;
+  name: string;
+  description: string | null;
+  qty_available: number;
+  is_available: boolean;
+  sort_order: number | null;
+  created_at: string;
+  updated_at: string;
+  category: string;
+  is_active: boolean;
+};
+
+export type ProductUnitRow = {
+  id: string;
+  product_id: string;
+  label: string;
+  conversion_to_base: number;
+  unit_price_cents: number;
+  is_active: boolean;
+  slug: string;
+  sort_order: number | null;
+  created_at: string;
+  updated_at: string;
+  sku: string | null;
+};
+
+export type OrderingScheduleRow = {
+  id: string;
+  is_singleton: boolean;
+  is_open: boolean;
+  weekly_open_day: number | null;
+  weekly_open_time: string | null;
+  weekly_close_day: number | null;
+  weekly_close_time: string | null;
+  override_closes_at: string | null;
+  created_at: string;
+  updated_at: string;
+  intro_note: string | null;
+};

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,7 +1,8 @@
 // pg Pool (DEC-046). One pool per server process, connection string from
 // DATABASE_URL: Neon pooled endpoint in hosted envs (per-scope in Vercel,
 // DEC-049 — Preview entries must apply to ALL preview branches, or previews
-// silently fall back to the localhost default below and 500 on every query),
+// silently fall back to the localhost default below and 500 on every query;
+// a malformed pasted value surfaces as ENOTFOUND on a nonsense hostname),
 // the docker compose service locally/CI. Never a prod default — prod writes
 // are explicit-arg only (db/migrate.ts).
 import pg from "pg";

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,54 @@
+// pg Pool (DEC-046). One pool per server process, connection string from
+// DATABASE_URL: Neon pooled endpoint in hosted envs (per-scope in Vercel,
+// DEC-049), the docker compose service locally/CI. Never a prod default —
+// prod writes are explicit-arg only (db/migrate.ts).
+import pg from "pg";
+
+// Match the JSON shapes supabase-js returned so downstream code is unchanged:
+// - numeric → number (qty_available / conversion_to_base arithmetic)
+// - timestamptz → ISO string (created_at sorts lexicographically in the UI)
+// - date → 'YYYY-MM-DD' string (week_of is used as a map key)
+// Values nested inside json_agg/json_build_object come back through JSON and
+// already have these shapes; the parsers cover top-level columns.
+pg.types.setTypeParser(pg.types.builtins.NUMERIC, parseFloat);
+pg.types.setTypeParser(pg.types.builtins.TIMESTAMPTZ, (v) =>
+  new Date(v).toISOString(),
+);
+pg.types.setTypeParser(pg.types.builtins.DATE, (v) => v);
+
+const globalForDb = globalThis as unknown as { pgPool?: pg.Pool };
+
+// next dev hot-reloads modules; reuse the pool across reloads or local dev
+// leaks connections until Neon's cap.
+export const pool =
+  globalForDb.pgPool ??
+  new pg.Pool({
+    connectionString:
+      process.env.DATABASE_URL ??
+      "postgres://bushel:bushel@localhost:5433/bushel_dev",
+    max: 5,
+  });
+if (process.env.NODE_ENV !== "production") globalForDb.pgPool = pool;
+
+// Thin helper for the common case — rows only.
+export async function query<T extends pg.QueryResultRow = pg.QueryResultRow>(
+  text: string,
+  params?: unknown[],
+): Promise<T[]> {
+  const res = await pool.query<T>(text, params as never[]);
+  return res.rows;
+}
+
+// Exactly-one-row reads (singletons, counts). Throws with the caller's label
+// when the row is missing — same loud-failure discipline as .single() had.
+export async function queryOne<T extends pg.QueryResultRow>(
+  label: string,
+  text: string,
+  params?: unknown[],
+): Promise<T> {
+  const rows = await query<T>(text, params);
+  if (rows.length !== 1) {
+    throw new Error(`${label}: expected 1 row, got ${rows.length}`);
+  }
+  return rows[0];
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,7 +1,9 @@
 // pg Pool (DEC-046). One pool per server process, connection string from
 // DATABASE_URL: Neon pooled endpoint in hosted envs (per-scope in Vercel,
-// DEC-049), the docker compose service locally/CI. Never a prod default —
-// prod writes are explicit-arg only (db/migrate.ts).
+// DEC-049 — Preview entries must apply to ALL preview branches, or previews
+// silently fall back to the localhost default below and 500 on every query),
+// the docker compose service locally/CI. Never a prod default — prod writes
+// are explicit-arg only (db/migrate.ts).
 import pg from "pg";
 
 // Match the JSON shapes supabase-js returned so downstream code is unchanged:

--- a/src/lib/fulfillment/link.ts
+++ b/src/lib/fulfillment/link.ts
@@ -1,18 +1,16 @@
-// Public harvest-sheet link token (#195). The token lives in the admin-only
-// fulfillment_link singleton; both reads here go through the service-role
-// client, which bypasses RLS — the same pattern as customer token lookup.
-import { createAdminClient } from "@/lib/supabase/admin";
+// Public harvest-sheet link token (#195). The token lives in the
+// fulfillment_link singleton; the service layer resolves it (DEC-048) — the
+// same pattern as customer token lookup.
+import { query, queryOne } from "@/lib/db";
 
 // The current public report token. Used server-side to build the link Annabel
 // opens / copies from /admin/orders.
 export async function getFulfillmentToken(): Promise<string> {
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("fulfillment_link")
-    .select("token")
-    .single();
-  if (error) throw new Error(`getFulfillmentToken: ${error.message}`);
-  return data.token;
+  const row = await queryOne<{ token: string }>(
+    "getFulfillmentToken",
+    `select token from fulfillment_link`,
+  );
+  return row.token;
 }
 
 // The token is a UUID. Shape-check before any DB call so scanner traffic
@@ -29,12 +27,9 @@ export async function isValidFulfillmentToken(
   token: string | undefined,
 ): Promise<boolean> {
   if (!token || !UUID_RE.test(token)) return false;
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("fulfillment_link")
-    .select("token")
-    .eq("token", token)
-    .maybeSingle();
-  if (error) throw new Error(`isValidFulfillmentToken: ${error.message}`);
-  return data !== null;
+  const rows = await query<{ token: string }>(
+    `select token from fulfillment_link where token = $1`,
+    [token],
+  );
+  return rows.length > 0;
 }

--- a/src/lib/pg-errors.ts
+++ b/src/lib/pg-errors.ts
@@ -1,0 +1,16 @@
+// Small helpers for surfacing pg errors in Server Actions, which return
+// { error: string } instead of throwing (the app's error contract).
+
+export function pgMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+export function pgCode(e: unknown): string | undefined {
+  return typeof e === "object" && e !== null && "code" in e
+    ? String((e as { code: unknown }).code)
+    : undefined;
+}
+
+// Postgres error codes the actions branch on.
+export const UNIQUE_VIOLATION = "23505";
+export const FOREIGN_KEY_VIOLATION = "23503";

--- a/tests/admin-base-unit.spec.ts
+++ b/tests/admin-base-unit.spec.ts
@@ -2,11 +2,11 @@ import { test, expect, type Page } from "@playwright/test";
 import {
   ADMIN_STORAGE_STATE,
   TEST_PRODUCTS,
-  admin,
   resetProductUnits,
   setProductQty,
   setProductUnits,
 } from "./helpers";
+import { query } from "@/lib/db";
 
 // #208 (DEC-038) — changeable base unit. "Make base" on a non-base unit row
 // opens a confirm modal; confirming calls the atomic set_base_unit RPC, which
@@ -75,26 +75,29 @@ test.describe("admin inventory · make base unit", () => {
 
     // DB: per lb is now 1.0, bunch rescaled to 2.0, stock 10 / 0.5 = 20,
     // prices untouched, new base sorts first.
-    const sb = admin();
-    const { data: units } = await sb
-      .from("product_units")
-      .select("label, conversion_to_base, unit_price_cents, sort_order")
-      .eq("product_id", KALE.id)
-      .order("sort_order");
+    const units = await query<{
+      label: string;
+      conversion_to_base: number;
+      unit_price_cents: number;
+      sort_order: number;
+    }>(
+      `select label, conversion_to_base, unit_price_cents, sort_order
+         from product_units where product_id = $1 order by sort_order`,
+      [KALE.id],
+    );
     expect(units).toHaveLength(2);
-    expect(units![0].label).toBe("per lb");
-    expect(Number(units![0].conversion_to_base)).toBe(1);
-    expect(units![0].unit_price_cents).toBe(800);
-    expect(units![1].label).toBe(KALE.unit);
-    expect(Number(units![1].conversion_to_base)).toBe(2);
-    expect(units![1].unit_price_cents).toBe(KALE.price_cents);
+    expect(units[0].label).toBe("per lb");
+    expect(Number(units[0].conversion_to_base)).toBe(1);
+    expect(units[0].unit_price_cents).toBe(800);
+    expect(units[1].label).toBe(KALE.unit);
+    expect(Number(units[1].conversion_to_base)).toBe(2);
+    expect(units[1].unit_price_cents).toBe(KALE.price_cents);
 
-    const { data: product } = await sb
-      .from("products")
-      .select("qty_available")
-      .eq("id", KALE.id)
-      .single();
-    expect(Number(product!.qty_available)).toBe(20);
+    const products = await query<{ qty_available: number }>(
+      `select qty_available from products where id = $1`,
+      [KALE.id],
+    );
+    expect(Number(products[0]!.qty_available)).toBe(20);
 
     // Reload + reopen: the drawer now badges "per lb" as base, and the inline
     // row's unit cell follows (it mirrors the base unit per DEC-037).
@@ -118,14 +121,12 @@ test.describe("admin inventory · make base unit", () => {
     await expect(confirmModal(page)).toBeHidden();
     await expect(drawer(page)).toBeVisible();
 
-    const sb = admin();
-    const { data } = await sb
-      .from("product_units")
-      .select("conversion_to_base")
-      .eq("product_id", KALE.id)
-      .eq("label", "per lb")
-      .single();
-    expect(Number(data!.conversion_to_base)).toBe(0.5);
+    const rows = await query<{ conversion_to_base: number }>(
+      `select conversion_to_base from product_units
+        where product_id = $1 and label = $2`,
+      [KALE.id, "per lb"],
+    );
+    expect(Number(rows[0]!.conversion_to_base)).toBe(0.5);
   });
 
   test("make base is gated while the drawer has unsaved edits", async ({ page }) => {

--- a/tests/admin-customers.spec.ts
+++ b/tests/admin-customers.spec.ts
@@ -2,30 +2,27 @@ import { test, expect, type Page } from "@playwright/test";
 import {
   ADMIN_STORAGE_STATE,
   TEST_CUSTOMERS,
-  admin,
 } from "./helpers";
+import { query } from "@/lib/db";
 
 async function resetTestCustomers() {
-  const supabase = admin();
-  for (const token of [TEST_CUSTOMERS.farmStand.token, TEST_CUSTOMERS.restaurant.token]) {
-    await supabase
-      .from("customers")
-      .update({
-        business_name: null,
-        email: null,
-        phone: null,
-        delivery_address: null,
-        is_active: true,
-        send_weekly_link: true,
-        priority: 100,
-      })
-      .eq("token", token);
+  const seedTokens = [TEST_CUSTOMERS.farmStand.token, TEST_CUSTOMERS.restaurant.token];
+  for (const token of seedTokens) {
+    await query(
+      `update customers
+          set business_name = null,
+              email = null,
+              phone = null,
+              delivery_address = null,
+              is_active = true,
+              send_weekly_link = true,
+              priority = 100
+        where token = $1`,
+      [token],
+    );
   }
   // Drop any non-seed customers created by tests
-  await supabase
-    .from("customers")
-    .delete()
-    .not("token", "in", `(${[TEST_CUSTOMERS.farmStand.token, TEST_CUSTOMERS.restaurant.token].map((t) => `"${t}"`).join(",")})`);
+  await query(`delete from customers where token <> all($1)`, [seedTokens]);
 }
 
 function rowByName(page: Page, name: string) {
@@ -81,8 +78,10 @@ test.describe("admin customers", () => {
 
   test("Hide customer deactivates and drops the row from the list", async ({ page }) => {
     // Seed phone so beforeEach-cleaned customer can be edited
-    const supabase = admin();
-    await supabase.from("customers").update({ phone: "216-555-0100" }).eq("token", TEST_CUSTOMERS.restaurant.token);
+    await query(`update customers set phone = $1 where token = $2`, [
+      "216-555-0100",
+      TEST_CUSTOMERS.restaurant.token,
+    ]);
 
     await page.goto("/admin/customers");
     await rowByName(page, TEST_CUSTOMERS.restaurant.name).click();
@@ -108,7 +107,6 @@ test.describe("admin customers", () => {
   });
 
   test("Regenerate rotates the customer token and refreshes the row", async ({ page }) => {
-    const supabase = admin();
     const seedToken = TEST_CUSTOMERS.restaurant.token;
 
     try {
@@ -133,10 +131,10 @@ test.describe("admin customers", () => {
       expect(newToken).not.toBe(seedToken);
     } finally {
       // Restore the seed token so subsequent tests + global-setup upsert behave.
-      await supabase
-        .from("customers")
-        .update({ token: seedToken })
-        .eq("name", TEST_CUSTOMERS.restaurant.name);
+      await query(`update customers set token = $1 where name = $2`, [
+        seedToken,
+        TEST_CUSTOMERS.restaurant.name,
+      ]);
     }
   });
 
@@ -176,17 +174,15 @@ test.describe("admin customers", () => {
     // Wait for the server action's round-trip to persist before reloading —
     // otherwise on slow projects (mobile WebKit) the reload can race and read
     // the pre-toggle DB row.
-    const supabase = admin();
     const expectedFlipped = initial === "true" ? false : true;
     await expect
       .poll(
         async () => {
-          const { data } = await supabase
-            .from("customers")
-            .select("send_weekly_link")
-            .eq("token", TEST_CUSTOMERS.farmStand.token)
-            .single();
-          return data?.send_weekly_link ?? null;
+          const rows = await query<{ send_weekly_link: boolean }>(
+            `select send_weekly_link from customers where token = $1`,
+            [TEST_CUSTOMERS.farmStand.token],
+          );
+          return rows[0]?.send_weekly_link ?? null;
         },
         { timeout: 5000 },
       )
@@ -206,11 +202,9 @@ test.describe("admin customers", () => {
   // beforeEach (resetTestCustomers) restores is_active=true on both seed rows
   // so the bare hide doesn't leak.
   test("Show hidden reveals inactive rows; drawer Restore restores them", async ({ page }) => {
-    const supabase = admin();
-    await supabase
-      .from("customers")
-      .update({ is_active: false })
-      .eq("token", TEST_CUSTOMERS.restaurant.token);
+    await query(`update customers set is_active = false where token = $1`, [
+      TEST_CUSTOMERS.restaurant.token,
+    ]);
 
     await page.goto("/admin/customers");
 

--- a/tests/admin-inventory-units.spec.ts
+++ b/tests/admin-inventory-units.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from "@playwright/test";
-import { ADMIN_STORAGE_STATE, TEST_PRODUCTS, admin, resetProductUnits } from "./helpers";
+import { ADMIN_STORAGE_STATE, TEST_PRODUCTS, resetProductUnits } from "./helpers";
+import { query } from "@/lib/db";
 
 // Per-product Units drawer (#152). The drawer opens from the units chip in
 // each row's unit cell. The 6.5a safety-net trigger gives every product a
@@ -73,9 +74,18 @@ test.describe("admin inventory · units drawer", () => {
     await expect(c).toHaveClass(/is-multi/);
 
     // verify persisted via DB
-    const sb = admin();
-    const { data } = await sb.from("product_units").select("label, unit_price_cents, conversion_to_base, is_active, sku").eq("product_id", KALE.id);
-    const extra = data?.find((u) => u.label === "per lb");
+    const data = await query<{
+      label: string;
+      unit_price_cents: number;
+      conversion_to_base: number;
+      is_active: boolean;
+      sku: string | null;
+    }>(
+      `select label, unit_price_cents, conversion_to_base, is_active, sku
+         from product_units where product_id = $1`,
+      [KALE.id],
+    );
+    const extra = data.find((u) => u.label === "per lb");
     expect(extra).toBeTruthy();
     expect(extra?.unit_price_cents).toBe(800);
     expect(Number(extra?.conversion_to_base)).toBe(0.5);
@@ -85,15 +95,19 @@ test.describe("admin inventory · units drawer", () => {
 
   test("inactive unit is reflected in chip subtext", async ({ page }) => {
     // seed an extra unit, then deactivate it via the drawer
-    const sb = admin();
-    await sb.from("product_units").insert({
-      product_id: EGGS.id,
-      label: "per half-dozen",
-      conversion_to_base: 0.5,
-      unit_price_cents: 350,
-      is_active: true,
-      slug: `eggs-per-half-dozen-${EGGS.id.slice(0, 8)}`,
-    });
+    await query(
+      `insert into product_units
+         (product_id, label, conversion_to_base, unit_price_cents, is_active, slug)
+       values ($1, $2, $3, $4, $5, $6)`,
+      [
+        EGGS.id,
+        "per half-dozen",
+        0.5,
+        350,
+        true,
+        `eggs-per-half-dozen-${EGGS.id.slice(0, 8)}`,
+      ],
+    );
 
     await page.goto("/admin/inventory");
     await expect(chip(page, EGGS.name)).toContainText(/2\s*units/);
@@ -110,15 +124,19 @@ test.describe("admin inventory · units drawer", () => {
   });
 
   test("remove a non-base unit", async ({ page }) => {
-    const sb = admin();
-    await sb.from("product_units").insert({
-      product_id: KALE.id,
-      label: "per lb",
-      conversion_to_base: 0.25,
-      unit_price_cents: 1200,
-      is_active: true,
-      slug: `kale-per-lb-${KALE.id.slice(0, 8)}`,
-    });
+    await query(
+      `insert into product_units
+         (product_id, label, conversion_to_base, unit_price_cents, is_active, slug)
+       values ($1, $2, $3, $4, $5, $6)`,
+      [
+        KALE.id,
+        "per lb",
+        0.25,
+        1200,
+        true,
+        `kale-per-lb-${KALE.id.slice(0, 8)}`,
+      ],
+    );
 
     await page.goto("/admin/inventory");
     await chip(page, KALE.name).click();

--- a/tests/admin-orders-export.spec.ts
+++ b/tests/admin-orders-export.spec.ts
@@ -4,11 +4,11 @@ import {
   ADMIN_STORAGE_STATE,
   TEST_CUSTOMERS,
   TEST_PRODUCTS,
-  admin,
   customerIds,
   clearOrdersForWeek,
   seedOrder,
 } from "./helpers";
+import { query } from "@/lib/db";
 import { weekOfMondayNY } from "@/lib/week";
 import {
   EXPORT_COLUMNS,
@@ -206,7 +206,10 @@ test.describe("admin orders export — UI", () => {
   // DEC-043: Item Number comes from the line's unit sku (→ slug fallback).
   // Set a sku for the download test's non-fallback path; restored in afterEach.
   async function setUnitSku(productId: string, sku: string | null): Promise<void> {
-    await admin().from("product_units").update({ sku }).eq("product_id", productId);
+    await query(`update product_units set sku = $1 where product_id = $2`, [
+      sku,
+      productId,
+    ]);
   }
 
   test.afterEach(async () => {

--- a/tests/admin-orders.spec.ts
+++ b/tests/admin-orders.spec.ts
@@ -4,12 +4,12 @@ import {
   ADMIN_STORAGE_STATE,
   TEST_CUSTOMERS,
   TEST_PRODUCTS,
-  admin,
   customerIds,
   clearOrdersForWeek,
   seedOrder,
   setProductQty,
 } from "./helpers";
+import { query } from "@/lib/db";
 import { shiftWeek, weekOfMondayNY } from "@/lib/week";
 import type { Locator } from "@playwright/test";
 
@@ -41,7 +41,7 @@ test.describe("admin orders list", () => {
     await clearOrdersForWeek(thisWeek);
     // Clear the week's sends so the action-stack Send buttons start at "Send"
     // (not "Re-send") regardless of prior-test/prior-run send state.
-    await admin().from("customer_sends").delete().eq("week_of", thisWeek);
+    await query(`delete from customer_sends where week_of = $1`, [thisWeek]);
   });
 
   test.afterAll(async () => {
@@ -196,8 +196,6 @@ test.describe("admin orders list", () => {
     await expect(row).toHaveAttribute("data-status", "new");
     await expandRow(row);
 
-    const sb = admin();
-
     await detailRowFor(row, orderId).getByRole("button", { name: /mark ready/i }).click();
     await expect(row).toHaveAttribute("data-status", "ready", { timeout: 5000 });
     // Wait for first transition to commit to DB before chaining the next click.
@@ -206,8 +204,11 @@ test.describe("admin orders list", () => {
     await expect
       .poll(
         async () => {
-          const { data } = await sb.from("orders").select("status").eq("id", orderId).single();
-          return data?.status ?? null;
+          const rows = await query<{ status: string }>(
+            `select status from orders where id = $1`,
+            [orderId],
+          );
+          return rows[0]?.status ?? null;
         },
         { timeout: 5000 },
       )
@@ -220,8 +221,11 @@ test.describe("admin orders list", () => {
     await expect
       .poll(
         async () => {
-          const { data } = await sb.from("orders").select("status").eq("id", orderId).single();
-          return data?.status ?? null;
+          const rows = await query<{ status: string }>(
+            `select status from orders where id = $1`,
+            [orderId],
+          );
+          return rows[0]?.status ?? null;
         },
         { timeout: 5000 },
       )
@@ -281,16 +285,14 @@ test.describe("admin orders list", () => {
     await expect(row).toHaveAttribute("data-status", "picked_up", { timeout: 5000 });
 
     // DB confirmation
-    const sb = admin();
     await expect
       .poll(
         async () => {
-          const { data } = await sb
-            .from("orders")
-            .select("status")
-            .eq("id", orderId)
-            .single();
-          return data?.status ?? null;
+          const rows = await query<{ status: string }>(
+            `select status from orders where id = $1`,
+            [orderId],
+          );
+          return rows[0]?.status ?? null;
         },
         { timeout: 5000 },
       )
@@ -312,10 +314,10 @@ test.describe("admin orders list", () => {
       items: [{ productId: TEST_PRODUCTS.kale.id, qty: 1, unitPriceCents: 300 }],
     });
     // The Confirm/Send link only renders with a phone on file (else "No phone").
-    await admin()
-      .from("customers")
-      .update({ phone: "2165550100" })
-      .eq("id", ids.restaurant);
+    await query(`update customers set phone = $1 where id = $2`, [
+      "2165550100",
+      ids.restaurant,
+    ]);
 
     await page.goto("/admin/orders");
 
@@ -448,7 +450,6 @@ test.describe("admin orders list", () => {
 
   test("expand row reveals line items, customer note, and reconciliation callout", async ({ page }) => {
     const ids = await customerIds();
-    const sb = admin();
     const orderId = await seedOrder({
       customerId: ids.farmStand,
       weekOf: thisWeek,
@@ -456,10 +457,10 @@ test.describe("admin orders list", () => {
       needsReconciliation: true,
       items: [{ productId: TEST_PRODUCTS.kale.id, qty: 4, unitPriceCents: 300 }],
     });
-    await sb
-      .from("orders")
-      .update({ notes: "Front gate is sticky — knock twice." })
-      .eq("id", orderId);
+    await query(`update orders set notes = $1 where id = $2`, [
+      "Front gate is sticky — knock twice.",
+      orderId,
+    ]);
 
     await page.goto("/admin/orders");
     const row = page.locator(`tr.ord-row[data-order-id="${orderId}"]`);

--- a/tests/admin-send.spec.ts
+++ b/tests/admin-send.spec.ts
@@ -3,37 +3,35 @@ import { test, expect } from "@playwright/test";
 import {
   ADMIN_STORAGE_STATE,
   TEST_CUSTOMERS,
-  admin,
   customerIds,
 } from "./helpers";
+import { query } from "@/lib/db";
 import { weekOfMondayNY } from "@/lib/week";
 
 async function clearSends(): Promise<void> {
-  const sb = admin();
   const weekOf = weekOfMondayNY();
-  await sb.from("customer_sends").delete().eq("week_of", weekOf);
+  await query(`delete from customer_sends where week_of = $1`, [weekOf]);
 }
 
 async function clearIntroNote(): Promise<void> {
-  const sb = admin();
-  await sb.from("ordering_schedule").update({ intro_note: null }).eq("is_singleton", true);
+  await query(
+    `update ordering_schedule set intro_note = null where is_singleton = true`,
+  );
 }
 
 async function clearCurrentWeekOrders(): Promise<void> {
-  const sb = admin();
   const weekOf = weekOfMondayNY();
   for (const c of Object.values(TEST_CUSTOMERS)) {
-    const { data } = await sb
-      .from("customers")
-      .select("id")
-      .eq("token", c.token)
-      .maybeSingle();
-    if (data?.id) {
-      await sb
-        .from("orders")
-        .delete()
-        .eq("customer_id", data.id)
-        .eq("week_of", weekOf);
+    const rows = await query<{ id: string }>(
+      `select id from customers where token = $1`,
+      [c.token],
+    );
+    const customer = rows[0] ?? null;
+    if (customer?.id) {
+      await query(
+        `delete from orders where customer_id = $1 and week_of = $2`,
+        [customer.id, weekOf],
+      );
     }
   }
 }
@@ -43,25 +41,18 @@ async function clearCurrentWeekOrders(): Promise<void> {
 // test flips send_weekly_link without restoring), so we re-establish phones,
 // priorities, subscribed state, and is_active each time.
 async function ensureTestCustomerState(): Promise<void> {
-  const sb = admin();
-  await sb
-    .from("customers")
-    .update({
-      phone: "(216) 555-0100",
-      priority: 200,
-      send_weekly_link: true,
-      is_active: true,
-    })
-    .eq("token", TEST_CUSTOMERS.farmStand.token);
-  await sb
-    .from("customers")
-    .update({
-      phone: "(216) 555-0200",
-      priority: 100,
-      send_weekly_link: true,
-      is_active: true,
-    })
-    .eq("token", TEST_CUSTOMERS.restaurant.token);
+  await query(
+    `update customers
+        set phone = $1, priority = $2, send_weekly_link = true, is_active = true
+      where token = $3`,
+    ["(216) 555-0100", 200, TEST_CUSTOMERS.farmStand.token],
+  );
+  await query(
+    `update customers
+        set phone = $1, priority = $2, send_weekly_link = true, is_active = true
+      where token = $3`,
+    ["(216) 555-0200", 100, TEST_CUSTOMERS.restaurant.token],
+  );
 }
 
 test.describe("admin send-queue", () => {
@@ -143,17 +134,15 @@ test.describe("admin send-queue", () => {
 
     // DB side. The pill flips optimistically before the server action
     // completes, so poll for the actual row insertion.
-    const sb = admin();
     await expect
       .poll(
         async () => {
-          const { data } = await sb
-            .from("customer_sends")
-            .select("customer_id")
-            .eq("customer_id", ids.farmStand)
-            .eq("week_of", weekOfMondayNY())
-            .eq("mode", "weekly_update");
-          return data?.length ?? 0;
+          const rows = await query<{ customer_id: string }>(
+            `select customer_id from customer_sends
+              where customer_id = $1 and week_of = $2 and mode = $3`,
+            [ids.farmStand, weekOfMondayNY(), "weekly_update"],
+          );
+          return rows.length;
         },
         { timeout: 5000 },
       )
@@ -207,17 +196,15 @@ test.describe("admin send-queue", () => {
     await expect(farmStandRow).toHaveAttribute("data-sent", "true");
 
     // DB confirmation.
-    const sb = admin();
     await expect
       .poll(
         async () => {
-          const { data } = await sb
-            .from("customer_sends")
-            .select("customer_id")
-            .eq("customer_id", ids.farmStand)
-            .eq("week_of", weekOfMondayNY())
-            .eq("mode", "weekly_update");
-          return data?.length ?? 0;
+          const rows = await query<{ customer_id: string }>(
+            `select customer_id from customer_sends
+              where customer_id = $1 and week_of = $2 and mode = $3`,
+            [ids.farmStand, weekOfMondayNY(), "weekly_update"],
+          );
+          return rows.length;
         },
         { timeout: 5000 },
       )

--- a/tests/customer-additional-orders.spec.ts
+++ b/tests/customer-additional-orders.spec.ts
@@ -3,7 +3,6 @@ import { weekOfMondayNY } from "@/lib/week";
 import {
   TEST_CUSTOMERS,
   TEST_PRODUCTS,
-  admin,
   customerIds,
   customerOrderUrl,
   resetCustomerOrderState,
@@ -12,6 +11,7 @@ import {
   setAllProductsSoldOut,
   setOrderingOpen,
 } from "./helpers";
+import { query } from "@/lib/db";
 
 // #211/DEC-039 + #227/DEC-041/DEC-042 — additive orders on the open-order
 // model. A customer's link renders their OPEN order editable (pre-populated
@@ -72,28 +72,27 @@ test.describe("/c/[token] additional orders", () => {
 
     // DB: still exactly one OPEN orders row for the customer; two line
     // items; inventory decremented for the appended line too.
-    const sb = admin();
     const ids = await customerIds();
-    const { data: orders } = await sb
-      .from("orders")
-      .select("id, status")
-      .eq("customer_id", ids.farmStand)
-      .in("status", ["new", "confirmed", "ready"]);
+    const orders = await query<{ id: string; status: string }>(
+      `select id, status from orders
+        where customer_id = $1 and status = any($2)`,
+      [ids.farmStand, ["new", "confirmed", "ready"]],
+    );
     expect(orders).toHaveLength(1);
 
-    const { data: items } = await sb
-      .from("order_items")
-      .select("id, submission_id")
-      .eq("order_id", orders![0].id);
+    const items = await query<{ id: string; submission_id: string | null }>(
+      `select id, submission_id from order_items where order_id = $1`,
+      [orders[0].id],
+    );
     expect(items).toHaveLength(2);
     // Both submissions carry their idempotency key (per-submission audit).
-    expect(items!.every((i) => i.submission_id !== null)).toBe(true);
+    expect(items.every((i) => i.submission_id !== null)).toBe(true);
 
-    const { data: eggs } = await sb
-      .from("products")
-      .select("qty_available")
-      .eq("id", TEST_PRODUCTS.eggs.id)
-      .single();
+    const eggsRows = await query<{ qty_available: number }>(
+      `select qty_available from products where id = $1`,
+      [TEST_PRODUCTS.eggs.id],
+    );
+    const eggs = eggsRows[0] ?? null;
     expect(eggs?.qty_available).toBe(TEST_PRODUCTS.eggs.qty_available - 1);
   });
 
@@ -129,19 +128,18 @@ test.describe("/c/[token] additional orders", () => {
     await expect(existing).toContainText("3×");
 
     // DB: still two granular rows, each carrying its submission_id.
-    const sb = admin();
     const ids = await customerIds();
-    const { data: orders } = await sb
-      .from("orders")
-      .select("id")
-      .eq("customer_id", ids.farmStand)
-      .in("status", ["new", "confirmed", "ready"]);
-    const { data: rows } = await sb
-      .from("order_items")
-      .select("id, submission_id")
-      .eq("order_id", orders![0].id);
+    const orders = await query<{ id: string }>(
+      `select id from orders
+        where customer_id = $1 and status = any($2)`,
+      [ids.farmStand, ["new", "confirmed", "ready"]],
+    );
+    const rows = await query<{ id: string; submission_id: string | null }>(
+      `select id, submission_id from order_items where order_id = $1`,
+      [orders[0].id],
+    );
     expect(rows).toHaveLength(2);
-    expect(new Set(rows!.map((r) => r.submission_id)).size).toBe(2);
+    expect(new Set(rows.map((r) => r.submission_id)).size).toBe(2);
   });
 
   test("open order renders the form in add mode with fulfillment read-only", async ({ page }) => {
@@ -266,16 +264,15 @@ test.describe("/c/[token] additional orders", () => {
     await page.locator(".submit-btn").click();
     await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
 
-    const sb = admin();
-    const { data: orders } = await sb
-      .from("orders")
-      .select("id, status")
-      .eq("customer_id", ids.farmStand)
-      .eq("week_of", weekOfMondayNY());
+    const orders = await query<{ id: string; status: string }>(
+      `select id, status from orders
+        where customer_id = $1 and week_of = $2`,
+      [ids.farmStand, weekOfMondayNY()],
+    );
     expect(orders).toHaveLength(2);
-    const fulfilled = orders!.find((o) => o.id === fulfilledId);
+    const fulfilled = orders.find((o) => o.id === fulfilledId);
     expect(fulfilled?.status).toBe("picked_up");
-    const fresh = orders!.find((o) => o.id !== fulfilledId);
+    const fresh = orders.find((o) => o.id !== fulfilledId);
     expect(fresh?.status).toBe("new");
   });
 });

--- a/tests/customer-order-units.spec.ts
+++ b/tests/customer-order-units.spec.ts
@@ -3,13 +3,13 @@ import { weekOfMondayNY } from "@/lib/week";
 import {
   TEST_CUSTOMERS,
   TEST_PRODUCTS,
-  admin,
   customerOrderUrl,
   resetCustomerOrderState,
   resetProductUnits,
   setProductUnits,
   setProductQty,
 } from "./helpers";
+import { query } from "@/lib/db";
 
 // 6.5c — Customer order form: per-product unit picker (#153). Kale is set up
 // as a two-unit product (bunch base + pound at 2× conversion). Eggs stays
@@ -143,42 +143,43 @@ test.describe("/c/[token] · per-product unit picker", () => {
     await page.locator(".submit-btn").click();
     await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
 
-    const sb = admin();
-    const { data: customer } = await sb
-      .from("customers")
-      .select("id")
-      .eq("token", TEST_CUSTOMERS.farmStand.token)
-      .single();
-    const { data: order } = await sb
-      .from("orders")
-      .select("id")
-      .eq("customer_id", customer!.id)
-      .eq("week_of", weekOfMondayNY())
-      .single();
-    const { data: lineItem } = await sb
-      .from("order_items")
-      .select("qty, unit_price_cents, product_unit_id, product_units(label)")
-      .eq("order_id", order!.id)
-      .eq("product_id", KALE.id)
-      .single();
+    const customers = await query<{ id: string }>(
+      `select id from customers where token = $1`,
+      [TEST_CUSTOMERS.farmStand.token],
+    );
+    const customer = customers[0]!;
+    const orders = await query<{ id: string }>(
+      `select id from orders where customer_id = $1 and week_of = $2`,
+      [customer.id, weekOfMondayNY()],
+    );
+    const order = orders[0]!;
+    const lineItems = await query<{
+      qty: number;
+      unit_price_cents: number;
+      product_unit_id: string;
+      unit_label: string;
+    }>(
+      `select oi.qty, oi.unit_price_cents, oi.product_unit_id, pu.label as unit_label
+         from order_items oi
+         join product_units pu on pu.id = oi.product_unit_id
+        where oi.order_id = $1 and oi.product_id = $2`,
+      [order.id, KALE.id],
+    );
+    const lineItem = lineItems[0] ?? null;
 
     // 6.5d: order_items.unit_price_cents pulled from product_units at RPC
     // time, product_unit_id matches the lb row (not the bunch fallback),
     // and qty stays in selected-unit units.
     expect(lineItem?.unit_price_cents).toBe(KALE_LB_PRICE);
     expect(lineItem?.qty).toBe(2);
-    expect(
-      (lineItem as unknown as { product_units: { label: string } })
-        ?.product_units?.label,
-    ).toBe("lb");
+    expect(lineItem?.unit_label).toBe("lb");
 
     // qty_available decremented by qty * conversion_to_base.
-    const { data: kale } = await sb
-      .from("products")
-      .select("qty_available")
-      .eq("id", KALE.id)
-      .single();
-    expect(Number(kale?.qty_available)).toBeCloseTo(
+    const kaleRows = await query<{ qty_available: number }>(
+      `select qty_available from products where id = $1`,
+      [KALE.id],
+    );
+    expect(Number(kaleRows[0]?.qty_available)).toBeCloseTo(
       KALE.qty_available - 2 * KALE_LB_CONV,
       2,
     );
@@ -187,9 +188,8 @@ test.describe("/c/[token] · per-product unit picker", () => {
   test("long product name is fully visible at 375px (resolves #144)", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== "mobile", "Wrap behavior is mobile-viewport-specific.");
     // Temporarily rename Kale to a long name to exercise the wrap path.
-    const sb = (await import("./helpers")).admin();
     const longName = "Heirloom Tuscan dinosaur kale (extra long name)";
-    await sb.from("products").update({ name: longName }).eq("id", KALE.id);
+    await query(`update products set name = $1 where id = $2`, [longName, KALE.id]);
     try {
       await page.goto(customerOrderUrl(TEST_CUSTOMERS.farmStand.token));
 
@@ -207,7 +207,7 @@ test.describe("/c/[token] · per-product unit picker", () => {
       });
       expect(lineCount).toBeGreaterThan(1);
     } finally {
-      await sb.from("products").update({ name: KALE.name }).eq("id", KALE.id);
+      await query(`update products set name = $1 where id = $2`, [KALE.name, KALE.id]);
     }
   });
 });

--- a/tests/customer-place-order.spec.ts
+++ b/tests/customer-place-order.spec.ts
@@ -1,23 +1,21 @@
 import { test, expect, type Page } from "@playwright/test";
 import { weekOfMondayNY } from "@/lib/week";
+import { query } from "@/lib/db";
 import {
   TEST_CUSTOMERS,
   TEST_PRODUCTS,
-  admin,
   customerOrderUrl,
   resetCustomerOrderState,
   setProductQty,
 } from "./helpers";
 
 async function getCustomerId(token: string): Promise<string> {
-  const sb = admin();
-  const { data, error } = await sb
-    .from("customers")
-    .select("id")
-    .eq("token", token)
-    .single();
-  if (error || !data) throw new Error(`Could not resolve customer ${token}`);
-  return data.id;
+  const rows = await query<{ id: string }>(
+    `select id from customers where token = $1`,
+    [token],
+  );
+  if (!rows[0]) throw new Error(`Could not resolve customer ${token}`);
+  return rows[0].id;
 }
 
 // Bumps the stepper on a named product to qty without relying on press-and-hold.
@@ -61,22 +59,25 @@ test.describe("/c/[token] place order", () => {
     // 2×$3.00 + 1×$6.00 = $12.00
     await expect(page.locator(".confirm-total")).toContainText("12.00");
 
-    const sb = admin();
     const farmStandId = await getCustomerId(TEST_CUSTOMERS.farmStand.token);
-    const { data: order } = await sb
-      .from("orders")
-      .select("id, needs_reconciliation, fulfillment_type")
-      .eq("customer_id", farmStandId)
-      .eq("week_of", weekOfMondayNY())
-      .single();
+    const orderRows = await query<{
+      id: string;
+      needs_reconciliation: boolean;
+      fulfillment_type: string;
+    }>(
+      `select id, needs_reconciliation, fulfillment_type
+         from orders where customer_id = $1 and week_of = $2`,
+      [farmStandId, weekOfMondayNY()],
+    );
+    const order = orderRows[0] ?? null;
     expect(order?.needs_reconciliation).toBe(false);
     expect(order?.fulfillment_type).toBe("delivery");
 
-    const { data: kale } = await sb
-      .from("products")
-      .select("qty_available")
-      .eq("id", TEST_PRODUCTS.kale.id)
-      .single();
+    const kaleRows = await query<{ qty_available: number }>(
+      `select qty_available from products where id = $1`,
+      [TEST_PRODUCTS.kale.id],
+    );
+    const kale = kaleRows[0] ?? null;
     expect(kale?.qty_available).toBe(TEST_PRODUCTS.kale.qty_available - 2);
   });
 
@@ -146,29 +147,27 @@ test.describe("/c/[token] place order", () => {
     await eggsInput.blur();
 
     // Sneak in a stock cut so the submit will oversell by 4.
-    const sb = admin();
-    await sb
-      .from("products")
-      .update({ qty_available: 1 })
-      .eq("id", TEST_PRODUCTS.eggs.id);
+    await query(`update products set qty_available = 1 where id = $1`, [
+      TEST_PRODUCTS.eggs.id,
+    ]);
 
     await page.locator(".submit-btn").click();
     await page.waitForURL(/\/c\/[^/]+\/confirmed$/);
 
     const farmStandId = await getCustomerId(TEST_CUSTOMERS.farmStand.token);
-    const { data: order } = await sb
-      .from("orders")
-      .select("needs_reconciliation")
-      .eq("customer_id", farmStandId)
-      .eq("week_of", weekOfMondayNY())
-      .single();
+    const orderRows = await query<{ needs_reconciliation: boolean }>(
+      `select needs_reconciliation
+         from orders where customer_id = $1 and week_of = $2`,
+      [farmStandId, weekOfMondayNY()],
+    );
+    const order = orderRows[0] ?? null;
     expect(order?.needs_reconciliation).toBe(true);
 
-    const { data: eggs } = await sb
-      .from("products")
-      .select("qty_available")
-      .eq("id", TEST_PRODUCTS.eggs.id)
-      .single();
+    const eggsRows = await query<{ qty_available: number }>(
+      `select qty_available from products where id = $1`,
+      [TEST_PRODUCTS.eggs.id],
+    );
+    const eggs = eggsRows[0] ?? null;
     expect(eggs?.qty_available).toBe(-4);
   });
 
@@ -199,12 +198,10 @@ test.describe("/c/[token] place order", () => {
     // (Status-filtered so the global-setup delivered fixture doesn't
     // inflate the count.)
     const farmStandId = await getCustomerId(TEST_CUSTOMERS.farmStand.token);
-    const sb = admin();
-    const { data: orders } = await sb
-      .from("orders")
-      .select("id")
-      .eq("customer_id", farmStandId)
-      .in("status", ["new", "confirmed", "ready"]);
+    const orders = await query<{ id: string }>(
+      `select id from orders where customer_id = $1 and status = any($2)`,
+      [farmStandId, ["new", "confirmed", "ready"]],
+    );
     expect(orders).toHaveLength(1);
   });
 });

--- a/tests/customer-token.spec.ts
+++ b/tests/customer-token.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
+import { query } from "@/lib/db";
 import {
   TEST_CUSTOMERS,
-  admin,
   customerOrderUrl,
   resetCustomerOrderState,
 } from "./helpers";
@@ -18,12 +18,11 @@ test.describe("/c/[token] route", () => {
   // into a paused-shell render.
   test.beforeEach(async () => {
     await resetCustomerOrderState();
-    const sb = admin();
     for (const token of [TEST_CUSTOMERS.farmStand.token, TEST_CUSTOMERS.restaurant.token]) {
-      await sb
-        .from("customers")
-        .update({ is_active: true, send_weekly_link: true })
-        .eq("token", token);
+      await query(
+        `update customers set is_active = true, send_weekly_link = true where token = $1`,
+        [token],
+      );
     }
   });
 
@@ -69,19 +68,17 @@ test.describe("/c/[token] route", () => {
   // renders and the order form is gone. Restore flags after each path.
   test.describe("account-state shells", () => {
     test.afterEach(async () => {
-      const sb = admin();
-      await sb
-        .from("customers")
-        .update({ is_active: true, send_weekly_link: true })
-        .eq("token", TEST_CUSTOMERS.restaurant.token);
+      await query(
+        `update customers set is_active = true, send_weekly_link = true where token = $1`,
+        [TEST_CUSTOMERS.restaurant.token],
+      );
     });
 
     test("send_weekly_link=false renders the paused shell", async ({ page }) => {
-      const sb = admin();
-      await sb
-        .from("customers")
-        .update({ send_weekly_link: false })
-        .eq("token", TEST_CUSTOMERS.restaurant.token);
+      await query(
+        `update customers set send_weekly_link = false where token = $1`,
+        [TEST_CUSTOMERS.restaurant.token],
+      );
 
       await page.goto(customerOrderUrl(TEST_CUSTOMERS.restaurant.token));
       await expect(page.getByRole("heading", { name: /weekly order link is paused/i })).toBeVisible();
@@ -91,11 +88,10 @@ test.describe("/c/[token] route", () => {
     });
 
     test("is_active=false renders the closed shell", async ({ page }) => {
-      const sb = admin();
-      await sb
-        .from("customers")
-        .update({ is_active: false })
-        .eq("token", TEST_CUSTOMERS.restaurant.token);
+      await query(
+        `update customers set is_active = false where token = $1`,
+        [TEST_CUSTOMERS.restaurant.token],
+      );
 
       await page.goto(customerOrderUrl(TEST_CUSTOMERS.restaurant.token));
       await expect(page.getByRole("heading", { name: /account is closed/i })).toBeVisible();
@@ -104,18 +100,17 @@ test.describe("/c/[token] route", () => {
     });
 
     test("toggling back restores the order form", async ({ page }) => {
-      const sb = admin();
-      await sb
-        .from("customers")
-        .update({ send_weekly_link: false })
-        .eq("token", TEST_CUSTOMERS.restaurant.token);
+      await query(
+        `update customers set send_weekly_link = false where token = $1`,
+        [TEST_CUSTOMERS.restaurant.token],
+      );
       await page.goto(customerOrderUrl(TEST_CUSTOMERS.restaurant.token));
       await expect(page.getByRole("heading", { name: /paused/i })).toBeVisible();
 
-      await sb
-        .from("customers")
-        .update({ send_weekly_link: true })
-        .eq("token", TEST_CUSTOMERS.restaurant.token);
+      await query(
+        `update customers set send_weekly_link = true where token = $1`,
+        [TEST_CUSTOMERS.restaurant.token],
+      );
       await page.reload();
       await expect(page.getByRole("heading", { name: /what.s available/i })).toBeVisible();
     });

--- a/tests/fulfillment-report.spec.ts
+++ b/tests/fulfillment-report.spec.ts
@@ -3,24 +3,22 @@ import { test, expect } from "@playwright/test";
 import {
   TEST_CUSTOMERS,
   TEST_PRODUCTS,
-  admin,
   customerIds,
   clearOrdersForWeek,
   seedOrder,
 } from "./helpers";
+import { query } from "@/lib/db";
 import { weekOfMondayNY } from "@/lib/week";
 
 // #195 — public Harvest & Pack Sheet at /f/[token]. Read-only rollup over the
 // week's orders. Runs on desktop + mobile (farm hands view it on phones).
 
 async function fulfillmentToken(): Promise<string> {
-  const sb = admin();
-  const { data, error } = await sb
-    .from("fulfillment_link")
-    .select("token")
-    .single();
-  if (error || !data) throw new Error(`fulfillment token: ${error?.message}`);
-  return data.token;
+  const rows = await query<{ token: string }>(
+    `select token from fulfillment_link`,
+  );
+  if (!rows[0]) throw new Error("fulfillment token: no row");
+  return rows[0].token;
 }
 
 const WEEK = weekOfMondayNY();
@@ -90,13 +88,11 @@ test("invalid token 404s", async ({ page }) => {
 
 test("excludes picked_up / delivered orders (#200)", async ({ page }) => {
   const ids = await customerIds();
-  const sb = admin();
   // The restaurant's (delivery) order is fulfilled — out the door.
-  await sb
-    .from("orders")
-    .update({ status: "delivered" })
-    .eq("customer_id", ids.restaurant)
-    .eq("week_of", WEEK);
+  await query(
+    `update orders set status = 'delivered' where customer_id = $1 and week_of = $2`,
+    [ids.restaurant, WEEK],
+  );
 
   try {
     await page.goto(`/f/${await fulfillmentToken()}`);
@@ -115,11 +111,10 @@ test("excludes picked_up / delivered orders (#200)", async ({ page }) => {
     ).toHaveText("3");
     await expect(page.locator(".fr-hv-line", { hasText: "Honey" })).toHaveCount(0);
   } finally {
-    await sb
-      .from("orders")
-      .update({ status: "new" })
-      .eq("customer_id", ids.restaurant)
-      .eq("week_of", WEEK);
+    await query(
+      `update orders set status = 'new' where customer_id = $1 and week_of = $2`,
+      [ids.restaurant, WEEK],
+    );
   }
 });
 
@@ -127,16 +122,14 @@ test("excludes picked_up / delivered orders (#200)", async ({ page }) => {
 // order that crosses a week boundary keeps printing until it's out the door.
 test("shows open orders from past weeks", async ({ page }) => {
   const ids = await customerIds();
-  const sb = admin();
   const [y, m, d] = WEEK.split("-").map((n) => parseInt(n, 10));
   const lastMonday = new Date(Date.UTC(y, m - 1, d - 7)).toISOString().slice(0, 10);
   // Re-stamp the farm stand's open order into LAST week (update, not insert —
   // the partial unique index allows only one open order per customer).
-  await sb
-    .from("orders")
-    .update({ week_of: lastMonday })
-    .eq("customer_id", ids.farmStand)
-    .eq("week_of", WEEK);
+  await query(
+    `update orders set week_of = $1 where customer_id = $2 and week_of = $3`,
+    [lastMonday, ids.farmStand, WEEK],
+  );
 
   try {
     await page.goto(`/f/${await fulfillmentToken()}`);
@@ -148,10 +141,9 @@ test("shows open orders from past weeks", async ({ page }) => {
       page.locator(".fr-hv-line", { hasText: "Kale" }).locator(".fr-hv-qty"),
     ).toHaveText("5");
   } finally {
-    await sb
-      .from("orders")
-      .update({ week_of: WEEK })
-      .eq("customer_id", ids.farmStand)
-      .eq("week_of", lastMonday);
+    await query(
+      `update orders set week_of = $1 where customer_id = $2 and week_of = $3`,
+      [WEEK, ids.farmStand, lastMonday],
+    );
   }
 });

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -2,6 +2,8 @@ import { chromium } from "@playwright/test";
 import { createClient } from "@supabase/supabase-js";
 import { mkdir } from "fs/promises";
 
+import { query } from "@/lib/db";
+
 export const TEST_ADMIN_EMAIL = "test-admin@bushel.test";
 export const TEST_ADMIN_PASSWORD = "BushelTest1!";
 const MAX_CHUNK_SIZE = 3180;
@@ -115,52 +117,66 @@ export default async function globalSetup() {
   }
   if (!userId) throw new Error("Could not create or find test admin user");
 
-  // Ensure public.users row with is_admin = true (service role bypasses RLS)
+  // Ensure public.users row with is_admin = true. This lives in the SUPABASE
+  // (auth) database, not the pg data DB — Supabase Auth remains the admin
+  // login until DEC-047 lands (10.3).
   const { error: upsertError } = await adminClient
     .from("users")
     .upsert({ id: userId, is_admin: true }, { onConflict: "id" });
   if (upsertError)
     throw new Error(`public.users upsert failed: ${upsertError.message}`);
 
+  // ── Data seeding below targets the pg data DB (DATABASE_URL), the same
+  //    database the app under test reads/writes (task 10.2). ──
+
   // Upsert test products so inventory tests are self-contained
-  const { error: productsError } = await adminClient.from("products").upsert(
-    [
-      { id: "cccccccc-0000-0000-0000-000000000001", name: "Kale",  qty_available: 10, is_available: true,  sort_order: 1 },
-      { id: "cccccccc-0000-0000-0000-000000000002", name: "Eggs",  qty_available: 5,  is_available: true,  sort_order: 2 },
-      { id: "cccccccc-0000-0000-0000-000000000003", name: "Honey", qty_available: 8,  is_available: true,  sort_order: 3 },
-    ],
-    { onConflict: "id" },
+  await query(
+    `insert into products (id, name, qty_available, is_available, sort_order)
+     values
+       ('cccccccc-0000-0000-0000-000000000001', 'Kale',  10, true, 1),
+       ('cccccccc-0000-0000-0000-000000000002', 'Eggs',   5, true, 2),
+       ('cccccccc-0000-0000-0000-000000000003', 'Honey',  8, true, 3)
+     on conflict (id) do update
+       set name = excluded.name, qty_available = excluded.qty_available,
+           is_available = excluded.is_available, sort_order = excluded.sort_order`,
   );
-  if (productsError)
-    throw new Error(`products upsert failed: ${productsError.message}`);
 
   // DEC-037: unit label + price live on the base product_units row and nothing
   // auto-spawns it — upsert the base rows alongside the products. Keyed on
   // (product_id, label) so a price drifted by a prior run is restored without
   // colliding with leftover extra units (specs reset those via
   // resetProductUnits / setProductUnits).
-  const { error: unitsError } = await adminClient.from("product_units").upsert(
-    [
-      { product_id: "cccccccc-0000-0000-0000-000000000001", label: "bunch", conversion_to_base: 1, unit_price_cents: 300,  is_active: true, sort_order: 0, slug: "kale-cccccccc" },
-      { product_id: "cccccccc-0000-0000-0000-000000000002", label: "dozen", conversion_to_base: 1, unit_price_cents: 600,  is_active: true, sort_order: 0, slug: "eggs-cccccccc" },
-      { product_id: "cccccccc-0000-0000-0000-000000000003", label: "jar",   conversion_to_base: 1, unit_price_cents: 1200, is_active: true, sort_order: 0, slug: "honey-cccccccc" },
-    ],
-    { onConflict: "product_id,label" },
+  await query(
+    `insert into product_units
+       (product_id, label, conversion_to_base, unit_price_cents, is_active, sort_order, slug)
+     values
+       ('cccccccc-0000-0000-0000-000000000001', 'bunch', 1, 300,  true, 0, 'kale-cccccccc'),
+       ('cccccccc-0000-0000-0000-000000000002', 'dozen', 1, 600,  true, 0, 'eggs-cccccccc'),
+       ('cccccccc-0000-0000-0000-000000000003', 'jar',   1, 1200, true, 0, 'honey-cccccccc')
+     on conflict (product_id, label) do update
+       set conversion_to_base = excluded.conversion_to_base,
+           unit_price_cents = excluded.unit_price_cents,
+           is_active = excluded.is_active,
+           sort_order = excluded.sort_order,
+           slug = excluded.slug`,
   );
-  if (unitsError)
-    throw new Error(`product_units upsert failed: ${unitsError.message}`);
 
   // Upsert test customers so customer-CRUD tests are self-contained.
   // is_active defaults true; tests that deactivate must reset to true.
-  const { error: customersError } = await adminClient.from("customers").upsert(
-    [
-      { name: "Test Farm Stand", token: "testtoken-farmstand-0001",  is_active: true, send_weekly_link: true, priority: 100, business_name: null, email: null, phone: null, delivery_address: "100 Farm Stand Way, Lakewood, OH 44107" },
-      { name: "Test Restaurant", token: "testtoken-restaurant-0001", is_active: true, send_weekly_link: true, priority: 100, business_name: null, email: null, phone: null, delivery_address: "200 Restaurant Row, Cleveland, OH 44102" },
-    ],
-    { onConflict: "token" },
+  await query(
+    `insert into customers
+       (name, token, is_active, send_weekly_link, priority, delivery_address)
+     values
+       ('Test Farm Stand', 'testtoken-farmstand-0001', true, true, 100,
+        '100 Farm Stand Way, Lakewood, OH 44107'),
+       ('Test Restaurant', 'testtoken-restaurant-0001', true, true, 100,
+        '200 Restaurant Row, Cleveland, OH 44102')
+     on conflict (token) do update
+       set name = excluded.name, is_active = excluded.is_active,
+           send_weekly_link = excluded.send_weekly_link,
+           priority = excluded.priority,
+           delivery_address = excluded.delivery_address`,
   );
-  if (customersError)
-    throw new Error(`customers upsert failed: ${customersError.message}`);
 
   // Seed a prior delivery order for Test Farm Stand so 3.4 delivery_preference
   // prefill is testable. week_of is in the past and status terminal so it
@@ -172,36 +188,20 @@ export default async function globalSetup() {
   // and orders-flow's "export respects the active view" test relies on it
   // emitting zero CSV rows (export is per line item). Adding items here
   // breaks that spec's not-toContain assertions.
-  const { data: farmStandRow, error: lookupError } = await adminClient
-    .from("customers")
-    .select("id")
-    .eq("token", "testtoken-farmstand-0001")
-    .single();
-  if (lookupError || !farmStandRow)
-    throw new Error(`farm stand lookup failed: ${lookupError?.message ?? "no row"}`);
-
-  const { data: existingPrior, error: priorLookupError } = await adminClient
-    .from("orders")
-    .select("id")
-    .eq("customer_id", farmStandRow.id)
-    .eq("week_of", "2026-04-27")
-    .maybeSingle();
-  if (priorLookupError)
-    throw new Error(`prior order lookup failed: ${priorLookupError.message}`);
-  if (!existingPrior) {
-    const { error: priorOrderError } = await adminClient.from("orders").insert({
-      customer_id: farmStandRow.id,
-      week_of: "2026-04-27",
-      fulfillment_type: "delivery",
-      delivery_address: "100 Farm Stand Way, Lakewood, OH 44107",
-      delivery_preference: "Back door, gate code 4321",
-      status: "delivered",
-      notes: null,
-      pickup_note: null,
-    });
-    if (priorOrderError)
-      throw new Error(`prior order insert failed: ${priorOrderError.message}`);
-  }
+  await query(
+    `insert into orders
+       (customer_id, week_of, fulfillment_type, delivery_address,
+        delivery_preference, status)
+     select id, '2026-04-27', 'delivery',
+            '100 Farm Stand Way, Lakewood, OH 44107',
+            'Back door, gate code 4321', 'delivered'
+       from customers
+      where token = 'testtoken-farmstand-0001'
+        and not exists (
+          select 1 from orders o
+           where o.customer_id = customers.id and o.week_of = '2026-04-27'
+        )`,
+  );
 
   // Sign in to get a real, server-verified session
   const anonClient = createClient(supabaseUrl, anonKey, {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@supabase/supabase-js";
+import { query } from "@/lib/db";
 import { weekOfMondayNY } from "@/lib/week";
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3001";
@@ -31,41 +31,33 @@ export const TEST_PRODUCTS = {
   honey: { id: "cccccccc-0000-0000-0000-000000000003", name: "Honey", unit: "jar",   price_cents: 1200, qty_available: 8  },
 } as const;
 
-// Lazy admin Supabase client — only constructed when a test calls it.
-export function admin() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-  return createClient(url, key, {
-    auth: { autoRefreshToken: false, persistSession: false },
-  });
-}
+// Test DB access goes through the same pg pool as the app (src/lib/db.ts) —
+// DATABASE_URL must point both at the same database (docker compose service
+// locally, the postgres service container in CI).
 
 // Resolves the two seeded test customers' UUIDs by token. Used by every spec
 // that needs to query orders/sends/etc. scoped to the test fixtures.
 export async function customerIds(): Promise<{ farmStand: string; restaurant: string }> {
-  const sb = admin();
-  const { data, error } = await sb
-    .from("customers")
-    .select("id, token")
-    .in("token", [TEST_CUSTOMERS.farmStand.token, TEST_CUSTOMERS.restaurant.token]);
-  if (error || !data) throw new Error(`customerIds: ${error?.message ?? "no rows"}`);
-  const map = new Map(data.map((r) => [r.token, r.id]));
-  return {
-    farmStand: map.get(TEST_CUSTOMERS.farmStand.token)!,
-    restaurant: map.get(TEST_CUSTOMERS.restaurant.token)!,
-  };
+  const rows = await query<{ id: string; token: string }>(
+    `select id, token from customers where token = any($1)`,
+    [[TEST_CUSTOMERS.farmStand.token, TEST_CUSTOMERS.restaurant.token]],
+  );
+  const map = new Map(rows.map((r) => [r.token, r.id]));
+  const farmStand = map.get(TEST_CUSTOMERS.farmStand.token);
+  const restaurant = map.get(TEST_CUSTOMERS.restaurant.token);
+  if (!farmStand || !restaurant) throw new Error("customerIds: seeded customers missing");
+  return { farmStand, restaurant };
 }
+
 // Deletes orders for the two seeded test customers in a given NY-week-Monday.
 // Caller passes the week explicitly (use `weekOfMondayNY()` from @/lib/week
 // for the current week).
 export async function clearOrdersForWeek(weekOf: string): Promise<void> {
-  const sb = admin();
   const ids = await customerIds();
-  await sb
-    .from("orders")
-    .delete()
-    .in("customer_id", [ids.farmStand, ids.restaurant])
-    .eq("week_of", weekOf);
+  await query(
+    `delete from orders where customer_id = any($1) and week_of = $2`,
+    [[ids.farmStand, ids.restaurant], weekOf],
+  );
 }
 
 // Inserts an order + its line items for a seeded test customer. Union of the
@@ -84,35 +76,34 @@ export type SeedOrderInput = {
   items: Array<{ productId: string; qty: number; unitPriceCents: number }>;
 };
 export async function seedOrder(input: SeedOrderInput): Promise<string> {
-  const sb = admin();
-  const { data: order, error: oErr } = await sb
-    .from("orders")
-    .insert({
-      customer_id: input.customerId,
-      week_of: input.weekOf,
-      fulfillment_type: input.fulfillmentType,
-      delivery_address:
-        input.fulfillmentType === "delivery" ? "123 Test St" : null,
-      delivery_preference:
-        input.fulfillmentType === "delivery"
-          ? (input.deliveryPreference ?? null)
-          : null,
-      status: input.status ?? "new",
-      needs_reconciliation: input.needsReconciliation ?? false,
-    })
-    .select("id")
-    .single();
-  if (oErr || !order) throw new Error(`seedOrder: ${oErr?.message}`);
+  const orderRows = await query<{ id: string }>(
+    `insert into orders
+       (customer_id, week_of, fulfillment_type, delivery_address,
+        delivery_preference, status, needs_reconciliation)
+     values ($1, $2, $3, $4, $5, $6, $7)
+     returning id`,
+    [
+      input.customerId,
+      input.weekOf,
+      input.fulfillmentType,
+      input.fulfillmentType === "delivery" ? "123 Test St" : null,
+      input.fulfillmentType === "delivery" ? (input.deliveryPreference ?? null) : null,
+      input.status ?? "new",
+      input.needsReconciliation ?? false,
+    ],
+  );
+  const orderId = orderRows[0].id;
 
-  const rows = input.items.map((i) => ({
-    order_id: order.id,
-    product_id: i.productId,
-    qty: i.qty,
-    unit_price_cents: i.unitPriceCents,
-  }));
-  const { error: iErr } = await sb.from("order_items").insert(rows);
-  if (iErr) throw new Error(`seedOrder items: ${iErr.message}`);
-  return order.id;
+  // product_unit_id omitted — the order_items_default_unit BEFORE-INSERT
+  // trigger fills the product's base unit, same as before.
+  for (const i of input.items) {
+    await query(
+      `insert into order_items (order_id, product_id, qty, unit_price_cents)
+       values ($1, $2, $3, $4)`,
+      [orderId, i.productId, i.qty, i.unitPriceCents],
+    );
+  }
+  return orderId;
 }
 
 // Clears the seeded test customers' current-NY-week orders AND any open
@@ -127,45 +118,36 @@ export async function seedOrder(input: SeedOrderInput): Promise<string> {
 // the global-setup fixture (a delivered 2026-04-27 prior order used to
 // assert delivery_preference prefill) must survive.
 export async function resetCustomerOrderState(): Promise<void> {
-  const sb = admin();
   const currentWeek = weekOfMondayNY();
   for (const c of Object.values(TEST_CUSTOMERS)) {
-    const { data } = await sb
-      .from("customers")
-      .select("id")
-      .eq("token", c.token)
-      .maybeSingle();
-    if (data?.id) {
-      await sb
-        .from("orders")
-        .delete()
-        .eq("customer_id", data.id)
-        .or(`week_of.eq.${currentWeek},status.in.(new,confirmed,ready)`);
-    }
+    await query(
+      `delete from orders
+        where customer_id = (select id from customers where token = $1)
+          and (week_of = $2 or status in ('new', 'confirmed', 'ready'))`,
+      [c.token, currentWeek],
+    );
   }
   for (const p of Object.values(TEST_PRODUCTS)) {
-    await sb
-      .from("products")
-      .update({ qty_available: p.qty_available })
-      .eq("id", p.id);
+    await query(`update products set qty_available = $1 where id = $2`, [
+      p.qty_available,
+      p.id,
+    ]);
   }
   // Phase 3.7 tests can flip is_open=false; restoring here means specs that
   // run after them still see the open form.
-  await sb
-    .from("ordering_schedule")
-    .update({ is_open: true })
-    .eq("is_singleton", true);
+  await query(
+    `update ordering_schedule set is_open = true where is_singleton = true`,
+  );
 }
 
 // Toggles the singleton ordering_schedule row's is_open flag for Phase 3.7
 // state tests. The schedule table has a single row by design; updating any
 // row updates the schedule.
 export async function setOrderingOpen(open: boolean): Promise<void> {
-  const sb = admin();
-  await sb
-    .from("ordering_schedule")
-    .update({ is_open: open })
-    .eq("is_singleton", true);
+  await query(
+    `update ordering_schedule set is_open = $1 where is_singleton = true`,
+    [open],
+  );
 }
 
 // Reset TEST_PRODUCTS sort_order back to seeded values (kale=1, eggs=2,
@@ -174,14 +156,16 @@ export async function setOrderingOpen(open: boolean): Promise<void> {
 // upserts these values, but it only runs once per playwright invocation —
 // in-run leakage needs this finer-grained reset.
 export async function resetProductSortOrder(): Promise<void> {
-  const sb = admin();
   const seeded: Array<{ id: string; sort_order: number }> = [
     { id: TEST_PRODUCTS.kale.id,  sort_order: 1 },
     { id: TEST_PRODUCTS.eggs.id,  sort_order: 2 },
     { id: TEST_PRODUCTS.honey.id, sort_order: 3 },
   ];
   for (const row of seeded) {
-    await sb.from("products").update({ sort_order: row.sort_order }).eq("id", row.id);
+    await query(`update products set sort_order = $1 where id = $2`, [
+      row.sort_order,
+      row.id,
+    ]);
   }
 }
 
@@ -189,13 +173,13 @@ export async function resetProductSortOrder(): Promise<void> {
 // hard-deleted, so a test that adds a throwaway product can't clean up through
 // the editor. This removes it at the DB level for test isolation.
 export async function deleteProductByName(name: string): Promise<void> {
-  await admin().from("products").delete().eq("name", name);
+  await query(`delete from products where name = $1`, [name]);
 }
 
 // #207 — flip a product's soft-delete flag. Hidden products (is_active=false)
 // drop out of the customer order form and the default admin view.
 export async function setProductActive(id: string, active: boolean): Promise<void> {
-  await admin().from("products").update({ is_active: active }).eq("id", id);
+  await query(`update products set is_active = $1 where id = $2`, [active, id]);
 }
 
 // Patches the singleton ordering_schedule row. Pass only the fields you want
@@ -208,8 +192,17 @@ export async function setOrderingSchedule(patch: {
   weekly_close_day?: number | null;
   weekly_close_time?: string | null;
 }): Promise<void> {
-  const sb = admin();
-  await sb.from("ordering_schedule").update(patch).eq("is_singleton", true);
+  const sets: string[] = [];
+  const params: unknown[] = [];
+  for (const [key, value] of Object.entries(patch)) {
+    params.push(value);
+    sets.push(`${key} = $${params.length}`);
+  }
+  if (sets.length === 0) return;
+  await query(
+    `update ordering_schedule set ${sets.join(", ")} where is_singleton = true`,
+    params,
+  );
 }
 
 // Drops every is_available=true product to qty_available = 0 — exercises
@@ -224,27 +217,21 @@ export async function setOrderingSchedule(patch: {
 // devs run tests against the same dev DB in parallel.
 export type ProductQtySnapshot = Array<{ id: string; qty_available: number }>;
 export async function setAllProductsSoldOut(): Promise<ProductQtySnapshot> {
-  const sb = admin();
-  const { data } = await sb
-    .from("products")
-    .select("id, qty_available")
-    .eq("is_available", true);
-  const snapshot: ProductQtySnapshot =
-    data?.map((r) => ({ id: r.id, qty_available: r.qty_available })) ?? [];
-  await sb
-    .from("products")
-    .update({ qty_available: 0 })
-    .eq("is_available", true);
+  const snapshot = await query<{ id: string; qty_available: number }>(
+    `select id, qty_available from products where is_available = true`,
+  );
+  await query(
+    `update products set qty_available = 0 where is_available = true`,
+  );
   return snapshot;
 }
 
 export async function restoreProductQty(snapshot: ProductQtySnapshot): Promise<void> {
-  const sb = admin();
   for (const row of snapshot) {
-    await sb
-      .from("products")
-      .update({ qty_available: row.qty_available })
-      .eq("id", row.id);
+    await query(`update products set qty_available = $1 where id = $2`, [
+      row.qty_available,
+      row.id,
+    ]);
   }
 }
 
@@ -252,8 +239,7 @@ export async function restoreProductQty(snapshot: ProductQtySnapshot): Promise<v
 // per-item sold-out) call this; cleanup is via resetCustomerOrderState in
 // afterEach, which only knows about TEST_PRODUCTS — pass an id in that set.
 export async function setProductQty(id: string, qty: number): Promise<void> {
-  const sb = admin();
-  await sb.from("products").update({ qty_available: qty }).eq("id", id);
+  await query(`update products set qty_available = $1 where id = $2`, [qty, id]);
 }
 
 // Resets a product's units to a single base row: label = baseLabel, conv = 1,
@@ -268,17 +254,16 @@ export async function resetProductUnits(
   basePriceCents: number,
   baseLabel: string,
 ): Promise<void> {
-  const sb = admin();
-  const { data: product } = await sb
-    .from("products")
-    .select("name")
-    .eq("id", productId)
-    .single();
+  const products = await query<{ name: string }>(
+    `select name from products where id = $1`,
+    [productId],
+  );
+  const product = products[0];
   if (!product) return;
 
   // Non-atomic: a concurrent reader between delete + insert would observe
   // zero units for this product. Relies on Playwright's workers=1 config.
-  await sb.from("product_units").delete().eq("product_id", productId);
+  await query(`delete from product_units where product_id = $1`, [productId]);
 
   const nameSlug = product.name
     .toLowerCase()
@@ -286,14 +271,12 @@ export async function resetProductUnits(
     .replace(/^-+|-+$/g, "");
   const id8 = productId.slice(0, 8);
 
-  await sb.from("product_units").insert({
-    product_id: productId,
-    label: baseLabel,
-    conversion_to_base: 1,
-    unit_price_cents: basePriceCents,
-    is_active: true,
-    slug: `${nameSlug}-${id8}`,
-  });
+  await query(
+    `insert into product_units
+       (product_id, label, conversion_to_base, unit_price_cents, is_active, slug)
+     values ($1, $2, 1, $3, true, $4)`,
+    [productId, baseLabel, basePriceCents, `${nameSlug}-${id8}`],
+  );
 }
 
 // Replaces a product's entire unit set in one call. The list is interpreted as
@@ -311,15 +294,14 @@ export async function setProductUnits(
   productId: string,
   units: UnitSeed[],
 ): Promise<void> {
-  const sb = admin();
-  const { data: product } = await sb
-    .from("products")
-    .select("name")
-    .eq("id", productId)
-    .single();
+  const products = await query<{ name: string }>(
+    `select name from products where id = $1`,
+    [productId],
+  );
+  const product = products[0];
   if (!product) return;
 
-  await sb.from("product_units").delete().eq("product_id", productId);
+  await query(`delete from product_units where product_id = $1`, [productId]);
 
   const nameSlug = product.name
     .toLowerCase()
@@ -327,21 +309,25 @@ export async function setProductUnits(
     .replace(/^-+|-+$/g, "");
   const id8 = productId.slice(0, 8);
 
-  const rows = units.map((u, idx) => {
+  for (const [idx, u] of units.entries()) {
     const labelSlug = u.label
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-+|-+$/g, "");
-    return {
-      product_id: productId,
-      label: u.label,
-      conversion_to_base: u.conversion_to_base,
-      unit_price_cents: u.unit_price_cents,
-      is_active: u.is_active ?? true,
-      sort_order: idx,
-      slug: `${nameSlug}-${labelSlug}-${id8}`,
-    };
-  });
-
-  await sb.from("product_units").insert(rows);
+    await query(
+      `insert into product_units
+         (product_id, label, conversion_to_base, unit_price_cents, is_active,
+          sort_order, slug)
+       values ($1, $2, $3, $4, $5, $6, $7)`,
+      [
+        productId,
+        u.label,
+        u.conversion_to_base,
+        u.unit_price_cents,
+        u.is_active ?? true,
+        idx,
+        `${nameSlug}-${labelSlug}-${id8}`,
+      ],
+    );
+  }
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -261,6 +261,18 @@ export async function resetProductUnits(
   const product = products[0];
   if (!product) return;
 
+  // order_items.product_unit_id is ON DELETE RESTRICT — line items placed
+  // against these units during the test must go first. (The supabase-era
+  // helper silently swallowed this FK error and no-op'd until the next
+  // resetCustomerOrderState cleared the orders; pg throws, so clean up the
+  // dependents explicitly. The affected orders are this spec's own fixtures
+  // and get deleted by the next reset anyway.)
+  await query(
+    `delete from order_items
+      where product_unit_id in (select id from product_units where product_id = $1)`,
+    [productId],
+  );
+
   // Non-atomic: a concurrent reader between delete + insert would observe
   // zero units for this product. Relies on Playwright's workers=1 config.
   await query(`delete from product_units where product_id = $1`, [productId]);
@@ -301,6 +313,12 @@ export async function setProductUnits(
   const product = products[0];
   if (!product) return;
 
+  // Same FK-dependent cleanup as resetProductUnits (see comment there).
+  await query(
+    `delete from order_items
+      where product_unit_id in (select id from product_units where product_id = $1)`,
+    [productId],
+  );
   await query(`delete from product_units where product_id = $1`, [productId]);
 
   const nameSlug = product.name

--- a/tests/notifications-flow.spec.ts
+++ b/tests/notifications-flow.spec.ts
@@ -3,9 +3,9 @@ import { test, expect } from "@playwright/test";
 import {
   ADMIN_STORAGE_STATE,
   TEST_CUSTOMERS,
-  admin,
   customerIds,
 } from "./helpers";
+import { query } from "@/lib/db";
 import { weekOfMondayNY } from "@/lib/week";
 
 // Phase 4.4 — cross-task integration tests covering the gaps that 4.1, 4.2,
@@ -15,59 +15,52 @@ import { weekOfMondayNY } from "@/lib/week";
 // modes independent on the (customer_id, week_of, mode) PK?
 
 async function resetCustomerState(): Promise<void> {
-  const sb = admin();
   for (const token of [TEST_CUSTOMERS.farmStand.token, TEST_CUSTOMERS.restaurant.token]) {
-    const { data, error } = await sb
-      .from("customers")
-      .update({
-        phone: "(216) 555-0100",
-        priority: 200,
-        send_weekly_link: true,
-        is_active: true,
-      })
-      .eq("token", token)
-      .select("id");
-    if (error) throw new Error(`resetCustomerState(${token}): ${error.message}`);
-    if (!data?.length) throw new Error(`resetCustomerState(${token}): no rows updated — test customer missing`);
+    const rows = await query<{ id: string }>(
+      `update customers
+          set phone = $1, priority = $2, send_weekly_link = true, is_active = true
+        where token = $3
+        returning id`,
+      ["(216) 555-0100", 200, token],
+    );
+    if (!rows.length) throw new Error(`resetCustomerState(${token}): no rows updated — test customer missing`);
   }
 }
 
 async function clearSends(): Promise<void> {
-  await admin()
-    .from("customer_sends")
-    .delete()
-    .eq("week_of", weekOfMondayNY());
+  await query(`delete from customer_sends where week_of = $1`, [
+    weekOfMondayNY(),
+  ]);
 }
 
 // admin-settings.spec.ts flips ordering_schedule.is_open without restoring,
 // and the "deep-link → customer page" test below renders the customer order
 // page (which redirects to the closed state when is_open=false).
 async function ensureOrderingOpen(): Promise<void> {
-  await admin()
-    .from("ordering_schedule")
-    .update({ is_open: true, override_closes_at: null })
-    .eq("is_singleton", true);
+  await query(
+    `update ordering_schedule
+        set is_open = true, override_closes_at = null
+      where is_singleton = true`,
+  );
 }
 
 // Polls customer_sends for a row's sent_at, optionally requiring it to
 // differ from a prior value (used to detect a second upsert landed). Real
 // signal of "the server action completed" — beats a fixed sleep.
 async function pollSentAt(
-  sb: ReturnType<typeof admin>,
   customerId: string,
   mode: string,
   notEqualTo: string | null,
 ): Promise<string | null> {
   const deadline = Date.now() + 5000;
   while (Date.now() < deadline) {
-    const { data } = await sb
-      .from("customer_sends")
-      .select("sent_at")
-      .eq("customer_id", customerId)
-      .eq("week_of", weekOfMondayNY())
-      .eq("mode", mode)
-      .maybeSingle();
-    if (data?.sent_at && data.sent_at !== notEqualTo) return data.sent_at;
+    const rows = await query<{ sent_at: string }>(
+      `select sent_at from customer_sends
+        where customer_id = $1 and week_of = $2 and mode = $3`,
+      [customerId, weekOfMondayNY(), mode],
+    );
+    const row = rows[0] ?? null;
+    if (row?.sent_at && row.sent_at !== notEqualTo) return row.sent_at;
     await new Promise((r) => setTimeout(r, 100));
   }
   return null;
@@ -135,16 +128,14 @@ test.describe("notifications cross-task flow", () => {
     await expect(farmStandRow.locator(".send-status")).toContainText("Sent", { timeout: 5000 });
 
     // Wait for the DB row to land (optimistic flip happens before action completes)
-    const sb = admin();
     await expect
       .poll(async () => {
-        const { data } = await sb
-          .from("customer_sends")
-          .select("customer_id")
-          .eq("customer_id", ids.farmStand)
-          .eq("week_of", weekOfMondayNY())
-          .eq("mode", "weekly_update");
-        return data?.length ?? 0;
+        const rows = await query<{ customer_id: string }>(
+          `select customer_id from customer_sends
+            where customer_id = $1 and week_of = $2 and mode = $3`,
+          [ids.farmStand, weekOfMondayNY(), "weekly_update"],
+        );
+        return rows.length;
       }, { timeout: 5000 })
       .toBe(1);
 
@@ -167,8 +158,7 @@ test.describe("notifications cross-task flow", () => {
 
     // First send
     await farmStandRow.getByRole("link", { name: /^send$/i }).click();
-    const sb = admin();
-    const firstSentAt = await pollSentAt(sb, ids.farmStand, "weekly_update", null);
+    const firstSentAt = await pollSentAt(ids.farmStand, "weekly_update", null);
     expect(firstSentAt).toBeTruthy();
 
     // Reload so the button now reads "Re-send"
@@ -183,17 +173,15 @@ test.describe("notifications cross-task flow", () => {
     // second action completed (sleep-then-count was flaky-by-construction).
     await reSendLink.click();
     await expect(reloadedRow.locator(".send-status")).toContainText("Sent");
-    const secondSentAt = await pollSentAt(sb, ids.farmStand, "weekly_update", firstSentAt);
+    const secondSentAt = await pollSentAt(ids.farmStand, "weekly_update", firstSentAt);
     expect(secondSentAt).not.toBe(firstSentAt);
 
-    const { data, error } = await sb
-      .from("customer_sends")
-      .select("customer_id")
-      .eq("customer_id", ids.farmStand)
-      .eq("week_of", weekOfMondayNY())
-      .eq("mode", "weekly_update");
-    expect(error).toBeNull();
-    expect(data?.length).toBe(1);
+    const rows = await query<{ customer_id: string }>(
+      `select customer_id from customer_sends
+        where customer_id = $1 and week_of = $2 and mode = $3`,
+      [ids.farmStand, weekOfMondayNY(), "weekly_update"],
+    );
+    expect(rows.length).toBe(1);
   });
 
 });

--- a/tests/orders-flow.spec.ts
+++ b/tests/orders-flow.spec.ts
@@ -4,7 +4,6 @@ import {
   ADMIN_STORAGE_STATE,
   TEST_CUSTOMERS,
   TEST_PRODUCTS,
-  admin,
   customerOrderUrl,
   customerIds,
   clearOrdersForWeek,
@@ -14,6 +13,7 @@ import {
   setProductQty,
   setProductUnits,
 } from "./helpers";
+import { query } from "@/lib/db";
 import { weekOfMondayNY } from "@/lib/week";
 import { EXPORT_COLUMNS } from "@/lib/admin/export-orders";
 
@@ -74,14 +74,12 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
     await customerCtx.close();
 
     // Pick up the order id the customer just created
-    const sb = admin();
     const ids = await customerIds();
-    const { data: order } = await sb
-      .from("orders")
-      .select("id")
-      .eq("customer_id", ids.farmStand)
-      .eq("week_of", thisWeek)
-      .single();
+    const orderRows = await query<{ id: string }>(
+      `select id from orders where customer_id = $1 and week_of = $2`,
+      [ids.farmStand, thisWeek],
+    );
+    const order = orderRows[0] ?? null;
     expect(order?.id).toBeTruthy();
     const orderId = order!.id;
 
@@ -101,8 +99,11 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
     await expect(row).toHaveAttribute("data-status", "ready", { timeout: 5000 });
     await expect
       .poll(async () => {
-        const { data } = await sb.from("orders").select("status").eq("id", orderId).single();
-        return data?.status ?? null;
+        const rows = await query<{ status: string }>(
+          `select status from orders where id = $1`,
+          [orderId],
+        );
+        return rows[0]?.status ?? null;
       }, { timeout: 5000 })
       .toBe("ready");
 
@@ -113,8 +114,11 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
     await expect(row).toHaveAttribute("data-status", "delivered", { timeout: 5000 });
     await expect
       .poll(async () => {
-        const { data } = await sb.from("orders").select("status").eq("id", orderId).single();
-        return data?.status ?? null;
+        const rows = await query<{ status: string }>(
+          `select status from orders where id = $1`,
+          [orderId],
+        );
+        return rows[0]?.status ?? null;
       }, { timeout: 5000 })
       .toBe("delivered");
 
@@ -320,22 +324,20 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
       await customerCtx.close();
 
       // Find the order id.
-      const sb = admin();
       const ids = await customerIds();
-      const { data: order } = await sb
-        .from("orders")
-        .select("id")
-        .eq("customer_id", ids.farmStand)
-        .eq("week_of", thisWeek)
-        .single();
+      const orderRows = await query<{ id: string }>(
+        `select id from orders where customer_id = $1 and week_of = $2`,
+        [ids.farmStand, thisWeek],
+      );
+      const order = orderRows[0] ?? null;
       expect(order?.id).toBeTruthy();
 
       // Inventory decremented by qty * conversion_to_base = 2 * 2 = 4.
-      const { data: kale } = await sb
-        .from("products")
-        .select("qty_available")
-        .eq("id", TEST_PRODUCTS.kale.id)
-        .single();
+      const kaleRows = await query<{ qty_available: number }>(
+        `select qty_available from products where id = $1`,
+        [TEST_PRODUCTS.kale.id],
+      );
+      const kale = kaleRows[0] ?? null;
       expect(Number(kale?.qty_available)).toBeCloseTo(
         TEST_PRODUCTS.kale.qty_available - 2 * LB_CONV,
         2,
@@ -393,14 +395,13 @@ test.describe("orders flow — cross-task (customer ↔ admin ↔ export)", () =
       await customerPage.waitForURL(/\/c\/[^/]+\/confirmed$/);
       await customerCtx.close();
 
-      const sb = admin();
       const ids = await customerIds();
-      const { data: order } = await sb
-        .from("orders")
-        .select("id, needs_reconciliation")
-        .eq("customer_id", ids.farmStand)
-        .eq("week_of", thisWeek)
-        .single();
+      const orderRows = await query<{ id: string; needs_reconciliation: boolean }>(
+        `select id, needs_reconciliation
+           from orders where customer_id = $1 and week_of = $2`,
+        [ids.farmStand, thisWeek],
+      );
+      const order = orderRows[0] ?? null;
       expect(order?.needs_reconciliation).toBe(true);
 
       // Admin orders detail → recon callout + per-line "lb oversold" message.


### PR DESCRIPTION
## Summary
Task 10.2: every data read/write now goes through a `pg` Pool (`DATABASE_URL` → Neon per DEC-049, docker Postgres locally/CI). Supabase remains **auth-only** (login, callback, middleware, admin session) until 10.3.

## Architecture
- `src/lib/db.ts` — Pool + type parsers pinning supabase-js JSON shapes (numeric→number, timestamptz→ISO string, date→'YYYY-MM-DD') so no consumer changed
- `src/lib/db-types.ts` — plain row types; `src/lib/pg-errors.ts` — error-code helpers
- `src/lib/admin/order-status.ts` — pure status domain split from `orders-queries.ts` (client components import it without dragging `pg` into browser bundles)
- `src/lib/admin/auth.ts` — transitional `getAdminUser()`; 10.3 swaps its body for the DEC-047 HMAC session, call sites stay
- **Security note:** RLS is gone on pg, so every admin Server Action now carries an explicit `getAdminUser()` gate replacing the old cookie-client+RLS pair (review confirmed all 14; `place-order` stays token-gated)

## Files changed
51 files: 6 lib query modules, 14 actions, 3 admin pages, cron route, `tests/helpers.ts` + `global-setup.ts` (data seeding → pg; supabase kept for admin session minting), 13 spec files (transport swap only), `ci.yml` (DATABASE_URL → postgres service + migrate step before build).

## Code review
Full-diff review: one real finding, fixed in 1e2ffd9 (`getOpenOrder` lost the loud multi-row invariant failure `.maybeSingle()` provided — restored). Confirmed clean: action-gate sweep, `place_order` param parity + redirect outside try/catch, JSON-aggregation shape parity with the old PostgREST embeds, pool lifecycle on Vercel, 23505/23503 error contracts, test-seeding parity. `src/lib/supabase/admin.ts` is now dead code — left for 10.5's supabase removal.

## Test plan
- [x] Typecheck, lint (1 pre-existing warning), build (verified pg stays out of client bundles)
- [x] Local Playwright against the app on docker `bushel_test`: `customer-place-order`, `admin-orders`, `customer-additional-orders`, `fulfillment-report` (desktop) + `admin-orders`, `customer-order-form` (mobile 375px) — **49 passed, 0 failed**
- [x] CI: full suite against the postgres service container — 373 passed (helpers FK-cleanup fix in b6a3942)
- [ ] **Preview click-through** (the preview deploy reads the Neon dev-branch DB, which I seeded with Kale/Eggs/Honey + a test customer):
  1. Open the Vercel preview URL from the comment below, at `/c/preview-tester-0001` → order form renders with Kale ($3/bunch), Eggs ($6/dozen), Honey ($12/jar)
  2. Add a couple items → Submit → lands on the confirmed page with your items listed
  3. Log in to `/admin` (Google OAuth as usual) → Orders shows the order you just placed; Inventory shows the three products with qty decremented by what you ordered
  4. Nothing here touches production — prod is still on Supabase until 10.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
