### PR TITLE
auto-sync downstream — 2026-07-07

### DIFF
--- a/.claude/skills/promote-production/SKILL.md
+++ b/.claude/skills/promote-production/SKILL.md
@@ -20,13 +20,13 @@ git status --porcelain
 ```
 If non-empty, STOP. Tell the user: "Uncommitted changes — commit, stash, or discard before promoting." Wait.
 
-## Step 0.5 — Confirm the release was QA'd
+## Step 0.5 — Run the project's pre-promote checks
 
-If the project deploys the trunk (`main`) to a shared staging or preview environment before production, confirm it was actually QA'd against **this** release before promoting. The environment and what to check are project-specific — they live in `.claude/CLAUDE-context.md` (`## Migration Protocol (project)`) or `docs/DEPLOYMENT.md`. Ask the user:
+Projects define their own pre-promote gates — a staging/preview QA confirmation, a "no unapplied migrations on prod" check, whatever must be true before shipping. These are project-specific, so they live project-side: read `.claude/CLAUDE-context.md` (`## Migration Protocol (project)`, plus any `## Pre-promote checks` section) and `docs/DEPLOYMENT.md`, then run or confirm every gate listed there before continuing.
 
-**"Has the staging/preview environment been QA'd against this release since the last merge? (yes/no)"**
+The common gate — **QA confirmation:** if the project deploys the trunk to a shared staging/preview environment, confirm it was actually QA'd against **this** release since the last merge. Ask the user: **"Has the staging/preview environment been QA'd against this release? (yes/no)"**
 
-If no, STOP and tell them to QA first. Do not proceed on an unconfirmed answer. If the project deploys straight to production with no separate staging surface, skip this step.
+For any gate that fails or is unconfirmed (no QA, unapplied migrations, etc.), STOP — do not proceed. If the project documents no pre-promote checks, skip this step.
 
 ## Step 1 — Sync local refs
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -115,6 +115,20 @@ Several agents and slash-command skills support the development workflow. All ru
 
 ---
 
+### 8. @ideas
+
+**Purpose:** Idea curator. Captures new ideas as rows in `docs/FUTURE_IDEAS.md`, dedupes against what's already parked, cross-references SPEC/DECISIONS/PROJECT_PLAN/open issues, and keeps the prioritized index in sync.
+
+**When to invoke:**
+- To park a new idea without derailing the build
+- To re-rank the index or audit the parking lot for staleness
+
+**Spec:** `.claude/agents/ideas.md`
+
+**Output:** A one-report curation summary (captured / dedup + cross-reference / flags). Edits only `docs/FUTURE_IDEAS.md`.
+
+---
+
 ## Session Skills
 
 Slash commands manage session lifecycle. Time tracking is automatic.
@@ -224,6 +238,7 @@ Slash commands manage session lifecycle. Time tracking is automatic.
 | @doc-consistency | Sonnet | Via `/doc-consistency-check`, ad-hoc when docs feel drifted | Cross-reference facts across docs; flag mismatches + placeholders. Report-only |
 | @tape-reader | Sonnet | Via `/read-the-tape` | Audit JSONL transcripts for anti-patterns, propose skill improvements |
 | @sync-config | Sonnet | Via `/push-seeds` / `/pull-seeds`, nightly Routine | Classify template diffs, propose backports/forward-ports |
+| @ideas | Sonnet | Park an idea, re-rank, or audit the parking lot | Curate `docs/FUTURE_IDEAS.md`; edits only that file |
 | /its-alive | — | Session start | Open session file + timestamp + briefing |
 | /pause-this | — | Mid-session break | Safe pause with commit |
 | /restart-this | — | Resume from pause | Reload context |


### PR DESCRIPTION
**Base:** main

## Sources
- seeds@50e7ef5 (main) → bushel

## Files updated
- `.claude/skills/promote-production/SKILL.md` — full-file overwrite from seeds (logic-drift: Step 0.5 rewritten to read project-defined pre-promote gates)
- `docs/AGENTS.md` — 2 Template-only hunks forward-ported: new `### 8. @ideas` section + `@ideas` row in Agent Summary table

## Classification table

| File | Hunk | Provenance | Classification | Action |
|------|------|------------|----------------|--------|
| `.claude/skills/promote-production/SKILL.md` | hash mismatch | Class: logic | Forward-port | logic-drift — full-file overwrite from seeds |
| `docs/AGENTS.md` | new `### 8. @ideas` section | Template-only | Forward-port | Applied |
| `docs/AGENTS.md` | new `@ideas` table row | Template-only | Forward-port | Applied |

## Skip summary
- Skipped (class:context, 7 files): SPEC.md, BRAND.md, DECISIONS.md, PROJECT_PLAN.md, RETROSPECTIVES.md, USER_STORIES.md, FUTURE_IDEAS.md
- Skipped (logic, hash-equal, 15 files): 12 skills + 3 logic agents (ideas, sync-config, tape-reader)
- `.claude/agents/ui-reviewer.md`: 4 Both-modified hunks skipped ([Project]→bushel + brand token substitutions, PULL preserves project concretions)
- Hybrid files with no diff: CLAUDE.md, architect.md, code-review.md, doc-consistency.md, pm.md, CHEATSHEET.md, VELOCITY_AND_POKER_GUIDE.md

## Operational notes
- Duplicate-PR check ran cleanly against `mobiustripper42/bushel`.
- Project-type: `webapp`. No type-gated skips.

_Nightly auto-sync Routine (DEC-S010) — one commit, human review before merge._

---
_Generated by [Claude Code](https://claude.ai/code/session_017J9vAi79cKpwhfmce5rcwZ)_