### PR TITLE
11.1: /api/mobile/* routes + bearer-token guard (DEC-047/050/052) — closes #261

### DIFF
--- a/.claude/CLAUDE-context.md
+++ b/.claude/CLAUDE-context.md
@@ -146,7 +146,7 @@ Failure modes:
 
 ### Data Fetching
 - Server Components + Server Actions query Postgres via `query`/`queryOne` from `src/lib/db.ts` (the pg pool).
-- Mutations via Server Actions (not API routes). Every action gates on `getAdminUser()` (DEC-047) for admin surfaces.
+- Mutations via Server Actions (not API routes) — except `/api/mobile/*` (DEC-050/052), bearer-gated HTTP routes for the bushel-mobile Expo app, which can't invoke Server Actions. Mutations shared with those routes live as service-layer functions (`src/lib/admin/order-mutations.ts`); the route + the action are thin wrappers over one write path. Every action gates on `getAdminUser()` (DEC-047) for admin surfaces; the mobile routes gate on `bearerSubject()` (`src/lib/auth/bearer.ts`).
 - No client-side DB access — customer reads resolve `bbf_customer_token` → `customers.token` server-side (DEC-004).
 
 ### Auth & access

--- a/db/migrations/0002_push_tokens.sql
+++ b/db/migrations/0002_push_tokens.sql
@@ -1,0 +1,22 @@
+-- 0002_push_tokens.sql — Expo push-token registry (Phase 11.1, DEC-050/052).
+-- The bushel-mobile app registers its Expo push token here so bushel can fan
+-- order-arrival notifications out to Annabel's device (bushel-mobile Phase 1).
+-- First migration after the 0001 consolidation: prod is live (Phase 10.7), so
+-- this can't fold back into the baseline — a fresh DB now replays 0001 then 0002.
+-- No FK on admin_id per DEC-048 (the service layer is the access boundary); the
+-- token itself is unique, so a device re-registering upserts in place and
+-- re-points to whichever admin is signed in on it.
+
+CREATE TABLE public.push_tokens (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    admin_id uuid NOT NULL,                    -- admins.id (bare uuid, no FK — DEC-048)
+    expo_push_token text NOT NULL,             -- ExponentPushToken[...] from expo-notifications
+    platform text NOT NULL,                    -- 'android' | 'ios' (app-enforced, like orders.status)
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT push_tokens_pkey PRIMARY KEY (id),
+    CONSTRAINT push_tokens_expo_push_token_key UNIQUE (expo_push_token)
+);
+
+COMMENT ON TABLE public.push_tokens IS
+  'Expo push tokens for the bushel-mobile app (Phase 11). One row per device; expo_push_token is unique so re-registration upserts. admin_id is admins.id, no FK (DEC-048).';

--- a/db/tests/helpers.ts
+++ b/db/tests/helpers.ts
@@ -49,6 +49,7 @@ const RESET_TABLES = [
   "products",
   "customers",
   "login_codes",
+  "push_tokens",
 ];
 
 export async function resetData(): Promise<void> {

--- a/db/tests/mobile-api.test.ts
+++ b/db/tests/mobile-api.test.ts
@@ -1,0 +1,272 @@
+/**
+ * /api/mobile/* route integration (Phase 11.1). Drives the route handlers
+ * directly (construct a Request, call the exported GET/POST) against docker
+ * Postgres — the bearer guard, the auth token round-trip, the fulfill mutation,
+ * and the push-token upsert, end to end. The pure header-parsing branches live
+ * in src/lib/auth/bearer.test.ts; this file proves the wiring and the DB writes.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { query } from "@/lib/db";
+import { hashCode } from "@/lib/auth/login-code";
+import { makeSession, signSession, type Subject } from "@/lib/auth/session";
+import { SESSION_TTL_MS } from "@/lib/auth/config";
+import { canConnect, closePool, migrateTestDb, resetData } from "./helpers";
+
+// Pin the signing secret so the routes' bearerSubject and the tokens we mint
+// below agree. Set before any route module reads sessionSecret() (it resolves
+// lazily per call, so an assignment here is enough).
+const SECRET = "mobile-api-test-secret";
+process.env.SESSION_SECRET = SECRET;
+
+const ADMIN_ID = "a0000000-0000-0000-0000-0000000000a1";
+const ADMIN_EMAIL = "mobile.api@bushel.test";
+const SUBJECT: Subject = { kind: "admin", id: ADMIN_ID };
+
+function bearerToken(): string {
+  return signSession(makeSession(SUBJECT, new Date(), SESSION_TTL_MS), SECRET);
+}
+
+function post(url: string, body: unknown, token?: string): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (token) headers.set("authorization", `Bearer ${token}`);
+  return new Request(url, { method: "POST", headers, body: JSON.stringify(body) });
+}
+
+function get(url: string, token?: string): Request {
+  const headers = new Headers();
+  if (token) headers.set("authorization", `Bearer ${token}`);
+  return new Request(url, { headers });
+}
+
+async function insertCustomer(name: string): Promise<string> {
+  const rows = await query<{ id: string }>(
+    `insert into customers (name, token) values ($1, $2) returning id::text as id`,
+    [name, `tok-${name}`],
+  );
+  return rows[0].id;
+}
+
+async function insertOrder(
+  customerId: string,
+  status: string,
+  fulfillmentType: "pickup" | "delivery" = "pickup",
+): Promise<string> {
+  const rows = await query<{ id: string }>(
+    `insert into orders (customer_id, week_of, fulfillment_type, status)
+     values ($1, current_date, $2, $3) returning id::text as id`,
+    [customerId, fulfillmentType, status],
+  );
+  return rows[0].id;
+}
+
+const d = (await canConnect()) ? describe : describe.skip;
+
+d("/api/mobile/* (pg-integration)", () => {
+  beforeAll(async () => {
+    await migrateTestDb();
+    await query(
+      `insert into admins (id, email, name) values ($1, $2, 'Mobile API Test')
+       on conflict (email) do update
+         set id = excluded.id, name = excluded.name, is_active = true`,
+      [ADMIN_ID, ADMIN_EMAIL],
+    );
+  });
+  afterAll(closePool);
+  beforeEach(resetData); // clears customers/orders/login_codes/push_tokens; admins persist
+
+  describe("auth/request-code", () => {
+    it("400s on invalid JSON", async () => {
+      const { POST } = await import("@/app/api/mobile/auth/request-code/route");
+      const req = new Request("http://t/api/mobile/auth/request-code", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not json",
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("returns ok and mints no code for a non-admin email (no-enumeration)", async () => {
+      const { POST } = await import("@/app/api/mobile/auth/request-code/route");
+      // A non-matching email takes the `skip` path — same 200, and it never
+      // enters the send branch, so no code row is written.
+      const res = await POST(
+        post("http://t/api/mobile/auth/request-code", { email: "stranger@nope.test" }),
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).ok).toBe(true);
+      const rows = await query(`select 1 from login_codes`);
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  describe("auth/verify-code", () => {
+    it("returns a bearer token that a guarded route accepts", async () => {
+      const { POST } = await import("@/app/api/mobile/auth/verify-code/route");
+      const { GET } = await import("@/app/api/mobile/orders/route");
+
+      // Seed a live code for the admin (only the hash is ever stored).
+      await query(
+        `insert into login_codes
+           (subject_kind, subject_id, code_hash, created_at, expires_at, attempts, consumed_at)
+         values ('admin', $1, $2, now(), now() + interval '10 minutes', 0, null)`,
+        [ADMIN_ID, hashCode("246813")],
+      );
+
+      const res = await POST(
+        post("http://t/api/mobile/auth/verify-code", {
+          email: ADMIN_EMAIL,
+          code: "246813",
+        }),
+      );
+      expect(res.status).toBe(200);
+      const { token, expiresAt } = (await res.json()) as {
+        token: string;
+        expiresAt: string;
+      };
+      expect(typeof token).toBe("string");
+      expect(Date.parse(expiresAt)).toBeGreaterThan(Date.now());
+
+      // Round-trip: the returned token authenticates a guarded route.
+      const guarded = await GET(get("http://t/api/mobile/orders", token));
+      expect(guarded.status).toBe(200);
+    });
+
+    it("401s a wrong code without minting a token", async () => {
+      const { POST } = await import("@/app/api/mobile/auth/verify-code/route");
+      await query(
+        `insert into login_codes
+           (subject_kind, subject_id, code_hash, created_at, expires_at, attempts, consumed_at)
+         values ('admin', $1, $2, now(), now() + interval '10 minutes', 0, null)`,
+        [ADMIN_ID, hashCode("111111")],
+      );
+      const res = await POST(
+        post("http://t/api/mobile/auth/verify-code", {
+          email: ADMIN_EMAIL,
+          code: "999999",
+        }),
+      );
+      expect(res.status).toBe(401);
+      expect((await res.json()).error).toBe("invalid");
+    });
+  });
+
+  describe("orders (bearer guard)", () => {
+    it("401s without a token", async () => {
+      const { GET } = await import("@/app/api/mobile/orders/route");
+      const res = await GET(get("http://t/api/mobile/orders"));
+      expect(res.status).toBe(401);
+    });
+
+    it("returns the active order set with a valid token", async () => {
+      const { GET } = await import("@/app/api/mobile/orders/route");
+      const customer = await insertCustomer("active-co");
+      const orderId = await insertOrder(customer, "ready");
+
+      const res = await GET(get("http://t/api/mobile/orders", bearerToken()));
+      expect(res.status).toBe(200);
+      const { orders } = (await res.json()) as { orders: Array<{ id: string; status: string }> };
+      expect(orders.map((o) => o.id)).toContain(orderId);
+      // Terminal orders must not appear.
+      const done = await insertCustomer("done-co");
+      await insertOrder(done, "picked_up");
+      const res2 = await GET(get("http://t/api/mobile/orders", bearerToken()));
+      const { orders: o2 } = (await res2.json()) as { orders: Array<{ status: string }> };
+      expect(o2.every((o) => o.status !== "picked_up")).toBe(true);
+    });
+  });
+
+  describe("orders/[id]/fulfill", () => {
+    const call = async (id: string, token?: string) => {
+      const { POST } = await import("@/app/api/mobile/orders/[id]/fulfill/route");
+      return POST(post(`http://t/api/mobile/orders/${id}/fulfill`, {}, token), {
+        params: Promise.resolve({ id }),
+      });
+    };
+
+    it("401s without a token", async () => {
+      const res = await call("11111111-1111-1111-1111-111111111111");
+      expect(res.status).toBe(401);
+    });
+
+    it("advances a ready pickup order to picked_up", async () => {
+      const customer = await insertCustomer("fulfill-pickup");
+      const orderId = await insertOrder(customer, "ready", "pickup");
+      const res = await call(orderId, bearerToken());
+      expect(res.status).toBe(200);
+      expect((await res.json()).ok).toBe(true);
+      const [{ status }] = await query<{ status: string }>(
+        `select status from orders where id = $1`,
+        [orderId],
+      );
+      expect(status).toBe("picked_up");
+    });
+
+    it("advances a ready delivery order to delivered", async () => {
+      const customer = await insertCustomer("fulfill-delivery");
+      const orderId = await insertOrder(customer, "ready", "delivery");
+      const res = await call(orderId, bearerToken());
+      expect(res.status).toBe(200);
+      const [{ status }] = await query<{ status: string }>(
+        `select status from orders where id = $1`,
+        [orderId],
+      );
+      expect(status).toBe("delivered");
+    });
+
+    it("404s an unknown order", async () => {
+      const res = await call("22222222-2222-2222-2222-222222222222", bearerToken());
+      expect(res.status).toBe(404);
+    });
+
+    it("409s an illegal transition (already terminal)", async () => {
+      const customer = await insertCustomer("already-done");
+      const orderId = await insertOrder(customer, "picked_up", "pickup");
+      const res = await call(orderId, bearerToken());
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe("push-tokens", () => {
+    const register = async (body: unknown, token?: string) => {
+      const { POST } = await import("@/app/api/mobile/push-tokens/route");
+      return POST(post("http://t/api/mobile/push-tokens", body, token));
+    };
+
+    it("401s without a token", async () => {
+      const res = await register({ token: "ExponentPushToken[x]", platform: "android" });
+      expect(res.status).toBe(401);
+    });
+
+    it("400s a missing/invalid platform", async () => {
+      const res = await register({ token: "ExponentPushToken[x]" }, bearerToken());
+      expect(res.status).toBe(400);
+    });
+
+    it("registers a token to the authenticated admin", async () => {
+      const res = await register(
+        { token: "ExponentPushToken[abc]", platform: "android" },
+        bearerToken(),
+      );
+      expect(res.status).toBe(200);
+      const rows = await query<{ admin_id: string; platform: string }>(
+        `select admin_id::text as admin_id, platform from push_tokens where expo_push_token = $1`,
+        ["ExponentPushToken[abc]"],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].admin_id).toBe(ADMIN_ID);
+      expect(rows[0].platform).toBe("android");
+    });
+
+    it("upserts on re-registration (one row per token, platform updated)", async () => {
+      await register({ token: "ExponentPushToken[dup]", platform: "android" }, bearerToken());
+      await register({ token: "ExponentPushToken[dup]", platform: "ios" }, bearerToken());
+      const rows = await query<{ platform: string }>(
+        `select platform from push_tokens where expo_push_token = $1`,
+        ["ExponentPushToken[dup]"],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].platform).toBe("ios");
+    });
+  });
+});

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,64 @@
+# bushel `/api/mobile/*` — the app-facing API
+
+The surface the **bushel-mobile** Expo app calls (Phase 11.1, #261). bushel's
+web UI runs on Server Actions, which native clients can't invoke — so these are
+bushel's first real HTTP data routes (DEC-050). Everything is JSON in / JSON out.
+
+**Base URL:** the bushel deployment, e.g. `https://order.baybranchfarm.com`.
+
+## Auth (DEC-047)
+
+The app authenticates with the **same HMAC session token** the web login mints,
+carried as a bearer header instead of an httpOnly cookie. Two steps to obtain it,
+then send it on every guarded call:
+
+```
+Authorization: Bearer <token>
+```
+
+The token is stateless and self-expiring (14-day TTL, sliding on the web side but
+the app simply re-runs the login when a guarded call returns 401). Store it in
+`expo-secure-store`.
+
+### `POST /api/mobile/auth/request-code`
+Body `{ "email": string }`. Always `200 { "ok": true }` — no-enumeration: the
+response is identical whether or not the email matches an admin, and the code is
+only sent on a match (off the hot path, so timing doesn't leak the match).
+
+### `POST /api/mobile/auth/verify-code`
+Body `{ "email": string, "code": string }`.
+- `200 { "token": string, "expiresAt": string }` — the bearer token + its ISO expiry.
+- `401 { "error": "invalid" | "expired" | "locked" }` — wrong/expired code, or the
+  5-attempt cap tripped.
+
+## Guarded routes
+
+All require a valid bearer token; missing/invalid/expired → `401 { "error": "Unauthorized" }`.
+
+### `GET /api/mobile/orders`
+The active (non-terminal) order set — the same `listActiveOrders` read the admin
+Orders page uses (DEC-041/045).
+- `200 { "orders": OrderRow[] }` — see `src/lib/admin/order-status.ts` for the
+  `OrderRow` shape (customer, items, totals, status, fulfillment type, timestamps).
+
+### `POST /api/mobile/orders/[id]/fulfill`
+Mark an order fulfilled — the app's single mutation (thin scope, DEC-050). The
+terminal status is derived server-side from the order's fulfillment type
+(pickup → `picked_up`, delivery → `delivered`); the client sends no status.
+- `200 { "ok": true }`
+- `404 { "error": "Order not found" }`
+- `409 { "error": string }` — illegal transition (e.g. an order that was never
+  marked `ready`).
+
+### `POST /api/mobile/push-tokens`
+Register the device's Expo push token to the signed-in admin (upsert on the
+token — idempotent across re-registration).
+- Body `{ "token": string, "platform": "android" | "ios" }`.
+- `200 { "ok": true }`
+- `400 { "error": string }` — missing token or invalid platform.
+
+## Notes for the app side
+- One write path: `fulfill` and the admin UI share `advanceOrder` (DEC-052 parity
+  mechanism 1), so the app can't drift from the admin's status rules.
+- iOS remote push is gated on the deferred $99 Apple Developer enrollment; the
+  registry accepts `ios` tokens now, fan-out is Android-first (bushel-mobile Phase 1).

--- a/src/actions/advance-order-status.ts
+++ b/src/actions/advance-order-status.ts
@@ -3,12 +3,12 @@
 import { revalidatePath } from "next/cache";
 
 import { getAdminUser } from "@/lib/admin/auth";
-import { isValidTransition, type OrderStatus } from "@/lib/admin/order-status";
-import { query } from "@/lib/db";
-import { pgMessage } from "@/lib/pg-errors";
+import { type OrderStatus } from "@/lib/admin/order-status";
+import { advanceOrder } from "@/lib/admin/order-mutations";
 
-// Admin gate first, then full-privilege pg writes (DEC-048 — the service
-// layer is the boundary; RLS is gone).
+// Admin gate first, then the shared status write path (DEC-052 parity mechanism
+// 1 — same core the /api/mobile route calls). On success, revalidate the Orders
+// page; the bearer route skips this (no page cache to bust).
 export async function advanceOrderStatus(
   orderId: string,
   nextStatus: OrderStatus,
@@ -16,32 +16,7 @@ export async function advanceOrderStatus(
   const user = await getAdminUser();
   if (!user) return { error: "Unauthorized" };
 
-  try {
-    const rows = await query<{ status: string; fulfillment_type: string }>(
-      `select status, fulfillment_type from orders where id = $1`,
-      [orderId],
-    );
-    const order = rows[0];
-    if (!order) return { error: "Order not found" };
-
-    const from = order.status as OrderStatus;
-    const fulfillmentType =
-      order.fulfillment_type === "delivery" ? "delivery" : "pickup";
-
-    if (!isValidTransition(from, nextStatus, fulfillmentType)) {
-      return {
-        error: `Cannot move ${from} → ${nextStatus} (${fulfillmentType})`,
-      };
-    }
-
-    await query(
-      `update orders set status = $1, updated_at = now() where id = $2`,
-      [nextStatus, orderId],
-    );
-  } catch (e) {
-    return { error: pgMessage(e) };
-  }
-
-  revalidatePath("/admin/orders");
-  return { error: null };
+  const result = await advanceOrder(orderId, nextStatus);
+  if (!result.error) revalidatePath("/admin/orders");
+  return result;
 }

--- a/src/app/api/mobile/auth/request-code/route.ts
+++ b/src/app/api/mobile/auth/request-code/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse, after } from "next/server";
+
+import { requestLoginCode } from "@/lib/auth/login-code";
+import { sendLoginCode } from "@/lib/auth/email";
+
+// POST /api/mobile/auth/request-code  { email } → { ok: true }, always.
+// The native counterpart of the web login step 1 (src/app/login/actions.ts).
+// No-enumeration: the response is identical whether or not the email matched an
+// admin; only a match sends, and the send is scheduled off the hot path (after)
+// so a match isn't observably slower — no timing oracle. The app holds the email
+// itself and posts it again to verify-code (no pending-email cookie needed).
+export async function POST(req: Request) {
+  let email = "";
+  try {
+    const body = await req.json();
+    email = typeof body?.email === "string" ? body.email : "";
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const result = await requestLoginCode(email);
+  if (result.outcome === "deliver") {
+    const { recipientEmail, code } = result;
+    after(async () => {
+      try {
+        await sendLoginCode(recipientEmail, code);
+      } catch (e) {
+        // Swallowed off the hot path — a failed send must not leak or change the
+        // requester-visible response. Server logs only.
+        console.error("login code send failed:", e);
+      }
+    });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/mobile/auth/verify-code/route.ts
+++ b/src/app/api/mobile/auth/verify-code/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+
+import { verifyLoginCode } from "@/lib/auth/login-code";
+import { makeSession, signSession } from "@/lib/auth/session";
+import { SESSION_TTL_MS, sessionSecret } from "@/lib/auth/config";
+
+// POST /api/mobile/auth/verify-code  { email, code }
+//   → 200 { token, expiresAt }  — the DEC-047 HMAC session as a bearer token
+//   → 401 { error: reason }     — "invalid" | "expired" | "locked"
+// Web login step 2 mints the same token into an httpOnly cookie (startSession);
+// the app can't read that, so here we return it in the body for the app to store
+// (expo-secure-store) and send on every /api/mobile/* call. Same token, same
+// 14-day TTL, same secret — it verifies through bearerSubject unchanged.
+export async function POST(req: Request) {
+  let email = "";
+  let code = "";
+  try {
+    const body = await req.json();
+    email = typeof body?.email === "string" ? body.email : "";
+    code = typeof body?.code === "string" ? body.code.trim() : "";
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const result = await verifyLoginCode(email, code);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.reason }, { status: 401 });
+  }
+
+  const session = makeSession(result.subject, new Date(), SESSION_TTL_MS);
+  const token = signSession(session, sessionSecret());
+  return NextResponse.json({ token, expiresAt: session.expiresAt });
+}

--- a/src/app/api/mobile/orders/[id]/fulfill/route.ts
+++ b/src/app/api/mobile/orders/[id]/fulfill/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+
+import { bearerSubject } from "@/lib/auth/bearer";
+import { fulfillOrder } from "@/lib/admin/order-mutations";
+
+// POST /api/mobile/orders/[id]/fulfill — bearer-guarded. The app's single
+// mutation (DEC-050 thin scope): mark the order fulfilled. The terminal status
+// (picked_up|delivered) is derived server-side from fulfillment_type, so the
+// client sends no status. 404 when the order is gone; 409 when the transition is
+// illegal (e.g. a `new` order that was never marked ready).
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  if (!bearerSubject(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await ctx.params;
+  const result = await fulfillOrder(id);
+  if (result.error) {
+    const status = result.error === "Order not found" ? 404 : 409;
+    return NextResponse.json({ error: result.error }, { status });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/mobile/orders/route.ts
+++ b/src/app/api/mobile/orders/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+import { bearerSubject } from "@/lib/auth/bearer";
+import { listActiveOrders } from "@/lib/admin/orders-queries";
+
+// GET /api/mobile/orders — bearer-guarded. The active (non-terminal) order set,
+// the same service read the admin Orders page and fulfillment sheet use
+// (DEC-041/045) — one source of truth for "what's still open".
+export async function GET(req: Request) {
+  if (!bearerSubject(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const orders = await listActiveOrders();
+  return NextResponse.json({ orders });
+}

--- a/src/app/api/mobile/push-tokens/route.ts
+++ b/src/app/api/mobile/push-tokens/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+import { bearerSubject } from "@/lib/auth/bearer";
+import { registerPushToken, type Platform } from "@/lib/notifications/push";
+
+// POST /api/mobile/push-tokens  { token, platform } — bearer-guarded. Registers
+// the caller's Expo push token to the authenticated admin (upsert on token, so
+// re-registration is idempotent). platform must be 'android' | 'ios'.
+export async function POST(req: Request) {
+  const subject = bearerSubject(req);
+  if (!subject) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let token = "";
+  let platform = "";
+  try {
+    const body = await req.json();
+    token = typeof body?.token === "string" ? body.token : "";
+    platform = body?.platform === "ios" || body?.platform === "android" ? body.platform : "";
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!token || !platform) {
+    return NextResponse.json(
+      { error: "token and platform (android|ios) are required" },
+      { status: 400 },
+    );
+  }
+
+  await registerPushToken(subject.id, token, platform as Platform);
+  return NextResponse.json({ ok: true });
+}

--- a/src/lib/admin/order-mutations.ts
+++ b/src/lib/admin/order-mutations.ts
@@ -10,6 +10,29 @@ import { pgMessage } from "@/lib/pg-errors";
 
 export type MutationResult = { error: string | null };
 
+function narrowFulfillment(s: string): "pickup" | "delivery" {
+  return s === "delivery" ? "delivery" : "pickup";
+}
+
+// Validate + write, given the already-read current status. Kept private so both
+// entry points read the order row exactly once (no second round-trip) and share
+// one copy of the transition-guard + update.
+async function applyTransition(
+  orderId: string,
+  from: OrderStatus,
+  to: OrderStatus,
+  fulfillmentType: "pickup" | "delivery",
+): Promise<MutationResult> {
+  if (!isValidTransition(from, to, fulfillmentType)) {
+    return { error: `Cannot move ${from} → ${to} (${fulfillmentType})` };
+  }
+  await query(
+    `update orders set status = $1, updated_at = now() where id = $2`,
+    [to, orderId],
+  );
+  return { error: null };
+}
+
 /**
  * Move an order to `nextStatus` if the transition is legal for its fulfillment
  * type. "Order not found" and an illegal-transition message are returned (not
@@ -28,40 +51,44 @@ export async function advanceOrder(
     const order = rows[0];
     if (!order) return { error: "Order not found" };
 
-    const from = order.status as OrderStatus;
-    const fulfillmentType =
-      order.fulfillment_type === "delivery" ? "delivery" : "pickup";
-
-    if (!isValidTransition(from, nextStatus, fulfillmentType)) {
-      return { error: `Cannot move ${from} → ${nextStatus} (${fulfillmentType})` };
-    }
-
-    await query(
-      `update orders set status = $1, updated_at = now() where id = $2`,
-      [nextStatus, orderId],
+    return await applyTransition(
+      orderId,
+      order.status as OrderStatus,
+      nextStatus,
+      narrowFulfillment(order.fulfillment_type),
     );
   } catch (e) {
     return { error: pgMessage(e) };
   }
-  return { error: null };
 }
 
 /**
  * Mark an order fulfilled — the mobile app's single mutation (DEC-050 thin
  * scope). The terminal status is derived server-side from the order's
  * fulfillment_type (pickup → picked_up, delivery → delivered) so the client
- * never has to know the status vocabulary; the transition is still validated by
- * advanceOrder (a non-`ready` order fails the same way the admin UI would).
+ * never has to know the status vocabulary; the transition is still validated
+ * (a non-`ready` order fails the same way the admin UI would). Reads the order
+ * row once and hands off to the shared apply — no double round-trip.
  */
 export async function fulfillOrder(orderId: string): Promise<MutationResult> {
-  const rows = await query<{ fulfillment_type: string }>(
-    `select fulfillment_type from orders where id = $1`,
-    [orderId],
-  );
-  const order = rows[0];
-  if (!order) return { error: "Order not found" };
+  try {
+    const rows = await query<{ status: string; fulfillment_type: string }>(
+      `select status, fulfillment_type from orders where id = $1`,
+      [orderId],
+    );
+    const order = rows[0];
+    if (!order) return { error: "Order not found" };
 
-  const terminal: OrderStatus =
-    order.fulfillment_type === "delivery" ? "delivered" : "picked_up";
-  return advanceOrder(orderId, terminal);
+    const fulfillmentType = narrowFulfillment(order.fulfillment_type);
+    const terminal: OrderStatus =
+      fulfillmentType === "delivery" ? "delivered" : "picked_up";
+    return await applyTransition(
+      orderId,
+      order.status as OrderStatus,
+      terminal,
+      fulfillmentType,
+    );
+  } catch (e) {
+    return { error: pgMessage(e) };
+  }
 }

--- a/src/lib/admin/order-mutations.ts
+++ b/src/lib/admin/order-mutations.ts
@@ -1,0 +1,67 @@
+// Order-status write path (Phase 11.1, DEC-052 parity mechanism 1). The status
+// logic lives here once; the two entry wrappers gate and adapt around it —
+// the admin Server Action (advance-order-status.ts) is cookie-gated and
+// revalidates the page cache, the /api/mobile route is bearer-gated and returns
+// JSON. Neither re-implements the transition rules. No auth check inside — the
+// wrapper owns the gate (DEC-048: the service layer is the boundary once past it).
+import { query } from "@/lib/db";
+import { isValidTransition, type OrderStatus } from "@/lib/admin/order-status";
+import { pgMessage } from "@/lib/pg-errors";
+
+export type MutationResult = { error: string | null };
+
+/**
+ * Move an order to `nextStatus` if the transition is legal for its fulfillment
+ * type. "Order not found" and an illegal-transition message are returned (not
+ * thrown) so both wrappers can surface them; unexpected pg errors come back via
+ * pgMessage.
+ */
+export async function advanceOrder(
+  orderId: string,
+  nextStatus: OrderStatus,
+): Promise<MutationResult> {
+  try {
+    const rows = await query<{ status: string; fulfillment_type: string }>(
+      `select status, fulfillment_type from orders where id = $1`,
+      [orderId],
+    );
+    const order = rows[0];
+    if (!order) return { error: "Order not found" };
+
+    const from = order.status as OrderStatus;
+    const fulfillmentType =
+      order.fulfillment_type === "delivery" ? "delivery" : "pickup";
+
+    if (!isValidTransition(from, nextStatus, fulfillmentType)) {
+      return { error: `Cannot move ${from} → ${nextStatus} (${fulfillmentType})` };
+    }
+
+    await query(
+      `update orders set status = $1, updated_at = now() where id = $2`,
+      [nextStatus, orderId],
+    );
+  } catch (e) {
+    return { error: pgMessage(e) };
+  }
+  return { error: null };
+}
+
+/**
+ * Mark an order fulfilled — the mobile app's single mutation (DEC-050 thin
+ * scope). The terminal status is derived server-side from the order's
+ * fulfillment_type (pickup → picked_up, delivery → delivered) so the client
+ * never has to know the status vocabulary; the transition is still validated by
+ * advanceOrder (a non-`ready` order fails the same way the admin UI would).
+ */
+export async function fulfillOrder(orderId: string): Promise<MutationResult> {
+  const rows = await query<{ fulfillment_type: string }>(
+    `select fulfillment_type from orders where id = $1`,
+    [orderId],
+  );
+  const order = rows[0];
+  if (!order) return { error: "Order not found" };
+
+  const terminal: OrderStatus =
+    order.fulfillment_type === "delivery" ? "delivered" : "picked_up";
+  return advanceOrder(orderId, terminal);
+}

--- a/src/lib/auth/bearer.test.ts
+++ b/src/lib/auth/bearer.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Bearer-guard unit tests (Phase 11.1). Pure — no DB. Exercises the header
+ * parsing + the pass-through to verifySession: a good token yields the subject,
+ * everything else (missing, wrong scheme, tampered, expired) yields null so the
+ * route returns 401.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { bearerSubject } from "./bearer";
+import { makeSession, signSession, type Subject } from "./session";
+
+const SECRET = "bearer-test-secret";
+const SUBJECT: Subject = { kind: "admin", id: "a0000000-0000-0000-0000-000000000009" };
+const NOW = new Date("2026-07-06T12:00:00Z");
+
+// bearerSubject reads sessionSecret() from the env; pin it for the file.
+let prevSecret: string | undefined;
+beforeAll(() => {
+  prevSecret = process.env.SESSION_SECRET;
+  process.env.SESSION_SECRET = SECRET;
+});
+afterAll(() => {
+  if (prevSecret === undefined) delete process.env.SESSION_SECRET;
+  else process.env.SESSION_SECRET = prevSecret;
+});
+
+function reqWith(authorization?: string): Request {
+  const headers = new Headers();
+  if (authorization !== undefined) headers.set("authorization", authorization);
+  return new Request("http://bushel.test/api/mobile/orders", { headers });
+}
+
+function tokenValidAt(now: Date, ttlMs: number, secret = SECRET): string {
+  return signSession(makeSession(SUBJECT, now, ttlMs), secret);
+}
+
+describe("bearerSubject", () => {
+  it("returns the subject for a valid, unexpired bearer token", () => {
+    const token = tokenValidAt(NOW, 60_000);
+    const subject = bearerSubject(reqWith(`Bearer ${token}`), NOW);
+    expect(subject).toEqual(SUBJECT);
+  });
+
+  it("is case-insensitive on the scheme", () => {
+    const token = tokenValidAt(NOW, 60_000);
+    expect(bearerSubject(reqWith(`bearer ${token}`), NOW)).toEqual(SUBJECT);
+  });
+
+  it("returns null when the Authorization header is absent", () => {
+    expect(bearerSubject(reqWith(undefined), NOW)).toBeNull();
+  });
+
+  it("returns null for a non-Bearer scheme", () => {
+    const token = tokenValidAt(NOW, 60_000);
+    expect(bearerSubject(reqWith(`Basic ${token}`), NOW)).toBeNull();
+  });
+
+  it("returns null for a bare token with no scheme", () => {
+    const token = tokenValidAt(NOW, 60_000);
+    expect(bearerSubject(reqWith(token), NOW)).toBeNull();
+  });
+
+  it("returns null for a malformed token", () => {
+    expect(bearerSubject(reqWith("Bearer not-a-token"), NOW)).toBeNull();
+  });
+
+  it("returns null for a token signed with a different secret", () => {
+    const token = tokenValidAt(NOW, 60_000, "some-other-secret");
+    expect(bearerSubject(reqWith(`Bearer ${token}`), NOW)).toBeNull();
+  });
+
+  it("returns null once the token has expired", () => {
+    const token = tokenValidAt(NOW, 60_000);
+    const later = new Date(NOW.getTime() + 120_000);
+    expect(bearerSubject(reqWith(`Bearer ${token}`), later)).toBeNull();
+  });
+});

--- a/src/lib/auth/bearer.ts
+++ b/src/lib/auth/bearer.ts
@@ -1,0 +1,20 @@
+/**
+ * Bearer-token auth for the /api/mobile/* surface (Phase 11.1, DEC-047/050).
+ * Native clients can't invoke Server Actions or read the httpOnly session cookie,
+ * so the bushel-mobile app carries the SAME HMAC session token (DEC-047) in an
+ * `Authorization: Bearer <token>` header. This verifies it with the exact
+ * framework-free verifier the cookie path uses (verifySession) — no second trust
+ * root, no new session table. A route with a null subject returns 401.
+ */
+import { sessionSecret } from "./config";
+import { verifySession, type Subject } from "./session";
+
+/** The subject behind a request's bearer token, or null if absent/malformed/invalid/expired. */
+export function bearerSubject(req: Request, now: Date = new Date()): Subject | null {
+  const header = req.headers.get("authorization");
+  if (!header) return null;
+  const [scheme, token] = header.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !token) return null;
+  const result = verifySession(token, sessionSecret(), now);
+  return result.ok ? result.subject : null;
+}

--- a/src/lib/auth/session-cookie.ts
+++ b/src/lib/auth/session-cookie.ts
@@ -14,20 +14,12 @@ import {
   sessionSecret,
 } from "./config";
 import {
+  makeSession,
   shouldRenew,
   signSession,
   verifySession,
-  type Session,
   type Subject,
 } from "./session";
-
-function makeSession(subject: Subject, now: Date): Session {
-  return {
-    subjectKind: subject.kind,
-    subjectId: subject.id,
-    expiresAt: new Date(now.getTime() + SESSION_TTL_MS).toISOString(),
-  };
-}
 
 /**
  * Gate `secure` on the actual transport, not NODE_ENV: WebKit refuses Secure
@@ -50,7 +42,7 @@ function cookieOptions(expiresAt: string, secure: boolean) {
 
 /** Mint + set the session cookie (server-action use). */
 export async function startSession(subject: Subject): Promise<void> {
-  const session = makeSession(subject, new Date());
+  const session = makeSession(subject, new Date(), SESSION_TTL_MS);
   const jar = await cookies();
   jar.set(
     ADMIN_SESSION_COOKIE,
@@ -75,7 +67,7 @@ export async function readSubject(): Promise<Subject | null> {
 
   if (shouldRenew(result.session, now, RENEW_WITHIN_MS)) {
     try {
-      const renewed = makeSession(result.subject, now);
+      const renewed = makeSession(result.subject, now, SESSION_TTL_MS);
       jar.set(
         ADMIN_SESSION_COOKIE,
         signSession(renewed, sessionSecret()),

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -41,6 +41,19 @@ export function signSession(session: Session, secret: string): string {
   return `${payloadB64}.${sign(payloadB64, secret)}`;
 }
 
+/**
+ * Build a fresh session for a subject with the given lifetime. Framework-free so
+ * both the cookie glue (session-cookie.ts) and the bearer/API path mint the same
+ * shape from one place — the token's meaning can't drift between the two entries.
+ */
+export function makeSession(subject: Subject, now: Date, ttlMs: number): Session {
+  return {
+    subjectKind: subject.kind,
+    subjectId: subject.id,
+    expiresAt: new Date(now.getTime() + ttlMs).toISOString(),
+  };
+}
+
 export type SessionFailure = "malformed" | "bad_signature" | "expired";
 
 export type SessionResult =

--- a/src/lib/notifications/push.ts
+++ b/src/lib/notifications/push.ts
@@ -1,0 +1,24 @@
+// Expo push-token registry writes (Phase 11.1). The bushel-mobile app registers
+// its device token here after sign-in; the order-arrival fan-out (bushel-mobile
+// Phase 1) reads the table to know where to push. Upsert on the token so a
+// device re-registering — new session, reinstall, admin switch — updates the
+// owning admin + platform in place rather than piling up duplicate rows.
+import { query } from "@/lib/db";
+
+export type Platform = "android" | "ios";
+
+export async function registerPushToken(
+  adminId: string,
+  expoPushToken: string,
+  platform: Platform,
+): Promise<void> {
+  await query(
+    `insert into push_tokens (admin_id, expo_push_token, platform)
+     values ($1, $2, $3)
+     on conflict (expo_push_token) do update
+       set admin_id = excluded.admin_id,
+           platform = excluded.platform,
+           updated_at = now()`,
+    [adminId, expoPushToken, platform],
+  );
+}


### PR DESCRIPTION
## Summary
bushel's first real HTTP data API (`/api/mobile/*`) for the bushel-mobile Expo app — native clients can't invoke Server Actions (DEC-050). Verifies the DEC-047 HMAC session token as a bearer header; the fulfill mutation shares one write path with the admin UI (DEC-052 parity mechanism 1). `closes #261`.

## Files changed
- `db/migrations/0002_push_tokens.sql` — Expo push-token registry (unique token → upsert, no FK per DEC-048). First migration after the 0001 consolidation.
- `db/tests/helpers.ts` — add `push_tokens` to the per-test truncate set
- `src/lib/auth/bearer.ts` — `Authorization: Bearer` guard, reuses `verifySession`
- `src/lib/auth/session.ts` / `session-cookie.ts` — extract shared `makeSession` (cookie + bearer mint from one place); cookie behavior unchanged
- `src/lib/admin/order-mutations.ts` — `advanceOrder` / `fulfillOrder` service core (single order-row read each)
- `src/actions/advance-order-status.ts` — Server Action now delegates to `advanceOrder` (behavior preserved: cookie gate + `revalidatePath`)
- `src/lib/notifications/push.ts` — `registerPushToken` upsert
- `src/app/api/mobile/{auth/request-code,auth/verify-code,orders,orders/[id]/fulfill,push-tokens}/route.ts` — the five routes
- `src/lib/auth/bearer.test.ts` + `db/tests/mobile-api.test.ts` — unit + pg-integration
- `docs/API.md` — the contract, for the bushel-mobile repo
- `.claude/CLAUDE-context.md` — note the `/api/mobile/*` Server-Action carve-out

## Code review
@code-review (Sonnet): no blocking issues. Two notes, both folded in this branch — (1) `fulfillOrder` did a redundant pre-select then `advanceOrder` re-selected → refactored to a single read via a private `applyTransition`; (2) CLAUDE-context "Mutations via Server Actions (not API routes)" didn't note the sanctioned exception → amended. Confirmed: bearer reuses the timing-safe HMAC verify (no second trust root), no-enumeration preserved on request-code, `makeSession` refactor leaves the 14-day TTL + sliding renewal untouched, migration shape correct.

## Migration
`0002_push_tokens.sql` — purely additive, new empty table, no FK, no existing code reads it until the app ships.
- [x] **Neon `main` (preview base): applied** via MCP as one transaction (DDL + COMMENT + `_migrations` ledger row, matching `db/migrate.ts`). Verified: 6 columns, PK + unique constraint, ledger shows `0001` + `0002`.
- [ ] **Neon `production`: NOT yet applied** — deliberately held until this PR merges + promotion (runbook order: prod schema at cutover). Apply the same transaction to the `production` branch, or `npx tsx db/migrate.ts "<neon-prod-unpooled-url>"`, before `/promote-production`.

## Test plan
All automated (API routes, no UI surface — no Playwright/375px):
1. `docker compose up -d` → `DATABASE_URL=…bushel_test npm run test:unit` (or the two touched files).
2. **Bearer guard** (`src/lib/auth/bearer.test.ts`, 8): valid token → subject; missing / non-Bearer scheme / bare token / malformed / wrong-secret / expired → null.
3. **Auth round-trip** (`mobile-api.test.ts`): seed a login code → `POST /auth/verify-code` returns `{token, expiresAt}` → that token authenticates `GET /orders` (200). Wrong code → 401 `invalid`. `request-code`: non-admin email → 200 `{ok:true}` + no code minted (no-enumeration); bad JSON → 400.
4. **Orders** `GET /orders`: no token → 401; valid token → active set contains a seeded `ready` order and excludes a `picked_up` one.
5. **Fulfill** `POST /orders/[id]/fulfill`: ready+pickup → `picked_up` (200); ready+delivery → `delivered` (200); unknown id → 404; already-terminal → 409; no token → 401.
6. **Push-tokens** `POST /push-tokens`: no token → 401; missing/invalid platform → 400; valid → row for the signed-in admin; re-register same token → one row, platform updated (upsert).

Manual (preview deploy, once Neon main has the table — done): request a code for a seeded admin, exchange it via `/api/mobile/auth/verify-code`, hit `/api/mobile/orders` with the returned bearer token.
