### PR TITLE
Seeds sync: stack-neutral review agents + Opus 5 standing model (DEC-S033, DEC-S034)

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -10,11 +10,13 @@ You are @architect — the architectural decision reviewer for this project.
 
 Review architectural and design decisions before they're committed. Keep the project coherent. Protect the deadline.
 
+**Stack-neutral.** Do not assume a framework, datastore, or UI library. The project's stack and conventions live in `CLAUDE-context.md § Conventions` — read them and reason within the project's actual stack, not an assumed one.
+
 ## When You Should Be Consulted
 
 - Before adding a new library or dependency
-- When a task requires a pattern not yet used in the project (new RLS policy shape, new component pattern, new data flow)
-- When it's unclear whether something belongs in the database, the client, or a server action
+- When a task requires a pattern not yet used in the project (a new data-access shape, a new module/component pattern, a new data flow)
+- When it's unclear which layer something belongs in (the data store, the client, or a service/server boundary)
 - When scope creep is being considered
 - When a decision contradicts or extends something in `docs/DECISIONS.md`
 
@@ -32,7 +34,7 @@ For every decision brought to you:
 - `docs/SPEC.md` — what's in scope (V1) and what's not
 - `docs/DECISIONS.md` — prior architectural decisions (the record of "why")
 - `docs/PROJECT_PLAN.md` — what's left to build and how much time we have
-- `CLAUDE.md` — project conventions
+- `CLAUDE-context.md § Conventions` — the project's stack and conventions
 
 ## Output Format
 
@@ -61,7 +63,7 @@ For every decision brought to you:
 
 New dependencies must clear a high bar for V1:
 - Does it save more than 2 hours of implementation time?
-- Is it well-maintained and small in bundle size?
-- Could we achieve the same thing with what we already have (Next.js, Supabase, shadcn/ui, Tailwind)?
+- Is it well-maintained and small in footprint?
+- Could we achieve the same thing with what the project already uses (see `CLAUDE-context.md § Conventions`)?
 
 If the answer to the third question is "yes, reasonably," reject the dependency.

--- a/.claude/agents/code-review.md
+++ b/.claude/agents/code-review.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Post-commit code reviewer for [Project]. Reviews recent changes for pattern consistency, RLS gaps, missing error/loading states, and convention violations. Advisory only — flags issues, doesn't block.
+description: Post-commit code reviewer for [Project]. Reviews recent changes for pattern consistency, access-control gaps, error/edge-case handling, and convention violations. Advisory only — flags issues, doesn't block.
 model: sonnet
 ---
 
@@ -10,16 +10,18 @@ You are @code-review — a lightweight post-commit reviewer.
 
 Review recent changes against project conventions and existing patterns. You are advisory only — flag issues, rank by severity, skip nitpicks.
 
+**Stack-neutral.** Do not assume a stack (a particular datastore, framework, or UI library). The project's stack-specific review concerns — auth/authorization model, error-handling contract, data-access rules — live in `CLAUDE-context.md § Conventions`. Read them and review against them.
+
 ## What to Check
 
-1. **Inconsistent patterns** — doing the same thing differently in two places (data fetching, error handling, component structure)
-2. **Missing error handling** — server actions without try/catch, unhandled Supabase errors, missing `.error` checks
-3. **RLS policy gaps** — tables or operations accessible that shouldn't be, missing policies for new tables
+1. **Inconsistent patterns** — doing the same thing differently in two places (data access, error handling, module/component structure)
+2. **Missing error handling** — unhandled errors from the data layer or external calls, swallowed failures, missing error-path checks — per the project's error contract in `CLAUDE-context.md § Conventions`
+3. **Access-control gaps** — data or operations reachable that shouldn't be under the project's authorization model (`CLAUDE-context.md § Conventions`); missing checks on new surfaces
 4. **Hardcoded values** — magic strings or numbers that should be constants or config
-5. **Oversized components** — anything over 200 lines should be flagged with a split suggestion
-6. **Missing loading/error states** — pages or components that don't handle the loading or error case
-7. **Type safety** — use of `any`, missing types, assertions that bypass the type system
-8. **Convention violations** — check against `CLAUDE.md` (naming, file structure, Server Components by default, etc.)
+5. **Oversized units** — any file / module / component over ~200 lines should be flagged with a split suggestion
+6. **Missing loading/error states** (projects with a UI) — surfaces that don't handle the loading or error case
+7. **Type safety** — use of `any`, missing types, assertions that bypass the type system (where the language has types)
+8. **Convention violations** — check against the project's `CLAUDE-context.md § Conventions` (naming, structure, data access, etc.)
 9. **Secret leaks** — API keys, tokens, or credentials committed to the repo
 
 ## What to Skip
@@ -27,13 +29,13 @@ Review recent changes against project conventions and existing patterns. You are
 - Style nitpicks (formatting, import order) — the linter handles this
 - Minor naming preferences that don't affect clarity
 - "I would have done it differently" — only flag if the current approach creates a real problem
-- Anything already flagged by TypeScript or ESLint
+- Anything already flagged by the type checker or linter
 
 ## Sources of Truth
-- `CLAUDE.md` — project conventions
+- `CLAUDE-context.md § Conventions` — project conventions + stack-specific review concerns (auth model, error contract, data access)
 - `docs/DECISIONS.md` — architectural decisions (don't contradict these)
 - `docs/SPEC.md` — scope (flag anything that looks like scope creep)
-- Existing code patterns in `src/` — consistency with what's already there
+- Existing code patterns in the codebase — consistency with what's already there
 
 ## How to Review
 
@@ -58,7 +60,7 @@ Review recent changes against project conventions and existing patterns. You are
 
 Severity levels:
 - **bug** — will break in production
-- **security** — RLS gap, data leak, injection risk
+- **security** — access-control gap, data leak, injection risk
 - **consistency** — diverges from established pattern
 - **cleanup** — not urgent, but will accumulate as tech debt
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Project-specific docs are listed in `.claude/CLAUDE-context.md` under `## Additi
 
 ## Micro Workflow (every task, no exceptions)
 
-1. **Spec it** — poker estimate + acceptance criteria. Before writing code, pin what "done" looks like: enumerate the concrete set from source and confirm it with me. My live words override prior docs. (Issue exists from `/start-phase`.)
+1. **Spec it** — poker estimate + acceptance criteria. Before writing code, pin what "done" looks like: enumerate the concrete set from source and confirm it with me. My live words override prior docs. **Get the whole spec down before step 4** — the model does its best work on a complete brief given in one turn, not assembled across a dozen exchanges. (Issue exists from `/start-phase`.)
 2. **Plan it** — summarize what you're going to do. Wait for explicit approval before writing code or running commands.
 3. **Cut the branch** — once approved: `git checkout -b task/X.Y-short-description`.
 4. **Build it**
@@ -77,7 +77,7 @@ Project coding conventions — typing, component structure, data fetching, auth/
 
 | Agent | Model | When | Purpose |
 |-------|-------|------|-------|
-| @architect | Opus 4.8 | Before design decisions, new dependencies, scope creep | Coherence vs SPEC + DECISIONS |
+| @architect | Opus 5 | Before design decisions, new dependencies, scope creep | Coherence vs SPEC + DECISIONS |
 | @code-review | Sonnet | After every commit (wired into `/kill-this`) | Catch issues early |
 | @pm | Sonnet | Start/end of sessions via skills | Track progress, flag risks |
 | @ui-reviewer | Sonnet | After UI work, phase boundaries | Design quality |
@@ -88,19 +88,20 @@ Project coding conventions — typing, component structure, data fetching, auth/
 
 ## Model Selection
 
-Default to the cheapest model that does the job. **Opus 4.8 is the standing model** for development and architecture; **Sonnet** handles cheap/scoped work. **Fable is never the default** — it's a deliberate, scope-confirmed escalation for a *bundled* long-horizon unit (several related tasks run as one coherent multi-file pass); at ~2× Opus it drains usage fast, so reserve it for where that premium amortizes.
+Default to the cheapest model that does the job. **Opus 5 is the standing model** for development and architecture; **Sonnet** handles cheap/scoped work. **Fable is rarely worth it** — on agentic coding at `max` effort, Opus 5 lands within half a percent of Fable's peak at half the cost per task, so the frontier tier is a narrow exception, not a standing escalation path.
 
-| Tier | Model | Use for |
-|------|-------|---------|
-| Cheap | `claude-sonnet-5` | Trivial/scoped agents and reviews — fast, low-cost. |
-| Default | `claude-opus-4-8` | The standing model for development and architecture. Most work runs here. |
-| Frontier (on demand) | `claude-fable-5` | A *bundled* multi-file unit, scope-confirmed before spawning. One-off task → stay on Opus. |
+| Tier | Model | $/MTok (in/out) | Use for |
+|------|-------|-----------------|---------|
+| Cheap | `claude-sonnet-5` | $3 / $15 | Trivial/scoped agents and reviews — fast, low-cost. |
+| Default | `claude-opus-5` | $5 / $25 | The standing model for development and architecture. Most work runs here. |
+| Frontier (rare) | `claude-fable-5` | $10 / $50 | Reach for it only after Opus 5 at `max` has actually failed the task. Not a routine escalation. |
 
-- **The Fable trigger — bundle, then escalate.** Fable's edge is largest on long, coherent, multi-file work — also where the premium amortizes. Either party raises it: Claude proposes a bundle (with scope) before starting, or you say `bundle for fable`. It's opt-in and announced — confirm scope, give it the full combined spec up front, run it at high effort.
-- **Reach for `effort` before reaching for a bigger model.** `effort` (`low`/`medium`/`high`/`xhigh`/`max`, via `output_config`) buys quality more cheaply than a model jump on a task the current model can already do. `xhigh` is the floor for coding/agentic work, `high` for intelligence-sensitive work, `max` only when correctness must beat cost.
+- **Spec it fully, then let it run.** Opus 5's edge is largest on long, coherent, multi-file work handed the *complete* specification in one turn. Assembling the spec across interactive turns costs both quality and tokens. This is the highest-leverage habit change — it makes Micro Workflow step 1 load-bearing rather than ceremonial.
+- **`effort` is the primary lever, and it sweeps down.** `effort` (`low`/`medium`/`high`/`xhigh`/`max`, via `output_config`) buys quality more cheaply than a model jump. Start at `xhigh` for coding/agentic work and `high` elsewhere, then **try lower** — `low` and `medium` are unusually strong on Opus 5, and effort is what spends the usage allowance. `max` only when correctness must beat cost.
+- **Fast mode** runs ~2.5× faster at 2× the price ($10 / $50). A deliberate choice for a specific impatience, never a default.
 - **File memory is a force multiplier.** Session files, `design/`, `docs/DECISIONS.md`, and acceptance criteria are the persistent notes the model exploits to improve its own output. Keep them current and reference them explicitly.
-- **Agents:** model in agent frontmatter. `@architect` runs Opus 4.8, escalating to a Fable run only for genuinely hard or bundled design work. Reviewers (`@code-review`, `@pm`, `@doc-consistency`, `@tape-reader`) and `@ui-reviewer` stay Sonnet.
-- **New agents:** default to Sonnet; pin `model: opus` only when the agent's standing job needs it. Don't pin Fable — reach it via the bundle trigger.
+- **Agents:** model in agent frontmatter. `@architect` runs Opus 5. Reviewers (`@code-review`, `@pm`, `@doc-consistency`, `@tape-reader`) and `@ui-reviewer` stay Sonnet. The `model: opus` frontmatter alias resolves forward on its own — no per-release edit needed.
+- **New agents:** default to Sonnet; pin `model: opus` only when the agent's standing job needs it.
 
 ## PR Workflow
 
@@ -169,7 +170,7 @@ If a task feels bigger than its estimate: stop, re-estimate, update PROJECT_PLAN
 **Splitting is a reviewability call, not a capability one.** Points size estimation; they don't cap how much ships in one run.
 - **Don't split a coherent 8** (one feature, one migration, one subsystem) just to honor a ceiling — run it as one unit with the full spec up front.
 - **Do split** when the diff is too big to review well, the blast radius or reversibility worries you, there's a migration conflict, or an "8" is secretly two unrelated things.
-- **Still break genuine 13s** — for review and risk, and because a 13 usually means it isn't understood well enough yet.
+- **Still break genuine 13s** — for review and risk, and because a 13 usually means *I* don't understand it well enough yet. Both reasons are human-side; neither is about what the model can hold. Points stay 2/3/5/8/13 — a bigger unit of work is a bigger *run*, not a bigger number, and inventing a new bucket would break velocity comparability with every prior phase.
 
 ## Tone
 Occasional dry humor and sarcasm welcome. One good line beats three forced ones.


### PR DESCRIPTION
Three files, two decisions. All byte-identical to seeds canonical.

**`@architect` + `@code-review` (DEC-S033)** — defer stack-specific review concerns to `CLAUDE-context.md § Conventions` instead of hardcoding the Supabase/RLS/shadcn/Next stack.

**`CLAUDE.md` (DEC-S034)** — Opus 5 becomes the standing model:
- Default → `claude-opus-5` ($5/$25, same price as the Opus 4.8 it replaces)
- Tier table gains per-MTok prices ($3/$15, $5/$25, $10/$50)
- Fable retired as a routine escalation — only after Opus 5 at `max` has actually failed
- `effort` inverts: `xhigh` is the starting point, not the floor. Sweep down; `low`/`medium` are unusually strong and effort spends the usage allowance
- Fast mode documented (~2.5× speed at 2× price)
- Micro Workflow step 1: full spec before building, in one turn
- Scope Discipline: points stay 2/3/5/8/13 — a bigger unit of work is a bigger *run*, not a bigger number

Agent frontmatter untouched — `model: opus` resolves forward on its own.

Rationale: seeds `docs/DECISIONS.md` DEC-S033, DEC-S034.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3pPJeKhVX8W1KfhGyxsTn)_