### PR TITLE
auto-sync downstream — 2026-07-21

### DIFF
--- a/docs/DEV_REFERENCE.md
+++ b/docs/DEV_REFERENCE.md
@@ -1,0 +1,42 @@
+# Dev Reference
+
+Reference material pulled out of the always-loaded `CLAUDE.md` shell (DEC-S031) — read when you need it, not every session.
+
+## `<VersionTag />` component
+
+Build-time version display, reads `process.env.NEXT_PUBLIC_APP_VERSION` + `process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA`. Renders e.g. `v1.2.3 (a1b2c3)`.
+
+Wiring:
+- `next.config.ts` (or `next.config.js`) forwards `npm_package_version` → `NEXT_PUBLIC_APP_VERSION`. Critical — without `NEXT_PUBLIC_`, client trees silently render `v0.0.0`.
+- Wire into login screen and footer.
+- Vercel sets `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` automatically. Local `npm run dev` outside Vercel omits the commit hash — that's intentional.
+
+```tsx
+import { VersionTag } from "@/components/VersionTag";
+<VersionTag className="text-xs text-muted-foreground" />
+```
+
+## CHANGELOG.md
+
+Auto-maintained by `/retro` and `/bump-major` (DEC-S013 — `/its-dead` no longer touches it). Don't edit by hand mid-flow — the skills always prepend after the `# Changelog` header. The first bump creates the file if absent.
+
+Format (Keep-a-Changelog inspired but simpler):
+```
+# Changelog
+
+## [1.2.3] - 2026-05-05
+- PR #42: Add login form
+
+## [1.2.2] - 2026-05-04
+- PR #41: Fix dashboard query
+```
+
+## PR Review on Mobile (developer notes)
+
+Doing PR reviews from your phone is tolerable if you structure for it:
+- **GitHub mobile app, not web.** The native app's diff + approve + merge flow is usable. The mobile web is not.
+- **Tap the preview URL first.** Vercel posts it as a comment. 60 seconds of clicking the actual feature catches more than reading the diff would.
+- **Enable auto-merge.** Repo Settings → enable auto-merge, then "Enable auto-merge" on each PR. Checks pass → it merges itself. One less thing to remember to do.
+- **Branch protection:** require CI green (Vercel build + Playwright). Skip reviewer count requirements for solo dev — they add friction with no benefit.
+- **Checklist PR descriptions.** `/kill-this` should populate: does this PR have a migration? RLS change? UI change at 375px? A checkbox list is fast to scan on a small screen.
+- **`gh` CLI on your dev server** is faster than any UI when you're at a keyboard: `gh pr list`, `gh pr view 42 --web`, `gh pr merge 42 --auto`.


### PR DESCRIPTION
Base: `main` (project default, DEC-S022).

Source: `mobiustripper42/seeds@ac7d7e7` (post-DEC-S030/S031 CLAUDE.md shell refactor).

## Sources

- bushel: 1 hunk forward-ported (`docs/DEV_REFERENCE.md` new file), 8 skipped

## Classification (action rows only, mode: auto)

| File | Hunk | Provenance | Classification | Action |
|------|------|------------|----------------|--------|
| `docs/DEV_REFERENCE.md` | (file) | Template-only | Forward-port | Forward-ported (new file from seeds, DEC-S031 refactor) |

## Aggregated files changed

- `docs/DEV_REFERENCE.md` — Template-only pure addition

## Skipped hunks

- `Skipped (class:context, 7 files)`: `docs/SPEC.md`, `docs/BRAND.md`, `docs/DECISIONS.md`, `docs/PROJECT_PLAN.md`, `docs/RETROSPECTIVES.md`, `docs/USER_STORIES.md`, `docs/FUTURE_IDEAS.md`
- `Skipped (logic, hash-equal, 13 files)`
- `CLAUDE.md`: 3 Both-modified hunks skipped (mode:auto default) — DEC-S030/S031 shell refactor: reworded Micro Workflow step 1, Model Selection section (Fable tier restored), VersionTag/CHANGELOG/PR-review sections moved out to `docs/DEV_REFERENCE.md`. Project retains its pre-refactor content; interactive `/pull-seeds` needed to reconcile.
- `.claude/agents/ui-reviewer.md`: 2 Both-modified hunks skipped — Bay Branch Farm brand-token substitutions + project-specific fallback message.

## Operational notes

- File-class registry consulted at Step 1.4 (DEC-S018). Duplicate-PR check clean at run start.
- All hybrid Both-modified drift is deliberate project customization or seeds evolution requiring per-hunk human judgment — auto-mode correctly refuses per DEC-S018.

_Nightly bi-directional sync Routine (DEC-S010). Review the diff before merging._

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcBxC4XuBosUes5J4WG5dn)_