### PR TITLE
Roll out seeds shell audit + cite rule + DEV_REFERENCE (DEC-S030–S032)

### DIFF
--- a/.claude/agents/tape-reader.md
+++ b/.claude/agents/tape-reader.md
@@ -10,6 +10,10 @@ You are @tape-reader — the workflow auditor for Claude Code sessions.
 
 Read a session JSONL transcript, find where the workflow broke down, and propose concrete fixes to skill and agent files. You improve the workflow by watching what actually happened — not what should have happened.
 
+## Ground every finding — never invent a rule
+
+Before you flag a session for violating a project rule, convention, or preference, **verify that rule exists**: grep the repo (`CLAUDE.md`, `.claude/`, `docs/`, `BRAND.md`) and cite the file:line where it's written. If you can't cite it, the rule isn't real — do not flag it, and do not hedge it into the report ("flagging only because I saw it"). A fabricated convention dressed as an observation is worse than a missed finding: it trains the user to distrust every finding you make. Every finding cites two things — the rule's source line, and the transcript line(s) that breach it. No source, no finding.
+
 ## Step 1 — Parse the transcript
 
 **Use grep and wc only. Never use python3, node, or any interpreter to parse the JSONL — they trigger permission prompts and are not needed.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,15 +186,6 @@ Doing PR reviews from your phone is tolerable if you structure for it:
 
 Project-specific debugging gotchas (dev-server checks, stale-process traps, auth-redirect quirks) live in `.claude/CLAUDE-context.md` under `## Workflow Notes (project)`.
 
-## Memory
-
-Two actions, both automatic — never wait for the user to ask, and never defer to session end:
-
-1. **Save on the spot.** The moment the user states a durable fact (a preference, a correction, a project constraint), do two things in that same turn: (a) write the memory file, (b) add its one-line pointer to `MEMORY.md`. Saying "noted" or "I'll remember" is not saving — if no file was written, nothing was remembered.
-2. **Reconcile at session start.** When you load memory, list the memory directory and diff it against `MEMORY.md`. For any file missing a pointer line, add one. Only `MEMORY.md` loads at startup, so an unindexed file never recalls — this self-check catches drift without the user ever having to notice it broke.
-
-A memory is "working" only when both its file exists **and** it has a line in `MEMORY.md`. One without the other is invisible.
-
 ## Approval Before Action (all tasks)
 
 For every task — not just bugs — explain the plan and wait for approval before doing anything:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Project-specific docs are listed in `.claude/CLAUDE-context.md` under `## Additi
 
 ## Micro Workflow (every task, no exceptions)
 
-1. **Spec it** — poker estimate, acceptance criteria. Issue exists from `/start-phase`.
+1. **Spec it** — poker estimate + acceptance criteria. Before writing code, pin what "done" looks like: enumerate the concrete set from source and confirm it with me. My live words override prior docs. (Issue exists from `/start-phase`.)
 2. **Plan it** — summarize what you're going to do. Wait for explicit approval before writing code or running commands.
 3. **Cut the branch** — once approved: `git checkout -b task/X.Y-short-description`.
 4. **Build it**
@@ -88,19 +88,19 @@ Project coding conventions — typing, component structure, data fetching, auth/
 
 ## Model Selection
 
-Default to the cheapest model that does the job. **Opus 4.8 is the standing model** for real development and architecture; Sonnet handles cheap/scoped work.
-
-> **Fable is disabled for now (DEC-S029).** The frontier `claude-fable-5` tier and its bundle-then-escalate trigger are withdrawn from this guidance until re-enabled. Everything below routes between Opus (default) and Sonnet (cheap). DEC-S027 retains the prior Fable tiering as history for when it comes back.
+Default to the cheapest model that does the job. **Opus 4.8 is the standing model** for development and architecture; **Sonnet** handles cheap/scoped work. **Fable is never the default** — it's a deliberate, scope-confirmed escalation for a *bundled* long-horizon unit (several related tasks run as one coherent multi-file pass); at ~2× Opus it drains usage fast, so reserve it for where that premium amortizes.
 
 | Tier | Model | Use for |
 |------|-------|---------|
 | Cheap | `claude-sonnet-5` | Trivial/scoped agents and reviews — fast, low-cost. |
 | Default | `claude-opus-4-8` | The standing model for development and architecture. Most work runs here. |
+| Frontier (on demand) | `claude-fable-5` | A *bundled* multi-file unit, scope-confirmed before spawning. One-off task → stay on Opus. |
 
+- **The Fable trigger — bundle, then escalate.** Fable's edge is largest on long, coherent, multi-file work — also where the premium amortizes. Either party raises it: Claude proposes a bundle (with scope) before starting, or you say `bundle for fable`. It's opt-in and announced — confirm scope, give it the full combined spec up front, run it at high effort.
 - **Reach for `effort` before reaching for a bigger model.** `effort` (`low`/`medium`/`high`/`xhigh`/`max`, via `output_config`) buys quality more cheaply than a model jump on a task the current model can already do. `xhigh` is the floor for coding/agentic work, `high` for intelligence-sensitive work, `max` only when correctness must beat cost.
 - **File memory is a force multiplier.** Session files, `design/`, `docs/DECISIONS.md`, and acceptance criteria are the persistent notes the model exploits to improve its own output. Keep them current and reference them explicitly.
-- **Agents:** model in agent frontmatter. `@architect` runs Opus 4.8. Reviewers (`@code-review`, `@pm`, `@doc-consistency`, `@tape-reader`) and `@ui-reviewer` stay Sonnet.
-- **New agents:** default to Sonnet; pin `model: opus` only when the agent's standing job needs it.
+- **Agents:** model in agent frontmatter. `@architect` runs Opus 4.8, escalating to a Fable run only for genuinely hard or bundled design work. Reviewers (`@code-review`, `@pm`, `@doc-consistency`, `@tape-reader`) and `@ui-reviewer` stay Sonnet.
+- **New agents:** default to Sonnet; pin `model: opus` only when the agent's standing job needs it. Don't pin Fable — reach it via the bundle trigger.
 
 ## PR Workflow
 
@@ -137,118 +137,59 @@ Every dev project carries a SemVer version in `package.json`, mirrored to a git 
 
 **Detection:** these skills check `package.json` exists at the repo root before bumping. If it doesn't (template/markdown-only project), they no-op silently.
 
-### `<VersionTag />` component
+### Deploy + review reference
 
-Build-time version display, reads `process.env.NEXT_PUBLIC_APP_VERSION` + `process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA`. Renders e.g. `v1.2.3 (a1b2c3)`.
-
-Wiring:
-- `next.config.ts` (or `next.config.js`) forwards `npm_package_version` → `NEXT_PUBLIC_APP_VERSION`. Critical — without `NEXT_PUBLIC_`, client trees silently render `v0.0.0`.
-- Wire into login screen and footer.
-- Vercel sets `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` automatically. Local `npm run dev` outside Vercel omits the commit hash — that's intentional.
-
-```tsx
-import { VersionTag } from "@/components/VersionTag";
-<VersionTag className="text-xs text-muted-foreground" />
-```
-
-### CHANGELOG.md
-
-Auto-maintained by `/retro` and `/bump-major` (DEC-S013 — `/its-dead` no longer touches it). Don't edit by hand mid-flow — the skills always prepend after the `# Changelog` header. The first bump creates the file if absent.
-
-Format (Keep-a-Changelog inspired but simpler):
-```
-# Changelog
-
-## [1.2.3] - 2026-05-05
-- PR #42: Add login form
-
-## [1.2.2] - 2026-05-04
-- PR #41: Fix dashboard query
-```
-
-### PR Review on Mobile (developer notes)
-
-Doing PR reviews from your phone is tolerable if you structure for it:
-- **GitHub mobile app, not web.** The native app's diff + approve + merge flow is usable. The mobile web is not.
-- **Tap the preview URL first.** Vercel posts it as a comment. 60 seconds of clicking the actual feature catches more than reading the diff would.
-- **Enable auto-merge.** Repo Settings → enable auto-merge, then "Enable auto-merge" on each PR. Checks pass → it merges itself. One less thing to remember to do.
-- **Branch protection:** require CI green (Vercel build + Playwright). Skip reviewer count requirements for solo dev — they add friction with no benefit.
-- **Checklist PR descriptions.** `/kill-this` should populate: does this PR have a migration? RLS change? UI change at 375px? A checkbox list is fast to scan on a small screen.
-- **`gh` CLI on your dev server** is faster than any UI when you're at a keyboard: `gh pr list`, `gh pr view 42 --web`, `gh pr merge 42 --auto`.
+The `<VersionTag />` wiring (login + footer, and the `NEXT_PUBLIC_` gotcha that silently renders `v0.0.0`), the CHANGELOG format, and the phone PR-review notes are reference material, not standing rules — they live in `docs/DEV_REFERENCE.md`, out of the always-loaded shell. Component source: `dev/claude/templates/VersionTag.tsx`.
 
 ## Workflow Notes
 - **Diagnostic commands** (build, lint, type check, test): run directly — see errors, fix them, don't bother the user.
 - **Environment-changing commands** (npm install, supabase migrations, git push, deploys): output these for the user to run.
 - **Never rebase a task branch that already has commits on origin.** If main has advanced while a PR branch is open, leave the branch as-is — GitHub's "Update branch" button handles this at merge time. Rebasing rewrites remote history and requires a force-push. Use `git merge --ff-only` only if explicitly asked.
-- **Debugging CI failures:** Before any multi-step local debug (spawning servers, reading cookies, modifying middleware), confirm the environment is functional: "Can you run the test suite locally right now? What env vars are set?" One environmental check before any code change.
+- **On a surprise or mismatch, reconcile before diagnosing.** Pin the assumption and the environment first — dev vs prod, which DB, is the server even up — before chasing a theory or building. One environmental check ("can you run the suite right now? what env vars are set?") beats a multi-step debug built on an unchecked premise.
 - **JSON parsing in Bash:** Prefer `gh ... --jq '...'` (built-in jq via `gh`) or `jq` over `python3 -c "import json,sys; ..."` one-liners. The python invocations trigger per-pattern permission prompts (each unique argument list is a new allowlist entry), while `gh --jq` runs under the existing `Bash(gh ...)` allowance. For non-`gh` JSON, install/use `jq` directly. Reserve python for cases where the data shape genuinely needs control flow.
 - **Bug reports:** create a GitHub issue, label `bug`, add to current or next phase.
+- **Don't guess third-party API shapes** from naming or 403/404 signals — stop and ask for the official docs; never write code against a guess.
 
 Project-specific debugging gotchas (dev-server checks, stale-process traps, auth-redirect quirks) live in `.claude/CLAUDE-context.md` under `## Workflow Notes (project)`.
 
 ## Approval Before Action (all tasks)
 
-For every task — not just bugs — explain the plan and wait for approval before doing anything:
-1. State what files you'll create or modify and why
-2. List commands you'll run, especially commits, pushes, package installs,
-   anything touching production
-3. Wait for "go", "do it", or equivalent
-4. Do not edit files or run commands until approved
+For every task — bug, feature, or question — explain the plan and wait for my go-ahead before doing anything:
+1. State what you'll create or modify and why, and list the commands you'll run (commits, pushes, installs, anything touching production).
+2. For a bug or question: explain the cause and your proposed fix first.
+3. Wait for "go", "do it", or equivalent. Don't edit files or run commands until approved.
 
-## Bug Reports & Questions
-When a bug is reported or a question is asked:
-1. Explain the cause and your proposed fix
-2. Wait for approval before making any changes
-3. Do not edit files, run commands, or implement fixes until given the go-ahead
+**Trust my statements the first time.** "It's fixed" / "it's done" is a fact, not a request to re-verify or keep digging. Register a decision I've stated as settled — verify at most once, never re-raise it later as a "gap." Make "check the obvious thing" the last sanity check, never the first hypothesis.
 
 ## Scope Discipline
-Check `docs/SPEC.md` "Not V1" before adding anything.
+Check `docs/SPEC.md` "Not V1" before adding anything. Apply a change only to the surface I named — don't propagate it to sibling pages, and never invent or misattribute a rationale I didn't state (especially in DECs and durable notes).
 
-If a task feels bigger than its estimate:
-1. Stop, re-estimate
-2. Update PROJECT_PLAN.md (at next phase boundary, or via Issue if mid-phase)
-3. If scope creep, flag and move on
+If a task feels bigger than its estimate: stop, re-estimate, update PROJECT_PLAN.md (next phase boundary, or via Issue mid-phase); if it's scope creep, flag it and move on.
 
-**Splitting is a reviewability call, not a model-capability one.** Points size *estimation*; they don't cap how much gets built in one run. A capable model holds coherence across far more than an 8, and splitting a *coherent* task fragments context — two stitched-together 5s can land worse than one well-specified 8. So:
+**Splitting is a reviewability call, not a capability one.** Points size estimation; they don't cap how much ships in one run.
 - **Don't split a coherent 8** (one feature, one migration, one subsystem) just to honor a ceiling — run it as one unit with the full spec up front.
-- **Do split** when the diff is too large to review well, the blast radius or reversibility worries you, there's a migration conflict (see PR Workflow), or an "8" is secretly two unrelated things.
-- **Still break genuine 13s** — for review and risk, and because a 13 usually means the task isn't understood well enough yet. Not because the model can't hold it.
-- Larger units lean harder on a complete spec + crisp ACs and the `@architect` gate. Raise the ceiling only with those in place.
+- **Do split** when the diff is too big to review well, the blast radius or reversibility worries you, there's a migration conflict, or an "8" is secretly two unrelated things.
+- **Still break genuine 13s** — for review and risk, and because a 13 usually means it isn't understood well enough yet.
 
 ## Tone
 Occasional dry humor and sarcasm welcome. One good line beats three forced ones.
 
-## Response Length
+## Communication
 
-Default to the shortest response that fully answers — usually 2–5 sentences. No preamble, no restating the question, no closing offers to help further. No reflexive "let me know if you need more" or "happy to expand." Do offer concrete follow-ups when they'd save a future round-trip. Length is requested explicitly ("expand," "give me the long version"), never the default.
+**Length isn't the metric — density is.** Give me everything relevant and cut the rest: no padding, no repetition, no jargon, no preamble, no restating my question. A long answer that's dense the whole way is fine; a short one that pads or repeats the same point is not. Lead with the answer, not a guess about what I did wrong.
 
-Be meticulous and skip disclaimers.
+**Never lead with a false premise.** On a bug or a surprise, if you don't know the cause, ask — "is the server up? which DB?" is one line and fair. What's banned is *stating* a made-up cause as fact and then explaining at length on top of it. Questions are fine; invented premises defended in paragraphs waste my time and tokens.
 
-## Verbosity
+**Cite facts; label proposals.** Any statement about the code, config, or project rules cites where you verified it — a file:line or a tool result. If you can't cite it, say it as a question, not a fact. This never applies to *ideas*: propose novel approaches freely — just label them "proposed / not in the codebase" instead of dressing them as facts. Inventing a fact is fabrication; a labeled proposal is not. The two are different acts, and only the first is banned.
 
-End-of-turn summaries: one or two sentences. What changed, what's next. Stop there.
+**Session summaries.** End of turn: one or two sentences — what changed, what's next. It's the first thing I read next session, so make it dense, not voluminous. Don't recap work I just watched. If a turn ends with a bullet list plus three paragraphs of prose, the prose is wrong — delete it.
 
-Do not recap work I just watched you do. Do not restate the task. Do not explain why an obvious step was obvious. The summary exists so I can re-enter context next session — not so you can demonstrate effort.
+**Narration** — switchable knob; name the level and I'll hold it (`narration: terse|normal|narrate`):
+- **Terse** (default): silence between tool calls; one sentence when you find something, change direction, or hit a blocker. No "Now I'll…", "Let me check…", no recapping what I just watched.
+- **Normal**: brief progress notes at meaningful steps.
+- **Narrate**: reasoning as you go — for teaching or a tricky change.
 
-If a turn ends with a tidy bullet list followed by three paragraphs of prose, the prose is wrong. Delete it.
-
-Mid-session updates: one sentence per state change. "Found X." "Switching to Y." "Build green." Not a paragraph.
-
-This rule applies double at session end. The session-summary block is the first thing I read next session — make it dense, not voluminous. Five bullets of work and a wall of text means I cannot actually use the summary. Cut the wall.
-
-## Narration
-
-`Response Length` and `Verbosity` above are the standing baseline. This is the switchable knob on top of them — Opus 4.8 narrates more by default, so name the level and I'll hold it for the session.
-
-- **Terse** (default): Silence between tool calls. One sentence only when I find something, change direction, or hit a blocker. No "Now I'll…", "Let me check…", "Looking at…", no recapping what you just watched. Close with one or two sentences on the outcome.
-- **Normal**: Brief progress notes at meaningful steps — not every action.
-- **Narrate**: Explain reasoning as I go. For teaching, debugging, or watching a tricky change land.
-
-Switch any time: `narration: terse|normal|narrate`.
-
-Two mechanics move narration the same direction, independent of level:
-- **Keep adaptive thinking on.** With thinking disabled, 4.8 spills reasoning into the visible answer — which reads as *more* narrative. Adaptive keeps reasoning in thinking blocks and the response clean.
-- **Lower `effort`** (`low` / `medium`) trims preamble and confirmations — a coarser lever than the levels above.
+Keep adaptive thinking on — reasoning stays in the thinking block and the reply stays clean; lower `effort` (`low`/`medium`) trims preamble further.
 
 ## Cost and Waste
 

--- a/docs/DEV_REFERENCE.md
+++ b/docs/DEV_REFERENCE.md
@@ -1,0 +1,42 @@
+# Dev Reference
+
+Reference material pulled out of the always-loaded `CLAUDE.md` shell (DEC-S031) — read when you need it, not every session.
+
+## `<VersionTag />` component
+
+Build-time version display, reads `process.env.NEXT_PUBLIC_APP_VERSION` + `process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA`. Renders e.g. `v1.2.3 (a1b2c3)`.
+
+Wiring:
+- `next.config.ts` (or `next.config.js`) forwards `npm_package_version` → `NEXT_PUBLIC_APP_VERSION`. Critical — without `NEXT_PUBLIC_`, client trees silently render `v0.0.0`.
+- Wire into login screen and footer.
+- Vercel sets `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` automatically. Local `npm run dev` outside Vercel omits the commit hash — that's intentional.
+
+```tsx
+import { VersionTag } from "@/components/VersionTag";
+<VersionTag className="text-xs text-muted-foreground" />
+```
+
+## CHANGELOG.md
+
+Auto-maintained by `/retro` and `/bump-major` (DEC-S013 — `/its-dead` no longer touches it). Don't edit by hand mid-flow — the skills always prepend after the `# Changelog` header. The first bump creates the file if absent.
+
+Format (Keep-a-Changelog inspired but simpler):
+```
+# Changelog
+
+## [1.2.3] - 2026-05-05
+- PR #42: Add login form
+
+## [1.2.2] - 2026-05-04
+- PR #41: Fix dashboard query
+```
+
+## PR Review on Mobile (developer notes)
+
+Doing PR reviews from your phone is tolerable if you structure for it:
+- **GitHub mobile app, not web.** The native app's diff + approve + merge flow is usable. The mobile web is not.
+- **Tap the preview URL first.** Vercel posts it as a comment. 60 seconds of clicking the actual feature catches more than reading the diff would.
+- **Enable auto-merge.** Repo Settings → enable auto-merge, then "Enable auto-merge" on each PR. Checks pass → it merges itself. One less thing to remember to do.
+- **Branch protection:** require CI green (Vercel build + Playwright). Skip reviewer count requirements for solo dev — they add friction with no benefit.
+- **Checklist PR descriptions.** `/kill-this` should populate: does this PR have a migration? RLS change? UI change at 375px? A checkbox list is fast to scan on a small screen.
+- **`gh` CLI on your dev server** is faster than any UI when you're at a keyboard: `gh pr list`, `gh pr view 42 --web`, `gh pr merge 42 --auto`.


### PR DESCRIPTION
Rolls the seeds `CLAUDE.md` shell work out to this repo, matching what was trialed on muster (PR #497).

## What changed
- **`CLAUDE.md`** brought fully current — Memory doctrine removed (DEC-S030); shell audit (DEC-S031): three overlapping verbosity sections merged into one **Communication** section, `Bug Reports` folded into `Approval Before Action`, `Splitting` trimmed, `Micro Workflow` step 1 sharpened to a spec-gate, Fable re-enabled; plus the **"Cite facts; label proposals"** rule (DEC-S032). (Also resolves the known bushel divergence that pinned `@architect` to Fable against DEC-S027 — the canonical shell restores the Opus default + on-demand Fable.)
- **`docs/DEV_REFERENCE.md`** added — VersionTag/CHANGELOG/mobile-PR reference moved out of the always-loaded shell (DEC-S031). This is the file the earlier auto-sync PR added *without* its shell; now they land together.
- **`@tape-reader`** gains the **"Ground every finding — never invent a rule"** cite-guard (DEC-S032).

Shell is byte-identical to the seeds canonical (`dev/claude/CLAUDE.md`). Rationale in seeds `docs/DECISIONS.md` DEC-S030–S032.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3pPJeKhVX8W1KfhGyxsTn)_