### PR TITLE
DEC-052: split bushel-mobile into an independent seeds repo

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -629,6 +629,43 @@ A customer has at most one **non-terminal** order; fulfilled orders (`picked_up`
 
 ---
 
+## DEC-052 — bushel-mobile is an independent seeds project; a phase never spans repos
+
+Decision: bushel-mobile (DEC-050's separate Expo repo) is a fully independent
+seeds-managed project — own CLAUDE.md shell + CLAUDE-context.md, own skills/agents,
+own orphan `sessions` branch, own SemVer/CHANGELOG/tags, phases numbered from 1, own
+`/retro`. It is NOT a satellite of bushel. Standing invariant: a phase is a single-repo
+accounting unit — issues, PRs, session files, version bumps, and retro all live in one
+repo. Work is never one phase spanning two repos.
+
+Phase 11 re-frame:
+- 11.1 (#261, 5pt, /api routes + bearer guard) stays a bushel phase — bushel code,
+  bushel issue, bushel retro/version. Mutations built as service-layer functions with
+  the /api route as a thin wrapper (DEC-050 parity mechanism 1).
+- #262–#265 close in bushel ("moved to bushel-mobile"), recreated as bushel-mobile
+  Phase 1 issues (15pt). bushel PROJECT_PLAN Phase 11 = 5pt; bushel-mobile Phase 1 = 15pt.
+  There is no single "20-pt Phase 11" — that framing was the bug.
+
+Mechanics:
+- Cross-repo `closes` does not auto-close; bushel-mobile PRs `closes` its own issues.
+  The 11.1 dependency is a plain cross-repo mention.
+- Sessions are single-repo (cwd-delimited); same Claude window may run separate sessions
+  in each repo.
+- project-type = `webapp` (no `mobile` type invented for one repo); DB/migration/Playwright
+  steps marked N/A or overridden in CLAUDE-context.md.
+- DEC-050's per-phase web↔app parity pass is owned by bushel-mobile's retro (downstream
+  repo carries the obligation so it can't be dropped).
+
+Why: the seeds machinery is single-repo by construction (sessions worktree, gh defaults,
+per-repo SemVer, DEC-S026 issue-based throughput). An Expo app's own package.json forces
+an independent version line, making a shared-ledger satellite impossible. Splitting at the
+repo boundary lets every skill run unmodified. Sets no precedent for muster (per DEC-050).
+
+Relates: DEC-050 (repo shape), DEC-047 (bearer session), DEC-S013/S014/S022/S026 (workflow),
+DEC-S011 (project-type).
+
+---
+
 ## Open / Pending Product Owner Discussion
 
 - **Minimum delivery amount (in dollars).** Threshold below which delivery is unavailable, or above which delivery is free. Phase 7+ candidate.

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -277,19 +277,17 @@ Re-keys order identity from the week to the open order, kills the scheduled-clos
 
 ---
 
-## Phase 11 — Expo mobile app: muster rehearsal, push-first (20 pts)
+## Phase 11 — Bushel `/api/*` surface for the mobile app (5 pts)
 
-Separate repo `bushel-mobile` (DEC-050): Expo/React Native, push notifications as the point (long-term path off SMS/Twilio for non-SMS users), read-only orders list + one mutation. Annabel = Android sideload APK ($0, full push). Emma = iPhone free-signed 7-day builds, install-only — **iOS remote push is gated on the deferred $99 Apple Developer enrollment** (APNs key requires paid membership). Bushel's first real `/api/*` routes (Server Actions are uncallable from native), authenticated by DEC-047's bearer-consumable session.
+Bushel's first real `/api/*` routes (Server Actions are uncallable from native), authenticated by DEC-047's bearer-consumable session. This is the backend contract the Expo app calls; the app itself is a **separate, independent repo** — `bushel-mobile` Phase 1 (DEC-052). A phase never spans repos: 11.2–11.5 moved to bushel-mobile.
 
 **Gated on Phase 10** (10.2 data layer + 10.3 auth merged) — building API routes against the Supabase layer would be throwaway work.
 
 | # | Task | Pts | Status |
 |---|---|---|---|
 | 11.1 | `/api/*` routes on bushel + bearer-token auth guard | 5 | [#261](https://github.com/mobiustripper42/bushel/issues/261) |
-| 11.2 | Expo app scaffold + email-code login + orders list | 5 | [#262](https://github.com/mobiustripper42/bushel/issues/262) |
-| 11.3 | Expo push: token registration + Android push end-to-end | 5 | [#263](https://github.com/mobiustripper42/bushel/issues/263) |
-| 11.4 | Mark-fulfilled mutation from the app | 2 | [#264](https://github.com/mobiustripper42/bushel/issues/264) |
-| 11.5 | Android EAS build → sideloaded APK; iOS free-sign install | 3 | [#265](https://github.com/mobiustripper42/bushel/issues/265) |
+
+→ **11.2–11.5 moved to bushel-mobile Phase 1 (DEC-052)** — Expo scaffold + login + orders (was #262), push (was #263), mark-fulfilled mutation (was #264), EAS build/sideload (was #265). Recreated as bushel-mobile issues; 15 pts on that repo's own ledger.
 
 DEC-039 (#218's additive-orders decision) lands in `DECISIONS.md` when 9.1 merges; DEC-040–045 are already written. Customer-facing order history (#136) stays in the backlog.
 


### PR DESCRIPTION
Part A of the bushel-mobile bootstrap (`docs/BUSHEL-MOBILE-KICKOFF.md`).

## What changed
- **DEC-052** added to `docs/DECISIONS.md` — bushel-mobile is a fully independent seeds-managed project (own CLAUDE.md shell, skills/agents, `sessions` branch, SemVer, `/retro`). Standing invariant: **a phase never spans repos.**
- **Phase 11 re-scoped** in `docs/PROJECT_PLAN.md` from 20pt → **5pt** (just 11.1 — the `/api/*` routes + bearer guard, which stays a bushel task). 11.2–11.5 moved to bushel-mobile Phase 1 (15pt, its own ledger).
- **Closed #262–#265** as "not planned" with a "Moved to bushel-mobile Phase 1 (DEC-052)" comment. Their design notes are preserved in the kickoff doc + DEC-052.

## Not in this PR
- Parts B–D (create/scaffold bushel-mobile, install seeds workflow, materialize its Phase 1) happen in the `bushel-mobile` repo.
- Task **11.1 (#261)** — the `/api/*` surface — is unaffected and still open in bushel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)