### PR TITLE
auto-sync downstream — 2026-07-15

### DIFF
--- a/.claude/skills/promote-production/SKILL.md
+++ b/.claude/skills/promote-production/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: promote-production
-description: Promote the active trunk (`main`) to the `production` deploy branch via fast-forward merge, then push. The release was already version-bumped and tagged on `main` by `/retro` or `/bump-major`, so promotion is deploy-only — it advances `production` to the tagged commit. Use when work on `main` is ready to ship. Requires `origin/production` to exist (DEC-S022).
+description: Promote the active trunk (`main`) to the `production` deploy branch via fast-forward merge, then push. Each promotion is a production release: dev projects patch-bump + tag the trunk here, then advance `production` to it (`/retro` owns the phase-close minor, `/bump-major` the major). Use when work on `main` is ready to ship. Requires `origin/production` to exist (DEC-S022).
 tools: Read, Edit, Write, Bash, Grep
 ---
 
-You are promoting `main` → `production`. Under DEC-S022, `main` is the always-active trunk and `production` is a downstream deploy pointer that Vercel (or whatever host) watches. Version bumps and tags already happened on `main` at `/retro` / `/bump-major`; this skill does **not** tag — it ff-merges the trunk into `production` and pushes, which is the deploy moment.
+You are promoting `main` → `production`. Under DEC-S022, `main` is the always-active trunk and `production` is a downstream deploy pointer that Vercel (or whatever host) watches. Each promotion is a production release: this skill **patch-bumps + tags** the trunk (dev projects), then ff-merges `main` into `production` and pushes — the deploy moment. `/retro` owns the phase-close minor bump; `/bump-major` the major. A `main` HEAD that already carries a fresh `v*` tag (e.g. `/retro`'s minor) ships as-is, without a second bump.
 
 ## Step 0 — Sanity gates
 
@@ -49,14 +49,43 @@ git log --oneline origin/main..origin/production
 ```
 Ask: **"production has diverged from main. Options: (a) merge production into main first (preserves both histories), (b) abort and resolve manually. Which?"** If (a), guide the user through merging `production` → `main` on a branch (likely needs a PR into `main`), then ask them to re-run /promote-production once that lands. Never auto-resolve.
 
-## Step 3 — Identify the release being shipped
+## Step 3 — Release the trunk (patch-bump + tag)
 
+Each promotion is a production release. First, is there anything new to ship?
 ```
-git fetch --tags
-SHIP_SHA=$(git rev-parse origin/main)
-SHIP_TAG=$(git tag --points-at "$SHIP_SHA" | grep '^v' | sort -V | tail -1)
+[ "$(git rev-parse origin/production)" = "$(git rev-parse origin/main)" ] && echo "nothing to ship"
 ```
-`SHIP_TAG` is the version tag already on the trunk HEAD (created by `/retro` or `/bump-major`). If `SHIP_TAG` is empty, surface a warning — promotion still works, but the promoted commit carries no version tag: **"⚠ No `v*` tag on `main` HEAD. Promote anyway (deploys an untagged commit), or bump first via `/retro` / `/bump-major`? (promote/abort)"** Wait. Do **not** invent or apply a tag here — tagging is the trunk skills' job (DEC-S022).
+If equal, STOP: "production is already at `main` HEAD — nothing to ship."
+
+**Non-dev project** (no `package.json` at repo root, DEC-S007): skip the bump. `SHIP_TAG=$(git tag --points-at origin/main | grep '^v' | sort -V | tail -1)` — promote whatever tag is there, or none. Go to Step 4.
+
+**Ship-as-is:** if `main` HEAD already carries a `v*` tag (e.g. `/retro`'s minor or `/bump-major`, and nothing merged since), don't double-bump:
+```
+HEAD_TAG=$(git tag --points-at origin/main | grep '^v' | sort -V | tail -1)
+```
+If `HEAD_TAG` is non-empty, set `SHIP_TAG="$HEAD_TAG"` and go to Step 4.
+
+**Otherwise, patch-bump on `main`** (release commits land on the trunk directly — same as `/retro` / `/bump-major`). Capture what's shipping first:
+```
+git checkout main && git pull --ff-only origin main
+SHIPPING=$(git log --oneline origin/production..HEAD)   # PRs/commits this release ships
+NEW_VERSION=$(npm version patch --no-git-tag-version | tr -d 'v')
+```
+Prepend a `CHANGELOG.md` entry (create it with a literal `# Changelog` header if absent; read first and STOP if the header isn't literal) after the header:
+```
+## [<NEW_VERSION>] - <YYYY-MM-DD>
+- <one bullet per PR/commit in $SHIPPING>
+```
+Commit, tag, push the trunk:
+```
+git add package.json CHANGELOG.md
+[ -f package-lock.json ] && git add package-lock.json
+git commit -m "Release v<NEW_VERSION>"
+git tag "v<NEW_VERSION>"
+git push origin main
+git push origin "v<NEW_VERSION>"
+SHIP_TAG="v<NEW_VERSION>"
+```
 
 ## Step 4 — ff-merge production → main HEAD
 
@@ -72,7 +101,7 @@ If `git merge --ff-only` fails (rare race — `main` moved between Step 2's chec
 ```
 git push origin production
 ```
-The tag, if any, is already on the remote (pushed by the trunk skill that created it). Only push tags here if Step 1's fetch revealed a local tag the remote lacks:
+The release tag was pushed in Step 3 (or already on the remote for a ship-as-is / non-dev promote). Belt-and-suspenders — push it if the remote somehow lacks it:
 ```
 [ -n "$SHIP_TAG" ] && git push origin "$SHIP_TAG" 2>/dev/null || true
 ```

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -200,9 +200,15 @@ If `BRANCH != $WORKING_BRANCH`: STOP. Tell the user "Switch to `$WORKING_BRANCH`
 gh pr list --state merged --search "merged:>=<phase_start_iso> merged:<=<phase_end_iso>" --json number,title,mergedAt --limit 100
 ```
 
-Sort by `mergedAt` ascending. Each PR earns one patch bump + one CHANGELOG entry.
+Sort by `mergedAt` ascending. On **deploy-off-main** projects each PR earns one patch bump + CHANGELOG entry (Step 8.2). On **production-branch** projects patches already landed at `/promote-production` (one release = one patch), so Step 8.2 is skipped and this list feeds only the phase CHANGELOG summary.
 
-### Step 8.2 — Patch-bump per PR
+### Step 8.2 — Patch-bump per PR (deploy-off-main projects only)
+
+**Skip this entire step if a `production` branch exists** — those projects patch-bump at `/promote-production` on each ship, so per-PR patches here would double-count:
+```
+git show-ref --verify --quiet refs/remotes/origin/production && echo "has production — skip to 8.3"
+```
+If `origin/production` exists, go straight to Step 8.3 (minor bump). Only projects that deploy straight off `main` patch-bump per PR below.
 
 For each PR in order, sequentially:
 
@@ -221,7 +227,7 @@ c. **Commit + tag (main only):**
    git commit -m "Bump version to v<NEW_VERSION> (PR #<N>)"
    git tag "v<NEW_VERSION>"
    ```
-   Tags land on the trunk at bump time. Promotion to `production` (if the project has it) carries the already-tagged commit — `/promote-production` does not tag.
+   Tags land on the trunk at bump time. (This step runs only for deploy-off-main projects — there's no `production` branch to promote to.)
 
 ### Step 8.3 — Minor-bump at phase close
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,14 +126,14 @@ Then repoint the host's production branch from `main` to `production` (e.g. Verc
 
 ## Versioning
 
-Every dev project carries a SemVer version in `package.json`, mirrored to a git tag (`vX.Y.Z`) on `main`. `/retro` is the sole place version bumps happen (DEC-S013 moved patch bumps out of `/its-dead`).
+Every dev project carries a SemVer version in `package.json`, mirrored to a git tag (`vX.Y.Z`) on `main`.
 
-**Three triggers (all run at `/retro` per DEC-S013):**
-- **Patch:** `/retro` Step 8.2 — one bump + CHANGELOG entry per PR merged in the phase window. Title pulled from GitHub.
-- **Minor:** `/retro` Step 8.3 — at phase close after all patches. CHANGELOG entry summarizes the phase.
+**Three triggers:**
+- **Patch:** on projects with a `production` branch, `/promote-production` bumps + tags on each ship — one release = one patch (a `main` HEAD that's already a fresh tag ships as-is). On projects that deploy straight off `main` (no `production` branch), `/retro` Step 8.2 patch-bumps per merged PR instead.
+- **Minor:** `/retro` Step 8.3 — at phase close, after any patches (Y+1, X=0). CHANGELOG entry summarizes the phase.
 - **Major:** `/bump-major` manual. User supplies the breaking-change rationale.
 
-**Tag rule:** tags are applied on the active trunk (`main`) at bump time (DEC-S022). A `production` deploy branch, if present, receives the already-tagged commit via `/promote-production` ff-merge — promotion does not tag.
+**Tag rule:** all tags are applied on the active trunk (`main`) at bump time (DEC-S022) — by `/promote-production` (patch, on ship), `/retro` (minor), or `/bump-major` (major). `production` only ever receives an already-tagged `main` commit via ff-merge.
 
 **Detection:** these skills check `package.json` exists at the repo root before bumping. If it doesn't (template/markdown-only project), they no-op silently.
 


### PR DESCRIPTION
Base: `main`

Nightly downstream sync (Routine, DEC-S010). Forward-porting template changes from `mobiustripper42/seeds` into this project. Applied via `@sync-config` in `direction: pull, mode: auto`.

**Sources**
- seeds `main` @ `1e09b7b` → bushel (webapp)

**Files changed**
- `.claude/skills/promote-production/SKILL.md` — logic-class overwrite from seeds
- `.claude/skills/retro/SKILL.md` — logic-class overwrite from seeds
- `CLAUDE.md` — DEC-S019 hybrid shell resynced from seeds

**Classification**

| File | Hunk | Provenance | Classification | Action |
|------|------|------------|----------------|--------|
| `.claude/skills/promote-production/SKILL.md` | logic-class drift (Step 3 rewrite) | Template-only | Forward-port | Overwritten from seeds |
| `.claude/skills/retro/SKILL.md` | logic-class drift (~29 diff lines) | Template-only | Forward-port | Overwritten from seeds |
| `CLAUDE.md` | §Versioning rewrite: three triggers + tag rule | Template-only | Forward-port | Overwritten from seeds (DEC-S019 shell) |

**Skipped hunks**
- `.claude/agents/ui-reviewer.md` — Project-only substitutions preserved (`[Project]`→`bushel`, "the project's design system"→"the Bay Branch Farm design system").
- `docs/SPEC.md`, `docs/BRAND.md`, `docs/DECISIONS.md`, `docs/PROJECT_PLAN.md`, `docs/RETROSPECTIVES.md`, `docs/USER_STORIES.md`, `docs/FUTURE_IDEAS.md` — context-class per DEC-S018 file-classes registry, dropped from scope.
- All other skills + agents + hybrid docs (AGENTS, VELOCITY_AND_POKER_GUIDE, CHEATSHEET) — byte-identical to seeds, no drift.

**Operational notes**
- Project type: `webapp`; seeds-version 4 matches project seeds-version 4.
- Step 1.5 duplicate-PR check: 1 open PR (#284, Tiller idea) — no path overlap with sync scope.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FvDyTBbM6FrrwDHegPLpzj)_